### PR TITLE
chore(package): update eslint to version 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "clean-webpack-plugin": "^0.1.18",
     "cross-env": "^5.1.3",
     "cz-conventional-changelog": "^2.0.0",
-    "eslint": "^4.18.1",
+    "eslint": "^5.0.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-node": "^6.0.1",


### PR DESCRIPTION
Closes #274 

> eslint now throws a deprecation warning for the "standard" file. I think we can use the 5.0.1 version!

@bneumann  So you're talking about:
```
(node:1696) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "standard")
```

I can live with that, maybe I'll ping https://github.com/standard/eslint-plugin-standard so that they can fix it? Do we need eslint-plugin-standard after all? Or would we rather use our own ruleset?


> do you agree updating to 5.0.1?

@sschmidTU If we can all live with the deprecation warning above, yes.


There is also
```
no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
```
which can't be fixed as it comes from the standards rule set too.
