### PR TITLE
Improvement/bounding box draw

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -135,7 +135,7 @@ import { OSMD } from '../src/OSMD/OSMD';
             var value = e.target.value;
             // clears the canvas element
             canvas.innerHTML = "";
-            osmdObj = new opensheetmusicdisplay.OSMD(canvas, false, value);
+            osmdObj = new OSMD(canvas, false, value);
             osmdObj.setLogLevel('info');
             selectOnChange();
 

--- a/src/MusicalScore/Graphical/DrawingEnums.ts
+++ b/src/MusicalScore/Graphical/DrawingEnums.ts
@@ -1,3 +1,5 @@
+import Dictionary from "typescript-collections/dist/lib/Dictionary";
+
 /**
  * The supported styles to draw a rectangle on the music sheet
  */
@@ -36,6 +38,43 @@ export enum OutlineAndFillStyleEnum {
     Comment9,
     Comment10
 }
+
+export const OUTLINE_AND_FILL_STYLE_DICT: Dictionary<OutlineAndFillStyleEnum, string> = new Dictionary<OutlineAndFillStyleEnum, string>();
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.BaseWritingColor, "Thistle");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.FollowingCursor, "Aqua");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.AlternativeFollowingCursor, "Azure");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.PlaybackCursor, "Bisque");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Highlighted, "CadetBlue");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.ErrorUnderlay, "DarkBlue");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Selected, "DarkGoldenRod");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.SelectionSymbol, "BlanchedAlmond");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.DebugColor1, "Chartreuse");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.DebugColor2, "DarkGreen");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.DebugColor3, "DarkOrange");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.SplitScreenDivision, "FireBrick");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.GreyTransparentOverlay, "DarkSalmon");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea1, "DarkSeaGreen");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea2, "DarkOrchid");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea3, "Aquamarine");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea4, "DarkKhaki");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea5, "ForestGreen");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea6, "AliceBlue");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea7, "DeepPink");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea8, "Coral");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea9, "DarkOliveGreen");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.MarkedArea10, "Chocolate");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment1, "DodgerBlue");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment2, "Blue");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment3, "Beige");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment4, "Crimson");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment5, "Fuchsia");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment6, "Brown");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment7, "BlanchedAlmond");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment8, "CornflowerBlue");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment9, "Cornsilk");
+OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment10, "DarkGrey");
+
+
 
 export enum StyleSets {
     MarkedArea,

--- a/src/MusicalScore/Graphical/DrawingEnums.ts
+++ b/src/MusicalScore/Graphical/DrawingEnums.ts
@@ -1,4 +1,4 @@
-import Dictionary from "typescript-collections/dist/lib/Dictionary";
+import * as Collections from "typescript-collections";
 
 /**
  * The supported styles to draw a rectangle on the music sheet
@@ -39,7 +39,8 @@ export enum OutlineAndFillStyleEnum {
     Comment10
 }
 
-export const OUTLINE_AND_FILL_STYLE_DICT: Dictionary<OutlineAndFillStyleEnum, string> = new Dictionary<OutlineAndFillStyleEnum, string>();
+// tslint:disable-next-line:max-line-length A linebreak would be more confusing here
+export const OUTLINE_AND_FILL_STYLE_DICT: Collections.Dictionary<OutlineAndFillStyleEnum, string> = new Collections.Dictionary<OutlineAndFillStyleEnum, string>();
 OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.BaseWritingColor, "Thistle");
 OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.FollowingCursor, "Aqua");
 OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.AlternativeFollowingCursor, "Azure");

--- a/src/MusicalScore/Graphical/DrawingEnums.ts
+++ b/src/MusicalScore/Graphical/DrawingEnums.ts
@@ -74,15 +74,13 @@ OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment8, "Cornflow
 OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment9, "Cornsilk");
 OUTLINE_AND_FILL_STYLE_DICT.setValue(OutlineAndFillStyleEnum.Comment10, "DarkGrey");
 
-
-
 export enum StyleSets {
     MarkedArea,
     Comment
 }
 
 /**
- * The layers which one can draw on (not suppoerted)
+ * The layers which one can draw on (not supported)
  */
 export enum GraphicalLayers {
     Background,

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -409,7 +409,7 @@ export abstract class MusicSheetDrawer {
             return;
         }
 
-        if (process.env.DRAW_BOUNDING_BOXES.toLowerCase() === "true" || process.env.DRAW_BOUNDING_BOXES === "1") {
+        if (process.env.DRAW_BOUNDING_BOXES === "1") {
             this.drawBoundingBoxes(page.PositionAndShape, 0, process.env.BOUNDING_BOX_TYPE);
         }
 

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -24,7 +24,7 @@ import {Instrument} from "../Instrument";
 import {MusicSymbolDrawingStyle, PhonicScoreModes} from "./DrawingMode";
 import {GraphicalOctaveShift} from "./GraphicalOctaveShift";
 import {GraphicalObject} from "./GraphicalObject";
-import { unitInPixels } from "./VexFlow/VexFlowMusicSheetDrawer";
+// import { unitInPixels } from "./VexFlow/VexFlowMusicSheetDrawer";
 
 /**
  * Draw a [[GraphicalMusicSheet]] (through the .drawSheet method)
@@ -428,6 +428,8 @@ export abstract class MusicSheetDrawer {
     private drawBoundingBoxes(startBox: BoundingBox, layer: number = 0, type: string = undefined): void {
         const dataObjectString: string = (startBox.DataObject.constructor as any).name;
         if (startBox.BoundingRectangle !== undefined && (dataObjectString === type || type === undefined)) {
+            // FIXME: Including this constant from VexFlowMusicSheetDrawer causes karma test to crash.
+            const unitInPixels: number = 10;
             const tmpRect: RectangleF2D = new RectangleF2D(startBox.AbsolutePosition.x * unitInPixels,
                                                            startBox.AbsolutePosition.y * unitInPixels,
                                                            startBox.Size.width * unitInPixels,

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -420,7 +420,7 @@ export abstract class MusicSheetDrawer {
         }
         // Draw bounding boxes for debug purposes. This has to be at the end because only
         // then all the calculations and recalculations are done
-        if (process.env.DRAW_BOUNDING_BOX_ELEMENT !== undefined) {
+        if (process.env.DRAW_BOUNDING_BOX_ELEMENT) {
             this.drawBoundingBoxes(page.PositionAndShape, 0, process.env.DRAW_BOUNDING_BOX_ELEMENT);
         }
 

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -24,7 +24,6 @@ import {Instrument} from "../Instrument";
 import {MusicSymbolDrawingStyle, PhonicScoreModes} from "./DrawingMode";
 import {GraphicalOctaveShift} from "./GraphicalOctaveShift";
 import {GraphicalObject} from "./GraphicalObject";
-// import { unitInPixels } from "./VexFlow/VexFlowMusicSheetDrawer";
 
 /**
  * Draw a [[GraphicalMusicSheet]] (through the .drawSheet method)
@@ -421,13 +420,19 @@ export abstract class MusicSheetDrawer {
         }
         // Draw bounding boxes for debug purposes. This has to be at the end because only
         // then all the calculations and recalculations are done
-        if (process.env.DRAW_BOUNDING_BOXES === "1") {
-            this.drawBoundingBoxes(page.PositionAndShape, 0, process.env.BOUNDING_BOX_TYPE);
+        if (process.env.DRAW_BOUNDING_BOX_ELEMENT !== undefined) {
+            this.drawBoundingBoxes(page.PositionAndShape, 0, process.env.DRAW_BOUNDING_BOX_ELEMENT);
         }
 
     }
 
-    private drawBoundingBoxes(startBox: BoundingBox, layer: number = 0, type: string = undefined): void {
+    /**
+     * Draw bounding boxes aroung GraphicalObjects
+     * @param startBox Bounding Box that is used as a staring point to recursively go through all child elements
+     * @param layer Layer to draw to
+     * @param type Type of element to show bounding boxes for as string.
+     */
+    private drawBoundingBoxes(startBox: BoundingBox, layer: number = 0, type: string = "all"): void {
         const dataObjectString: string = (startBox.DataObject.constructor as any).name;
         if (startBox.BoundingRectangle !== undefined && (dataObjectString === type || type === "all")) {
             const relBoundingRect: RectangleF2D = startBox.BoundingRectangle;

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -428,12 +428,11 @@ export abstract class MusicSheetDrawer {
     private drawBoundingBoxes(startBox: BoundingBox, layer: number = 0, type: string = undefined): void {
         const dataObjectString: string = (startBox.DataObject.constructor as any).name;
         if (startBox.BoundingRectangle !== undefined && (dataObjectString === type || type === undefined)) {
-            // FIXME: Including this constant from VexFlowMusicSheetDrawer causes karma test to crash.
-            const unitInPixels: number = 10;
-            const tmpRect: RectangleF2D = new RectangleF2D(startBox.AbsolutePosition.x * unitInPixels,
-                                                           startBox.AbsolutePosition.y * unitInPixels,
-                                                           startBox.Size.width * unitInPixels,
-                                                           startBox.Size.height * unitInPixels);
+            const relBoundingRect: RectangleF2D = startBox.BoundingRectangle;
+            let tmpRect: RectangleF2D = new RectangleF2D(startBox.AbsolutePosition.x + startBox.BorderLeft - 1,
+                                                         startBox.AbsolutePosition.y + startBox.BorderTop - 1,
+                                                         (relBoundingRect.width + 6), (relBoundingRect.height + 2));
+            tmpRect = this.applyScreenTransformationForRect(tmpRect);
             this.renderRectangle(tmpRect, <number>GraphicalLayers.Background, layer, 0.5);
             this.renderLabel(new GraphicalLabel(new Label(dataObjectString), 1.2, TextAlignment.CenterCenter),
                              layer, tmpRect.width, tmpRect.height, tmpRect.height, new PointF2D(tmpRect.x, tmpRect.y));

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -52,11 +52,13 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.canvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.canvasRenderingCtx.font = old;
     }
-    public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
+    public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
         const old: string | CanvasGradient | CanvasPattern = this.canvasRenderingCtx.fillStyle;
         this.canvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);
+        this.canvasRenderingCtx.globalAlpha = alpha;
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         this.canvasRenderingCtx.fillStyle = old;
+        this.canvasRenderingCtx.globalAlpha = 1;
     }
 
     private ctx: Vex.Flow.CanvasContext;

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -52,15 +52,6 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.canvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.canvasRenderingCtx.font = old;
     }
-
-    /**
-     * Renders a rectangle with the given style to the screen.
-     * It is given in screen coordinates.
-     * @param rectangle the rect in screen coordinates
-     * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
-     * @param styleId the style id
-     * @param alpha alpha value between 0 and 1
-     */
     public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
         const old: string | CanvasGradient | CanvasPattern = this.canvasRenderingCtx.fillStyle;
         this.canvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -52,6 +52,15 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.canvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.canvasRenderingCtx.font = old;
     }
+
+    /**
+     * Renders a rectangle with the given style to the screen.
+     * It is given in screen coordinates.
+     * @param rectangle the rect in screen coordinates
+     * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
+     * @param styleId the style id
+     * @param alpha alpha value between 0 and 1
+     */
     public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
         const old: string | CanvasGradient | CanvasPattern = this.canvasRenderingCtx.fillStyle;
         this.canvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -58,8 +58,14 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.ctx.restore();
     }
-    public renderRectangle(rectangle: RectangleF2D, styleId: number): void {
+
+    public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
+        this.ctx.save();
+        this.ctx.attributes.fill = VexFlowConverter.style(styleId);
+        this.ctx.attributes["fill-opacity"] = alpha;
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+        this.ctx.restore();
+        this.ctx.attributes["fill-opacity"] = 1;
     }
 
     private ctx: Vex.Flow.SVGContext;

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -59,6 +59,14 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.restore();
     }
 
+    /**
+     * Renders a rectangle with the given style to the screen.
+     * It is given in screen coordinates.
+     * @param rectangle the rect in screen coordinates
+     * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
+     * @param styleId the style id
+     * @param alpha alpha value between 0 and 1
+     */
     public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
         this.ctx.save();
         this.ctx.attributes.fill = VexFlowConverter.style(styleId);

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -58,15 +58,6 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.ctx.restore();
     }
-
-    /**
-     * Renders a rectangle with the given style to the screen.
-     * It is given in screen coordinates.
-     * @param rectangle the rect in screen coordinates
-     * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
-     * @param styleId the style id
-     * @param alpha alpha value between 0 and 1
-     */
     public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
         this.ctx.save();
         this.ctx.attributes.fill = VexFlowConverter.style(styleId);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -44,6 +44,14 @@ export abstract class VexFlowBackend {
   public abstract translate(x: number, y: number): void;
   public abstract renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
                              heightInPixel: number, screenPosition: PointF2D): void;
+  /**
+   * Renders a rectangle with the given style to the screen.
+   * It is given in screen coordinates.
+   * @param rectangle the rect in screen coordinates
+   * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
+   * @param styleId the style id
+   * @param alpha alpha value between 0 and 1
+   */
   public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number): void;
 
   public abstract getBackendType(): number;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -44,7 +44,7 @@ export abstract class VexFlowBackend {
   public abstract translate(x: number, y: number): void;
   public abstract renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
                              heightInPixel: number, screenPosition: PointF2D): void;
-  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number): void;
+  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number): void;
 
   public abstract getBackendType(): number;
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -14,7 +14,7 @@ import {GraphicalNote} from "../GraphicalNote";
 import {SystemLinesEnum} from "../SystemLinesEnum";
 import {FontStyles} from "../../../Common/Enums/FontStyles";
 import {Fonts} from "../../../Common/Enums/Fonts";
-import {OutlineAndFillStyleEnum} from "../DrawingEnums";
+import {OutlineAndFillStyleEnum, OUTLINE_AND_FILL_STYLE_DICT} from "../DrawingEnums";
 import {Logging} from "../../../Common/Logging";
 
 /**
@@ -430,7 +430,7 @@ export class VexFlowConverter {
      * @returns {string}
      */
     public static style(styleId: OutlineAndFillStyleEnum): string {
-        // TODO To be implemented
-        return "lightgreen";
+        const ret: string = OUTLINE_AND_FILL_STYLE_DICT.getValue(styleId);
+        return ret;
     }
 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -33,8 +33,6 @@ import {VexFlowGraphicalNote} from "./VexFlowGraphicalNote";
 export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     constructor() {
         super(new VexFlowGraphicalSymbolFactory());
-        let a: LyricsEntry = new LyricsEntry(undefined, undefined, undefined);
-        a = a;
         MusicSheetCalculator.TextMeasurer = new VexFlowTextMeasurer();
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -117,6 +117,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param rectangle the rect in screen coordinates
      * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
      * @param styleId the style id
+     * @param alpha alpha value between 0 and 1
      */
     protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, alpha: number): void {
        this.backend.renderRectangle(rectangle, styleId, alpha);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -118,8 +118,8 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param layer is the current rendering layer. There are many layers on top of each other to which can be rendered. Not needed for now.
      * @param styleId the style id
      */
-    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number): void {
-       this.backend.renderRectangle(rectangle, styleId);
+    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, alpha: number): void {
+       this.backend.renderRectangle(rectangle, styleId, alpha);
     }
 
     /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,8 +39,7 @@ module.exports = {
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
       DEBUG: false,
-      DRAW_BOUNDING_BOXES: '0',
-      BOUNDING_BOX_TYPE: 'GraphicalLabel', // Set to undefined for all bounding boxes otherwise put in the name of the object
+      DRAW_BOUNDING_BOX_ELEMENT: false, //  Specifies the element to draw bounding boxes for (e.g. 'GraphicalLabels'). If 'all', bounding boxes are drawn for all elements.
     }),
     // FIXME: use environment variable to control uglify.
     // new webpack.optimize.UglifyJsPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
       NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
       DEBUG: false,
       DRAW_BOUNDING_BOXES: '0',
-      BOUNDING_BOX_TYPE: 'GraphicalLabel', // Set to undefined for all bounding boxes othwise put in the name of the object
+      BOUNDING_BOX_TYPE: 'GraphicalLabel', // Set to undefined for all bounding boxes otherwise put in the name of the object
     }),
     // FIXME: use environment variable to control uglify.
     // new webpack.optimize.UglifyJsPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,12 @@ module.exports = {
       $: 'jquery',
       jQuery: 'jquery'
     }),
+    new webpack.EnvironmentPlugin({
+      NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
+      DEBUG: false,
+      DRAW_BOUNDING_BOXES: '0',
+      BOUNDING_BOX_TYPE: 'GraphicalLabel', // Set to undefined for all bounding boxes othwise put in the name of the object
+    }),
     // FIXME: use environment variable to control uglify.
     // new webpack.optimize.UglifyJsPlugin({
     //     warnings: false,


### PR DESCRIPTION
Adding possibility to draw bounding boxes around graphical objects. Can be controled by environment variables over webpack, which is also another feature coming with this PR.
 also implemented the "style to css" converter which basically assigns randomly chosen colors (by me) to the id number.