### PR TITLE
fix(MusicSheetCalculator.ts): shorten lyrics y offset

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -503,8 +503,7 @@ export abstract class MusicSheetCalculator {
                     }
 
                     // check BottomLine in this range and take the maximum between the two values
-                    const bottomLineMax: number = skyBottomLineCalculator.getBottomLineMaxInRange(minMarginLeft, maxMarginRight)
-                        + this.rules.StaffHeight;
+                    const bottomLineMax: number = skyBottomLineCalculator.getBottomLineMaxInRange(minMarginLeft, maxMarginRight);
                     lyricsStartYPosition = Math.max(lyricsStartYPosition, bottomLineMax);
                 }
             }
@@ -817,7 +816,7 @@ export abstract class MusicSheetCalculator {
     }
 
     /**
-     * Do layout on staff measures with only consist of a full rest.
+     * Do layout on staff measures which only consist of a full rest.
      * @param rest
      * @param gse
      * @param measure
@@ -1178,7 +1177,7 @@ export abstract class MusicSheetCalculator {
     protected calculatePageLabels(page: GraphicalMusicPage): void {
 
         // The PositionAndShape child elements of page need to be manually connected to the lyricist, composer, subtitle, etc.
-        // because the page are only available now
+        // because the page is only available now
         let firstSystemAbsoluteTopMargin: number = 10;
         if (page.MusicSystems.length > 0) {
             const firstMusicSystem: MusicSystem = page.MusicSystems[0];
@@ -1724,7 +1723,7 @@ export abstract class MusicSheetCalculator {
                 }
             }
         }
-        // the fill in the lyric word dashes and lyrics extends/underscores
+        // then fill in the lyric word dashes and lyrics extends/underscores
         for (let idx: number = 0, len: number = this.graphicalMusicSheet.MusicPages.length; idx < len; ++idx) {
             const graphicalMusicPage: GraphicalMusicPage = this.graphicalMusicSheet.MusicPages[idx];
             for (let idx2: number = 0, len2: number = graphicalMusicPage.MusicSystems.length; idx2 < len2; ++idx2) {


### PR DESCRIPTION
Shortened lyrics y-offset below the staff.
Now lyrics much better belong to the corresponding staff visually,
as with physical sheet music editions.

(also, some typo fixes)

I believe the lyrics Y offset was unnecessarily extended by EngravingRules.StaffHeight, because it's already set to Math.max of StaffHeight and the bounding box. no need to add StaffHeight to the bounding box.

(We shouldn't be too worried about a collision right at the bounding box. Most letters won't reach it, and most notes will not reach it either. Even if we're worried, we should only add a very small offset, maybe 0.1, not the 3.0 of StaffHeight)

Comparison screenshots below, first current state before fix:
(of course, the blue bounding box lines only show with debug information/bottomlines)
![lyricsyoffsetfixdevelop_examples](https://user-images.githubusercontent.com/33069673/42511770-147382f2-8453-11e8-98a8-fd1b6891ed2a.png)

 The third and fourth examples are from this PR's build. All lyrics seem to have a good offset now, including all voice examples in our demo.
(the Beethoven example should only show that we don't get collisions. the layouting isn't ideal, but no real voice part in sheet music has this many ledger lines, it's way out of the voice range because i shifted some notes two octaves lower)

Below an excerpt of a physical sheet music edition of Beethoven's An Die Ferne Geliebte, which shows that physical sheet music editions also put the lyrics very closely below the corresponding staff.

![lyricsyoffsetphysicalsheetmusicexamplefernegeliebte](https://user-images.githubusercontent.com/33069673/42512032-cd4e5ab8-8453-11e8-8255-a21c49f5bfb6.png)

(edition C.F. Peters, after 1949, from IMSLP)