### PR TITLE
Fix key signature without mode, common/alla breve time

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -533,7 +533,10 @@ export class VexFlowConverter {
             case KeyEnum.major:
                 ret = VexFlowConverter.majorMap[key.Key];
                 break;
+            // some XMLs don't have the mode set despite having a key signature.
             case KeyEnum.none:
+                ret = VexFlowConverter.majorMap[key.Key];
+                break;
             default:
                 ret = "C";
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -100,6 +100,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             log.warn("Found a measure with no voices... Continuing anyway.", mvoices);
             continue;
         }
+        // all voices that belong to one stave are collectively added to create a common context in VexFlow.
         formatter.joinVoices(voices);
     }
 

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -781,9 +781,6 @@ export class InstrumentReader {
           log.debug("InstrumentReader.addAbstractInstruction", errorMsg, ex);
         }
 
-        if ((num === 4 && denom === 4) || (num === 2 && denom === 2)) {
-          symbolEnum = RhythmSymbolEnum.NONE;
-        }
         this.abstractInstructions.push([1, new RhythmInstruction(
           new Fraction(num, denom, 0, false), symbolEnum
         )]);

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -711,7 +711,6 @@ export class InstrumentReader {
           keyEnum = KeyEnum.major;
           log.debug("InstrumentReader.addAbstractInstruction", errorMsg, ex);
         }
-
       }
       const keyInstruction: KeyInstruction = new KeyInstruction(undefined, key, keyEnum);
       this.abstractInstructions.push([1, keyInstruction]);


### PR DESCRIPTION
2 fixes:
fix(KeySignatureParse): key signature displayed correctly when mode not set in XML
fix(TimeSignatures): common time and alla breve display correctly

![image](https://user-images.githubusercontent.com/33069673/43200551-30d4124e-9016-11e8-82e2-af21ba21069d.png)

Previously, common time(C) was displayed as 4/4 and alla breve(C|) as 2/2,
and the D major signature in An die Musik was read as no key signature because mode attribute was missing:

![image](https://user-images.githubusercontent.com/33069673/43200657-7f23daba-9016-11e8-8531-ef8be4cf4782.png)