### PR TITLE
Adds SVG Rendering option

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -40,7 +40,8 @@
         nextCursorBtn,
         resetCursorBtn,
         showCursorBtn,
-        hideCursorBtn;
+        hideCursorBtn,
+        backendSelect;
 
     // Initialization code
     function init() {
@@ -59,6 +60,7 @@
         resetCursorBtn = document.getElementById("reset-cursor-btn");
         showCursorBtn = document.getElementById("show-cursor-btn");
         hideCursorBtn = document.getElementById("hide-cursor-btn");
+        backendSelect = document.getElementById("backend-select");
 
         // Hide error
         error();
@@ -87,7 +89,7 @@
         };
 
         // Create OSMD object and canvas
-        OSMD = new opensheetmusicdisplay.OSMD(canvas, false, "svg");
+        OSMD = new opensheetmusicdisplay.OSMD(canvas, false);
         OSMD.setLogLevel('info');
         document.body.appendChild(canvas);
 
@@ -123,6 +125,16 @@
         });
         showCursorBtn.addEventListener("click", function() {
             OSMD.cursor.show();
+        });
+
+        backendSelect.addEventListener("change", function(e) {
+            var value = e.target.value;
+            // clears the canvas element
+            canvas.innerHTML = "";
+            OSMD = new opensheetmusicdisplay.OSMD(canvas, false, value);
+            OSMD.setLogLevel('info');
+            selectOnChange();
+
         });
     }
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -87,7 +87,7 @@
         };
 
         // Create OSMD object and canvas
-        OSMD = new opensheetmusicdisplay.OSMD(canvas);
+        OSMD = new opensheetmusicdisplay.OSMD(canvas, false, "svg");
         OSMD.setLogLevel('info');
         document.body.appendChild(canvas);
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,6 +34,11 @@
             <p>... or just drop your MusicXML file on this page.</p>
         </td>
         <td valign="top" halign="right">
+            <p>Renderer Backend
+                <select id="backend-select" value="canvas">
+                    <option value="canvas">Canvas</option>>
+                    <option value="svg">SVG</option>
+                </select>
             <p>Cursor controls:
                 <input type="button" value="show" id="show-cursor-btn"/>
                 <input type="button" value="hide" id="hide-cursor-btn"/>

--- a/external/vexflow/vexflow.d.ts
+++ b/external/vexflow/vexflow.d.ts
@@ -148,9 +148,14 @@ declare namespace Vex {
         }
 
         export class Renderer {
-            constructor(canvas: HTMLCanvasElement, backend: any);
+            constructor(canvas: HTMLElement, backend: number);
 
-            public static Backends: any;
+            public static Backends: {
+                CANVAS: number,
+                RAPHAEL: number,
+                SVG: number,
+                VML: number
+            };
 
             public resize(a: number, b: number): void;
 
@@ -190,6 +195,7 @@ declare namespace Vex {
 
         export class CanvasContext {
             public scale(x: number, y: number): CanvasContext;
+            public fillRect(x: number, y: number, width: number, height: number): CanvasContext
         }
 
         export class StaveConnector {
@@ -203,7 +209,6 @@ declare namespace Vex {
 
             public draw(): void;
         }
-
     }
 }
 

--- a/external/vexflow/vexflow.d.ts
+++ b/external/vexflow/vexflow.d.ts
@@ -68,7 +68,7 @@ declare namespace Vex {
         export class StaveTie {
             constructor(notes_struct: any);
 
-            public setContext(ctx: CanvasContext): StaveTie;
+            public setContext(ctx: RenderContext): StaveTie;
 
             public draw(): void;
         }
@@ -111,7 +111,7 @@ declare namespace Vex {
             public getLineForY(y: number): number;
 
             public getModifiers(pos: any, cat: any): Clef[]; // FIXME
-            public setContext(ctx: CanvasContext): Stave;
+            public setContext(ctx: RenderContext): Stave;
 
             public addModifier(mod: any, pos: any): void;
 
@@ -159,7 +159,7 @@ declare namespace Vex {
 
             public resize(a: number, b: number): void;
 
-            public getContext(): CanvasContext;
+            public getContext(): CanvasContext|SVGContext;
         }
 
         export class TimeSignature {
@@ -180,7 +180,7 @@ declare namespace Vex {
         export class Beam {
             constructor(notes: StaveNote[], auto_stem: boolean);
 
-            public setContext(ctx: CanvasContext): Beam;
+            public setContext(ctx: RenderContext): Beam;
 
             public draw(): void;
         }
@@ -188,15 +188,28 @@ declare namespace Vex {
         export class Tuplet {
             constructor(notes: StaveNote[]);
 
-            public setContext(ctx: CanvasContext): Tuplet;
+            public setContext(ctx: RenderContext): Tuplet;
 
             public draw(): void;
         }
 
-        export class CanvasContext {
-            public scale(x: number, y: number): CanvasContext;
-            public fillRect(x: number, y: number, width: number, height: number): CanvasContext
-            public fillText(text: string, x: number, y: number): CanvasContext;
+        export class RenderContext {
+            public scale(x: number, y: number): RenderContext;
+            public fillRect(x: number, y: number, width: number, height: number): RenderContext
+            public fillText(text: string, x: number, y: number): RenderContext;
+            public setFont(family: string, size: number, weight: string): RenderContext;
+            public save(): RenderContext;
+            public restore(): RenderContext;
+        }
+
+        export class CanvasContext extends RenderContext {
+            public vexFlowCanvasContext: CanvasRenderingContext2D;
+        }
+
+        export class SVGContext extends RenderContext {
+            public svg: SVGElement;
+            public attributes: any;
+            public state: any;
         }
 
         export class StaveConnector {
@@ -206,7 +219,7 @@ declare namespace Vex {
 
             public setType(type: any): StaveConnector;
 
-            public setContext(ctx: CanvasContext): StaveConnector;
+            public setContext(ctx: RenderContext): StaveConnector;
 
             public draw(): void;
         }

--- a/external/vexflow/vexflow.d.ts
+++ b/external/vexflow/vexflow.d.ts
@@ -196,6 +196,7 @@ declare namespace Vex {
         export class CanvasContext {
             public scale(x: number, y: number): CanvasContext;
             public fillRect(x: number, y: number, width: number, height: number): CanvasContext
+            public fillText(text: string, x: number, y: number): CanvasContext;
         }
 
         export class StaveConnector {

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -21,9 +21,21 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.inner.appendChild(this.canvas);
         container.appendChild(this.inner);
         this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
-        this.ctx = this.renderer.getContext();
-        this.canvasRenderingCtx = (this.ctx as any).vexFlowCanvasContext;
+        this.ctx = <Vex.Flow.CanvasContext>this.renderer.getContext();
+        this.canvasRenderingCtx = this.ctx.vexFlowCanvasContext;
 
+    }
+
+    public getContext(): Vex.Flow.CanvasContext {
+        return this.ctx;
+    }
+
+    public clear(): void {
+        // Doesn't need to do anything
+    }
+
+    public scale(k: number): void {
+        this.ctx.scale(k, k);
     }
 
     public translate(x: number, y: number): void {
@@ -47,5 +59,6 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.canvasRenderingCtx.fillStyle = old;
     }
 
+    private ctx: Vex.Flow.CanvasContext;
     private canvasRenderingCtx: CanvasRenderingContext2D;
 }

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -9,43 +9,43 @@ import {VexFlowConverter} from "./VexFlowConverter";
 
 export class CanvasVexFlowBackend extends VexFlowBackend {
 
-  public getBackendType(): number {
-    return Vex.Flow.Renderer.Backends.CANVAS;
-  }
+    public getBackendType(): number {
+        return Vex.Flow.Renderer.Backends.CANVAS;
+    }
 
-  public initialize(container: HTMLElement): void {
-    this.canvas = document.createElement("canvas");
-    this.inner = document.createElement("div");
-    this.inner.style.position = "relative";
-    this.canvas.style.zIndex = "0";
-    this.inner.appendChild(this.canvas);
-    container.appendChild(this.inner);
-    this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
-    this.ctx = this.renderer.getContext();
-    this.canvasRenderingCtx = (this.ctx as any).vexFlowCanvasContext;
+    public initialize(container: HTMLElement): void {
+        this.canvas = document.createElement("canvas");
+        this.inner = document.createElement("div");
+        this.inner.style.position = "relative";
+        this.canvas.style.zIndex = "0";
+        this.inner.appendChild(this.canvas);
+        container.appendChild(this.inner);
+        this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
+        this.ctx = this.renderer.getContext();
+        this.canvasRenderingCtx = (this.ctx as any).vexFlowCanvasContext;
 
-  }
+    }
 
-  public translate(x: number, y: number): void {
-    this.canvasRenderingCtx.translate(x, y);
-  }
-  public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
-                    heightInPixel: number, screenPosition: PointF2D): void {
-    let old: string = this.canvasRenderingCtx.font;
-    this.canvasRenderingCtx.font = VexFlowConverter.font(
-        fontHeight,
-        fontStyle,
-        font
-    );
-    this.canvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
-    this.canvasRenderingCtx.font = old;
-  }
-  public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
-    let old: string|CanvasGradient|CanvasPattern = this.canvasRenderingCtx.fillStyle;
-    this.canvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);
-    this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-    this.canvasRenderingCtx.fillStyle = old;
-  }
+    public translate(x: number, y: number): void {
+        this.canvasRenderingCtx.translate(x, y);
+    }
+    public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
+                      heightInPixel: number, screenPosition: PointF2D): void  {
+        let old: string = this.canvasRenderingCtx.font;
+        this.canvasRenderingCtx.font = VexFlowConverter.font(
+            fontHeight,
+            fontStyle,
+            font
+        );
+        this.canvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
+        this.canvasRenderingCtx.font = old;
+    }
+    public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
+        let old: string | CanvasGradient | CanvasPattern = this.canvasRenderingCtx.fillStyle;
+        this.canvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);
+        this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+        this.canvasRenderingCtx.fillStyle = old;
+    }
 
-  private canvasRenderingCtx: CanvasRenderingContext2D;
+    private canvasRenderingCtx: CanvasRenderingContext2D;
 }

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -1,0 +1,51 @@
+import Vex = require("vexflow");
+
+import {VexFlowBackend} from "./VexFlowBackend";
+import {FontStyles} from "../../../Common/Enums/FontStyles";
+import {Fonts} from "../../../Common/Enums/Fonts";
+import {RectangleF2D} from "../../../Common/DataObjects/RectangleF2D";
+import {PointF2D} from "../../../Common/DataObjects/PointF2D";
+import {VexFlowConverter} from "./VexFlowConverter";
+
+export class CanvasVexFlowBackend extends VexFlowBackend {
+
+  public getBackendType(): number {
+    return Vex.Flow.Renderer.Backends.CANVAS;
+  }
+
+  public initialize(container: HTMLElement): void {
+    this.canvas = document.createElement("canvas");
+    this.inner = document.createElement("div");
+    this.inner.style.position = "relative";
+    this.canvas.style.zIndex = "0";
+    this.inner.appendChild(this.canvas);
+    container.appendChild(this.inner);
+    this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
+    this.ctx = this.renderer.getContext();
+    this.canvasRenderingCtx = (this.ctx as any).vexFlowCanvasContext;
+
+  }
+
+  public translate(x: number, y: number): void {
+    this.canvasRenderingCtx.translate(x, y);
+  }
+  public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
+                    heightInPixel: number, screenPosition: PointF2D): void {
+    let old: string = this.canvasRenderingCtx.font;
+    this.canvasRenderingCtx.font = VexFlowConverter.font(
+        fontHeight,
+        fontStyle,
+        font
+    );
+    this.canvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
+    this.canvasRenderingCtx.font = old;
+  }
+  public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
+    let old: string|CanvasGradient|CanvasPattern = this.canvasRenderingCtx.fillStyle;
+    this.canvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);
+    this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+    this.canvasRenderingCtx.fillStyle = old;
+  }
+
+  private canvasRenderingCtx: CanvasRenderingContext2D;
+}

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -1,6 +1,7 @@
 import Vex = require("vexflow");
 
 import {VexFlowBackend} from "./VexFlowBackend";
+import {VexFlowConverter} from "./VexFlowConverter";
 import {FontStyles} from "../../../Common/Enums/FontStyles";
 import {Fonts} from "../../../Common/Enums/Fonts";
 import {RectangleF2D} from "../../../Common/DataObjects/RectangleF2D";
@@ -19,18 +20,47 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.canvas.style.zIndex = "0";
         container.appendChild(this.inner);
         this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
-        this.ctx = this.renderer.getContext();
+        this.ctx = <Vex.Flow.SVGContext>this.renderer.getContext();
 
+    }
+
+    public getContext(): Vex.Flow.SVGContext {
+        return this.ctx;
+    }
+
+    public clear(): void {
+        const { svg } = this.ctx;
+        if (!svg) {
+            return;
+        }
+        // removes all children from the SVG element,
+        // effectively clearing the SVG viewport
+        while (svg.lastChild) {
+            svg.removeChild(svg.lastChild);
+        }
+    }
+
+    public scale(k: number): void {
+        this.ctx.scale(k, k);
     }
 
     public translate(x: number, y: number): void {
-        // TODO
+        // TODO: implement this
     }
     public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
                       heightInPixel: number, screenPosition: PointF2D): void {
-        this.ctx.fillText(text, screenPosition.x, screenPosition.y);
+        this.ctx.save();
+
+        this.ctx.setFont("Times New Roman", fontHeight, VexFlowConverter.fontStyle(fontStyle));
+        // font size is set by VexFlow in `pt`. This overwrites the font so it's set to px instead
+        this.ctx.attributes["font-size"] = `${fontHeight}px`;
+        this.ctx.state["font-size"] = `${fontHeight}px`;
+        this.ctx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
+        this.ctx.restore();
     }
     public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
     }
+
+    private ctx: Vex.Flow.SVGContext;
 }

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -8,29 +8,29 @@ import {PointF2D} from "../../../Common/DataObjects/PointF2D";
 
 export class SvgVexFlowBackend extends VexFlowBackend {
 
-  public getBackendType(): number {
-    return Vex.Flow.Renderer.Backends.SVG;
-  }
+    public getBackendType(): number {
+        return Vex.Flow.Renderer.Backends.SVG;
+    }
 
-  public initialize(container: HTMLElement): void {
-    this.canvas = document.createElement("div");
-    this.inner = this.canvas;
-    this.inner.style.position = "relative";
-    this.canvas.style.zIndex = "0";
-    container.appendChild(this.inner);
-    this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
-    this.ctx = this.renderer.getContext();
+    public initialize(container: HTMLElement): void {
+        this.canvas = document.createElement("div");
+        this.inner = this.canvas;
+        this.inner.style.position = "relative";
+        this.canvas.style.zIndex = "0";
+        container.appendChild(this.inner);
+        this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
+        this.ctx = this.renderer.getContext();
 
-  }
+    }
 
-  public translate(x: number, y: number): void {
-    // TODO
-  }
-  public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
-                    heightInPixel: number, screenPosition: PointF2D): void {
-    // TODO
-  }
-  public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
-    this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-  }
+    public translate(x: number, y: number): void {
+        // TODO
+    }
+    public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
+                      heightInPixel: number, screenPosition: PointF2D): void {
+        this.ctx.fillText(text, screenPosition.x, screenPosition.y);
+    }
+    public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
+        this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+    }
 }

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -1,0 +1,36 @@
+import Vex = require("vexflow");
+
+import {VexFlowBackend} from "./VexFlowBackend";
+import {FontStyles} from "../../../Common/Enums/FontStyles";
+import {Fonts} from "../../../Common/Enums/Fonts";
+import {RectangleF2D} from "../../../Common/DataObjects/RectangleF2D";
+import {PointF2D} from "../../../Common/DataObjects/PointF2D";
+
+export class SvgVexFlowBackend extends VexFlowBackend {
+
+  public getBackendType(): number {
+    return Vex.Flow.Renderer.Backends.SVG;
+  }
+
+  public initialize(container: HTMLElement): void {
+    this.canvas = document.createElement("div");
+    this.inner = this.canvas;
+    this.inner.style.position = "relative";
+    this.canvas.style.zIndex = "0";
+    container.appendChild(this.inner);
+    this.renderer = new Vex.Flow.Renderer(this.canvas, this.getBackendType());
+    this.ctx = this.renderer.getContext();
+
+  }
+
+  public translate(x: number, y: number): void {
+    // TODO
+  }
+  public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
+                    heightInPixel: number, screenPosition: PointF2D): void {
+    // TODO
+  }
+  public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
+    this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+  }
+}

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -1,0 +1,57 @@
+import * as Vex from "vexflow";
+import {FontStyles} from "../../../Common/Enums/FontStyles";
+import {Fonts} from "../../../Common/Enums/Fonts";
+import {RectangleF2D} from "../../../Common/DataObjects/RectangleF2D";
+import {PointF2D} from "../../../Common/DataObjects/PointF2D";
+
+export class VexFlowBackends {
+  public static CANVAS: 0;
+  public static RAPHAEL: 1;
+  public static SVG: 2;
+  public static VML: 3;
+
+}
+
+export abstract class VexFlowBackend {
+
+  public abstract initialize(container: HTMLElement): void;
+
+  public getInnerElement(): HTMLElement {
+    return this.inner;
+  }
+
+  public getCanvas(): HTMLElement {
+    return this.canvas;
+  }
+
+  public getContext(): Vex.Flow.CanvasContext {
+    return this.ctx;
+  }
+
+  public getRenderer(): Vex.Flow.Renderer {
+    return this.renderer;
+  }
+
+  // public abstract setWidth(width: number): void;
+  // public abstract setHeight(height: number): void;
+
+  public scale(k: number): void {
+    this.ctx.scale(k, k);
+  }
+
+  public resize(x: number, y: number): void {
+    this.renderer.resize(x, y);
+  }
+
+  public abstract translate(x: number, y: number): void;
+  public abstract renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
+                             heightInPixel: number, screenPosition: PointF2D): void;
+  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number): void;
+
+  public abstract getBackendType(): number;
+
+  protected renderer: Vex.Flow.Renderer;
+  protected inner: HTMLElement;
+  protected canvas: HTMLElement;
+  protected ctx: Vex.Flow.CanvasContext;
+}

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -24,24 +24,22 @@ export abstract class VexFlowBackend {
     return this.canvas;
   }
 
-  public getContext(): Vex.Flow.CanvasContext {
-    return this.ctx;
-  }
-
   public getRenderer(): Vex.Flow.Renderer {
     return this.renderer;
   }
 
+  public abstract getContext(): Vex.Flow.RenderContext;
+
   // public abstract setWidth(width: number): void;
   // public abstract setHeight(height: number): void;
 
-  public scale(k: number): void {
-    this.ctx.scale(k, k);
-  }
+  public abstract scale(k: number): void;
 
   public resize(x: number, y: number): void {
     this.renderer.resize(x, y);
   }
+
+  public abstract clear(): void;
 
   public abstract translate(x: number, y: number): void;
   public abstract renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
@@ -53,5 +51,4 @@ export abstract class VexFlowBackend {
   protected renderer: Vex.Flow.Renderer;
   protected inner: HTMLElement;
   protected canvas: HTMLElement;
-  protected ctx: Vex.Flow.CanvasContext;
 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -380,6 +380,23 @@ export class VexFlowConverter {
     }
 
     /**
+     * Converts the style into a string that VexFlow RenderContext can understand
+     * as the weight of the font
+     */
+    public static fontStyle(style: FontStyles): string {
+        switch (style) {
+            case FontStyles.Bold:
+                return "bold";
+            case FontStyles.Italic:
+                return "italic";
+            case FontStyles.BoldItalic:
+                return "italic bold";
+            default:
+                return "normal";
+        }
+    }
+
+    /**
      * Convert OutlineAndFillStyle to CSS properties
      * @param styleId
      * @returns {string}

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -181,7 +181,7 @@ export class VexFlowMeasure extends StaffMeasure {
      * Draw this measure on a VexFlow CanvasContext
      * @param ctx
      */
-    public draw(ctx: Vex.Flow.CanvasContext): void {
+    public draw(ctx: Vex.Flow.RenderContext): void {
         // If this is the first stave in the vertical measure, call the format
         // method to set the width of all the voices
         if (this.formatVoices) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -31,6 +31,10 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         this.renderer = this.backend.getRenderer();
     }
 
+    public clear(): void {
+        this.backend.clear();
+    }
+
     /**
      * Zoom the rendering areas
      * @param k is the zoom factor
@@ -46,7 +50,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param y
      */
     public resize(x: number, y: number): void {
-        this.renderer.resize(x, y);
+        this.backend.resize(x, y);
     }
 
     public translate(x: number, y: number): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -10,6 +10,7 @@ import {MusicSystem} from "../MusicSystem";
 import {GraphicalObject} from "../GraphicalObject";
 import {GraphicalLayers} from "../DrawingEnums";
 import {GraphicalStaffEntry} from "../GraphicalStaffEntry";
+import {VexFlowBackend} from "./VexFlowBackend";
 
 /**
  * This is a global contant which denotes the height in pixels of the space between two lines of the stave
@@ -20,17 +21,15 @@ export const unitInPixels: number = 10;
 
 export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     private renderer: Vex.Flow.Renderer;
-    private vfctx: Vex.Flow.CanvasContext;
-    private ctx: CanvasRenderingContext2D;
+    private backend: VexFlowBackend;
     private zoom: number = 1.0;
 
-    constructor(canvas: HTMLCanvasElement, isPreviewImageDrawer: boolean = false) {
+    constructor(element: HTMLElement,
+                backend: VexFlowBackend,
+                isPreviewImageDrawer: boolean = false) {
         super(new VexFlowTextMeasurer(), isPreviewImageDrawer);
-        this.renderer = new Vex.Flow.Renderer(canvas, Vex.Flow.Renderer.Backends.CANVAS);
-        this.vfctx = this.renderer.getContext();
-        // The following is a hack to retrieve the actual canvas' drawing context
-        // Not supposed to work forever....
-        this.ctx = (this.vfctx as any).vexFlowCanvasContext;
+        this.backend = backend;
+        this.renderer = this.backend.getRenderer();
     }
 
     /**
@@ -39,7 +38,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      */
     public scale(k: number): void {
         this.zoom = k;
-        this.vfctx.scale(k, k);
+        this.backend.scale(k);
     }
 
     /**
@@ -52,8 +51,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     }
 
     public translate(x: number, y: number): void {
-        // Translation seems not supported by VexFlow
-        this.ctx.translate(x, y);
+        this.backend.translate(x, y);
     }
 
     /**
@@ -70,7 +68,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
             measure.PositionAndShape.AbsolutePosition.x * unitInPixels,
             measure.PositionAndShape.AbsolutePosition.y * unitInPixels
         );
-        measure.draw(this.vfctx);
+        measure.draw(this.backend.getContext());
 
         // Draw the StaffEntries
         for (let staffEntry of measure.staffEntries){
@@ -104,15 +102,10 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      */
     protected renderLabel(graphicalLabel: GraphicalLabel, layer: number, bitmapWidth: number,
                           bitmapHeight: number, heightInPixel: number, screenPosition: PointF2D): void {
-        let ctx: CanvasRenderingContext2D = (this.vfctx as any).vexFlowCanvasContext;
-        let old: string = ctx.font;
-        ctx.font = VexFlowConverter.font(
-            graphicalLabel.Label.fontHeight * unitInPixels,
-            graphicalLabel.Label.fontStyle,
-            graphicalLabel.Label.font
-        );
-        ctx.fillText(graphicalLabel.Label.text, screenPosition.x, screenPosition.y + heightInPixel);
-        ctx.font = old;
+        const height: number = graphicalLabel.Label.fontHeight * unitInPixels;
+        const { fontStyle, font, text } = graphicalLabel.Label;
+
+        this.backend.renderText(height, fontStyle, font, text, heightInPixel, screenPosition);
     }
 
     /**
@@ -123,10 +116,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param styleId the style id
      */
     protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number): void {
-        let old: string|CanvasGradient|CanvasPattern = this.ctx.fillStyle;
-        this.ctx.fillStyle = VexFlowConverter.style(styleId);
-        this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-        this.ctx.fillStyle = old;
+       this.backend.renderRectangle(rectangle, styleId);
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -4,7 +4,6 @@ import {RectangleF2D} from "../../../Common/DataObjects/RectangleF2D";
 import {VexFlowMeasure} from "./VexFlowMeasure";
 import {PointF2D} from "../../../Common/DataObjects/PointF2D";
 import {GraphicalLabel} from "../GraphicalLabel";
-import {VexFlowConverter} from "./VexFlowConverter";
 import {VexFlowTextMeasurer} from "./VexFlowTextMeasurer";
 import {MusicSystem} from "../MusicSystem";
 import {GraphicalObject} from "../GraphicalObject";

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowTextMeasurer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowTextMeasurer.ts
@@ -1,7 +1,7 @@
 import {ITextMeasurer} from "../../Interfaces/ITextMeasurer";
 import {Fonts} from "../../../Common/Enums/Fonts";
 import {FontStyles} from "../../../Common/Enums/FontStyles";
-import {VexFlowConverter} from "./VexFlowConverter";
+// import {VexFlowConverter} from "./VexFlowConverter";
 /**
  * Created by Matthias on 21.06.2016.
  */
@@ -22,7 +22,8 @@ export class VexFlowTextMeasurer implements ITextMeasurer {
      * @returns {number}
      */
     public computeTextWidthToHeightRatio(text: string, font: Fonts, style: FontStyles): number {
-        this.context.font = VexFlowConverter.font(20, style, font);
-        return this.context.measureText(text).width / 20;
+        // this.context.font = VexFlowConverter.font(20, style, font);
+        // return this.context.measureText(text).width / 20;
+        return 1;
     }
 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowTextMeasurer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowTextMeasurer.ts
@@ -1,7 +1,7 @@
 import {ITextMeasurer} from "../../Interfaces/ITextMeasurer";
 import {Fonts} from "../../../Common/Enums/Fonts";
 import {FontStyles} from "../../../Common/Enums/FontStyles";
-// import {VexFlowConverter} from "./VexFlowConverter";
+import {VexFlowConverter} from "./VexFlowConverter";
 /**
  * Created by Matthias on 21.06.2016.
  */
@@ -22,8 +22,7 @@ export class VexFlowTextMeasurer implements ITextMeasurer {
      * @returns {number}
      */
     public computeTextWidthToHeightRatio(text: string, font: Fonts, style: FontStyles): number {
-        // this.context.font = VexFlowConverter.font(20, style, font);
-        // return this.context.measureText(text).width / 20;
-        return 1;
+        this.context.font = VexFlowConverter.font(20, style, font);
+        return this.context.measureText(text).width / 20;
     }
 }

--- a/src/OSMD/OSMD.ts
+++ b/src/OSMD/OSMD.ts
@@ -1,9 +1,12 @@
 import {IXmlElement} from "./../Common/FileIO/Xml";
 import {VexFlowMusicSheetCalculator} from "./../MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator";
+import {VexFlowBackend} from "./../MusicalScore/Graphical/VexFlow/VexFlowBackend";
 import {MusicSheetReader} from "./../MusicalScore/ScoreIO/MusicSheetReader";
 import {GraphicalMusicSheet} from "./../MusicalScore/Graphical/GraphicalMusicSheet";
 import {MusicSheetCalculator} from "./../MusicalScore/Graphical/MusicSheetCalculator";
 import {VexFlowMusicSheetDrawer} from "./../MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer";
+import {SvgVexFlowBackend} from "./../MusicalScore/Graphical/VexFlow/SvgVexFlowBackend";
+import {CanvasVexFlowBackend} from "./../MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend";
 import {MusicSheet} from "./../MusicalScore/MusicSheet";
 import {Cursor} from "./Cursor";
 import {MXLHelper} from "../Common/FileIO/Mxl";
@@ -18,7 +21,7 @@ export class OSMD {
      * @param container is either the ID, or the actual "div" element which will host the music sheet
      * @autoResize automatically resize the sheet to full page width on window resize
      */
-    constructor(container: string|HTMLElement, autoResize: boolean = false) {
+    constructor(container: string|HTMLElement, autoResize: boolean = false, backend: string = "canvas") {
         // Store container element
         if (typeof container === "string") {
             // ID passed
@@ -30,17 +33,22 @@ export class OSMD {
         if (!this.container) {
             throw new Error("Please pass a valid div container to OSMD");
         }
-        // Create the elements inside the container
-        this.canvas = document.createElement("canvas");
-        this.canvas.style.zIndex = "0";
-        let inner: HTMLElement = document.createElement("div");
-        inner.style.position = "relative";
-        inner.appendChild(this.canvas);
-        this.container.appendChild(inner);
+
+        if (backend === "svg") {
+            this.backend = new SvgVexFlowBackend();
+        } else {
+            this.backend = new CanvasVexFlowBackend();
+        }
+
+        this.backend.initialize(this.container);
+        this.canvas = this.backend.getCanvas();
+        const inner: HTMLElement = this.backend.getInnerElement();
+
         // Create the drawer
-        this.drawer = new VexFlowMusicSheetDrawer(this.canvas);
+        this.drawer = new VexFlowMusicSheetDrawer(this.canvas, this.backend, false);
         // Create the cursor
         this.cursor = new Cursor(inner, this);
+
         if (autoResize) {
             this.autoResize();
         }
@@ -50,7 +58,8 @@ export class OSMD {
     public zoom: number = 1.0;
 
     private container: HTMLElement;
-    private canvas: HTMLCanvasElement;
+    private canvas: HTMLElement;
+    private backend: VexFlowBackend;
     private sheet: MusicSheet;
     private drawer: VexFlowMusicSheetDrawer;
     private graphic: GraphicalMusicSheet;
@@ -191,8 +200,8 @@ export class OSMD {
         this.sheet = undefined;
         this.graphic = undefined;
         this.zoom = 1.0;
-        this.canvas.width = 0;
-        this.canvas.height = 0;
+        // this.canvas.width = 0;
+        // this.canvas.height = 0;
     }
 
     /**

--- a/src/OSMD/OSMD.ts
+++ b/src/OSMD/OSMD.ts
@@ -154,6 +154,7 @@ export class OSMD {
         this.graphic.Cursors.push(this.graphic.calculateCursorLineAtTimestamp(new Fraction(7, 4), OutlineAndFillStyleEnum.PlaybackCursor));*/
         // Update Sheet Page
         let height: number = this.graphic.MusicPages[0].PositionAndShape.BorderBottom * 10.0 * this.zoom;
+        this.drawer.clear();
         this.drawer.resize(width, height);
         this.drawer.scale(this.zoom);
         // Finally, draw

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer_Test.ts
@@ -7,6 +7,8 @@ import {VexFlowMusicSheetCalculator} from "../../../../src/MusicalScore/Graphica
 import {TestUtils} from "../../../Util/TestUtils";
 import {IXmlElement} from "../../../../src/Common/FileIO/Xml";
 import {Fraction} from "../../../../src/Common/DataObjects/Fraction";
+import {VexFlowBackend} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowBackend";
+import {CanvasVexFlowBackend} from "../../../../src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend";
 
 /* tslint:disable:no-unused-expression */
 describe("VexFlow Music Sheet Drawer", () => {
@@ -23,7 +25,9 @@ describe("VexFlow Music Sheet Drawer", () => {
 
         // Create the canvas in the document:
         let canvas: HTMLCanvasElement = document.createElement("canvas");
-        let drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas);
+        let backend: VexFlowBackend = new CanvasVexFlowBackend();
+        backend.initialize(canvas);
+        let drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend);
         drawer.drawSheet(gms);
         done();
     });
@@ -41,7 +45,9 @@ describe("VexFlow Music Sheet Drawer", () => {
 
         // Create the canvas in the document:
         let canvas: HTMLCanvasElement = document.createElement("canvas");
-        let drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas);
+        let backend: VexFlowBackend = new CanvasVexFlowBackend();
+        backend.initialize(canvas);
+        let drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend);
         drawer.drawSheet(gms);
         done();
     });


### PR DESCRIPTION
In order to solve the "blurriness" on Retina displays, I've added an option to render the music drawer by using the SVG backend from VexFlow.

I've also encapsulated logic related to the backend (ie: fillRect, translate, etc) to a separate class, so different strategies for custom rendering can be implemented, for SVG and Canvas. To test this, go to the demo page and select the SVG backend: http://jportela-osmd.netlify.com/

Currently, there are a few outstanding issues, which I think make sense to solve before merging this:

* Text Styles are not rendered
* Re-rendering a SVG-backend score will duplicate the "rendering artifacts" (try using the demo page with SVG, and resize it)
* I haven't added any documentation explaining that the new backend could be used (once it's stable, I can write it)
* I haven't really tested this through with all the features OSMD offers, as I'm still fairly new to the library.

Let me know what you think, I'll try to fix the issues I stated above, but I'd appreciate your feedback on this solution.

This solves #69 and #140 