### PR TITLE
Added loglevel as logging framework

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -93,7 +93,7 @@
                 canvas.width = width;
                 try {
                 sheet.render();
-                } catch (e) {};
+                } catch (e) {}
                 enable();
             }
         );
@@ -116,7 +116,6 @@
     }
 
     function Resize(startCallback, endCallback) {
-      "use strict";
 
       var rtime;
       var timeout = false;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -52,10 +52,6 @@
         showCursorBtn = document.getElementById("show-cursor-btn");
         hideCursorBtn = document.getElementById("hide-cursor-btn");
 
-        // Set up logging
-        log.setDefaultLevel('trace');
-        log.debug("Logging system set up.");
-
         // Hide error
         error();
 
@@ -84,6 +80,7 @@
 
         // Create sheet object and canvas
         sheet = new window.OSMD(canvas);
+        sheet.setLogLevel('info');
         document.body.appendChild(canvas);
 
         // Set resize event handler

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -52,6 +52,10 @@
         showCursorBtn = document.getElementById("show-cursor-btn");
         hideCursorBtn = document.getElementById("hide-cursor-btn");
 
+        // Set up logging
+        log.setDefaultLevel('trace');
+        log.debug("Logging system set up.");
+
         // Hide error
         error();
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,9 @@
     <!-- Include code and styles for this demo -->
     <script src="demo.js"></script>
     <link href="demo.css" media="all" rel="stylesheet" />
+
+    <!-- Loglevel library -->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/loglevel/1.4.1/loglevel.min.js"></script>
   </head>
   <body>
     <h1>OpenSheetMusicDisplay Demo</h1>

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,9 +13,6 @@
     <!-- Include code and styles for this demo -->
     <script src="demo.js"></script>
     <link href="demo.css" media="all" rel="stylesheet" />
-
-    <!-- Loglevel library -->
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/loglevel/1.4.1/loglevel.min.js"></script>
   </head>
   <body>
     <h1>OpenSheetMusicDisplay Demo</h1>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "es6-promise": "^3.2.1",
     "jszip": "^3.0.0",
+    "loglevel": "^1.4.1",
     "shortid": "^2.2.6",
     "typescript-collections": "^1.1.2",
     "vexflow": "^1.2.53"

--- a/src/OSMD/OSMD.ts
+++ b/src/OSMD/OSMD.ts
@@ -155,7 +155,7 @@ export class OSMD {
      * @param: content can be `trace`, `debug`, `info`, `warn` or `error`.
      */
     public setLogLevel(level: string): void {
-        switch(level) {
+        switch (level) {
             case "trace":
                 log.setDefaultLevel(LogLevel.TRACE);
                 break;

--- a/src/OSMD/OSMD.ts
+++ b/src/OSMD/OSMD.ts
@@ -13,6 +13,7 @@ import {ajax} from "./AJAX";
 import {Logging} from "../Common/Logging";
 import {Fraction} from "../Common/DataObjects/Fraction";
 import {OutlineAndFillStyleEnum} from "../MusicalScore/Graphical/DrawingEnums";
+import * as log from "loglevel";
 
 export class OSMD {
     /**
@@ -114,6 +115,7 @@ export class OSMD {
         this.sheet = reader.createMusicSheet(score, "Unknown path");
         this.graphic = new GraphicalMusicSheet(this.sheet, calc);
         this.cursor.init(this.sheet.MusicPartManager, this.graphic);
+        log.info("Loaded sheet successfully.");
         return Promise.resolve({});
     }
 

--- a/src/OSMD/OSMD.ts
+++ b/src/OSMD/OSMD.ts
@@ -85,7 +85,7 @@ export class OSMD {
                 let parser: DOMParser = new DOMParser();
                 content = parser.parseFromString(str, "text/xml");
             } else if (str.length < 2083) {
-                // Assume now 'str' is a URL
+                // Assume now "str" is a URL
                 // Retrieve the file at the given URL
                 return ajax(str).then(
                     (s: string) => { return self.load(s); },
@@ -115,7 +115,7 @@ export class OSMD {
         this.sheet = reader.createMusicSheet(score, "Unknown path");
         this.graphic = new GraphicalMusicSheet(this.sheet, calc);
         this.cursor.init(this.sheet.MusicPartManager, this.graphic);
-        log.info("Loaded sheet successfully.");
+        log.info(`Loaded sheet ${this.sheet.TitleString} successfully.`);
         return Promise.resolve({});
     }
 
@@ -147,6 +147,35 @@ export class OSMD {
         this.drawer.drawSheet(this.graphic);
         // Update the cursor position
         this.cursor.update();
+    }
+
+    /**
+     * Sets the logging level for this OSMD instance. By default, this is set to `warn`.
+     *
+     * @param: content can be `trace`, `debug`, `info`, `warn` or `error`.
+     */
+    public setLogLevel(level: string): void {
+        switch(level) {
+            case "trace":
+                log.setDefaultLevel(LogLevel.TRACE);
+                break;
+            case "debug":
+                log.setDefaultLevel(LogLevel.DEBUG);
+                break;
+            case "info":
+                log.setDefaultLevel(LogLevel.INFO);
+                break;
+            case "warn":
+                log.setDefaultLevel(LogLevel.WARN);
+                break;
+            case "error":
+                log.setDefaultLevel(LogLevel.ERROR);
+                break;
+            default:
+                log.warn(`Could not set log level to ${level}. Using warn instead.`);
+                log.setDefaultLevel(LogLevel.WARN);
+                break;
+        }
     }
 
     /**

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,7 @@
 {
   "globalDependencies": {
     "chai": "registry:dt/chai#3.4.0+20160317120654",
+    "loglevel": "registry:dt/loglevel#1.4.0+20160412141402",
     "mocha": "registry:dt/mocha#2.2.5+20160317120654",
     "shortid": "registry:dt/shortid#0.0.0+20160316155526"
   },


### PR DESCRIPTION
See #21 
Added [loglevel](https://www.npmjs.com/package/loglevel)

Easy to use:
```javascript
    log.trace(msg);
    log.debug(msg);
    log.info(msg);
    log.warn(msg);
    log.error(msg);
```
 You can get different loggers, set log levels application-wide or per logger, etc.

Will resolve both #21 and #9.


