### PR TITLE
Migration to loglevel for all logging statements

### DIFF
--- a/src/MusicalScore/Graphical/BoundingBox.ts
+++ b/src/MusicalScore/Graphical/BoundingBox.ts
@@ -1,3 +1,4 @@
+import * as log from "loglevel";
 import {ArgumentOutOfRangeException} from "../Exceptions";
 import {PointF2D} from "../../Common/DataObjects/PointF2D";
 import {SizeF2D} from "../../Common/DataObjects/SizeF2D";
@@ -201,7 +202,7 @@ export class BoundingBox {
     public set Parent(value: BoundingBox) {
         this.parent = value;
         if (this.parent.ChildElements.indexOf(this) > -1) {
-            console.error("BoundingBox of " + (this.dataObject.constructor as any).name +
+            log.warn("BoundingBox of " + (this.dataObject.constructor as any).name +
             " already in children list of " + (this.parent.dataObject.constructor as any).name + "'s BoundingBox");
         } else {
             this.parent.ChildElements.push(this);

--- a/src/MusicalScore/Graphical/BoundingBox.ts
+++ b/src/MusicalScore/Graphical/BoundingBox.ts
@@ -202,7 +202,7 @@ export class BoundingBox {
     public set Parent(value: BoundingBox) {
         this.parent = value;
         if (this.parent.ChildElements.indexOf(this) > -1) {
-            log.warn("BoundingBox of " + (this.dataObject.constructor as any).name +
+            log.error("BoundingBox of " + (this.dataObject.constructor as any).name +
             " already in children list of " + (this.parent.dataObject.constructor as any).name + "'s BoundingBox");
         } else {
             this.parent.ChildElements.push(this);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -1,3 +1,4 @@
+import * as log from "loglevel";
 import {GraphicalStaffEntry} from "../GraphicalStaffEntry";
 import {VexFlowMeasure} from "./VexFlowMeasure";
 import {SourceStaffEntry} from "../../VoiceData/SourceStaffEntry";
@@ -28,7 +29,7 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                 const staveNote: Vex.Flow.StaveNote = tickable as Vex.Flow.StaveNote;
                 tickablePosition += staveNote.getNoteHeadEndX() - staveNote.getGlyphWidth() / 2;
             } else {
-                console.log(tickable);
+                log.trace(tickable);
                 const ghostNote: Vex.Flow.GhostNote = tickable;
                 // That's basically the same as the StaveNote does.
                 tickablePosition = ghostNote.getAbsoluteX() + ghostNote.x_shift;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -1,4 +1,3 @@
-import * as log from "loglevel";
 import {GraphicalStaffEntry} from "../GraphicalStaffEntry";
 import {VexFlowMeasure} from "./VexFlowMeasure";
 import {SourceStaffEntry} from "../../VoiceData/SourceStaffEntry";
@@ -29,7 +28,6 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                 const staveNote: Vex.Flow.StaveNote = tickable as Vex.Flow.StaveNote;
                 tickablePosition += staveNote.getNoteHeadEndX() - staveNote.getGlyphWidth() / 2;
             } else {
-                log.trace(tickable);
                 const ghostNote: Vex.Flow.GhostNote = tickable;
                 // That's basically the same as the StaveNote does.
                 tickablePosition = ghostNote.getAbsoluteX() + ghostNote.x_shift;

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -1,3 +1,4 @@
+import * as log from "loglevel";
 import {Fraction} from "../../Common/DataObjects/Fraction";
 import {VerticalSourceStaffEntryContainer} from "./VerticalSourceStaffEntryContainer";
 import {SourceStaffEntry} from "./SourceStaffEntry";
@@ -214,7 +215,7 @@ export class SourceMeasure extends BaseIdClass {
                 }
             }
         }
-        //log.debug("created new container: ", staffEntry, this.verticalSourceStaffEntryContainers);
+        log.trace("created new container: ", staffEntry, this.verticalSourceStaffEntryContainers);
         return {createdNewContainer: true, staffEntry: staffEntry};
     }
 

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -1,4 +1,3 @@
-import * as log from "loglevel";
 import {Fraction} from "../../Common/DataObjects/Fraction";
 import {VerticalSourceStaffEntryContainer} from "./VerticalSourceStaffEntryContainer";
 import {SourceStaffEntry} from "./SourceStaffEntry";
@@ -215,7 +214,6 @@ export class SourceMeasure extends BaseIdClass {
                 }
             }
         }
-        log.trace("created new container: ", staffEntry, this.verticalSourceStaffEntryContainers);
         return {createdNewContainer: true, staffEntry: staffEntry};
     }
 

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -175,7 +175,7 @@ export class OpenSheetMusicDisplay {
     public setLogLevel(level: string): void {
         switch (level) {
             case "trace":
-                log.setLevel(log.levels.WARN);
+                log.setLevel(log.levels.TRACE);
                 break;
             case "debug":
                 log.setLevel(log.levels.DEBUG);


### PR DESCRIPTION
Changed all missing debug and error outputs so that they print using the `loglevel `framework.

- How can we put OSMD components into logical groups in terms of logging? I can imagine something, where it would be possible to mute all errors and warnings coming from the MusicXML reading parts but displaying the ones that result from rendering etc.
- Do we really need class names etc in the logging statement as @bneumann pointed out? loglevel does not alter the source of the call so with sourcemaps activated, you can easily find the origin of the log statement.