### PR TITLE
Update vexflow to new version 1.2.85 (fixes bugs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "loglevel": "^1.5.0",
     "shortid": "^2.2.6",
     "typescript-collections": "^1.1.2",
-    "vexflow": "^1.2.84"
+    "vexflow": "^1.2.85"
   },
   "devDependencies": {
     "@types/chai": "^4.0.3",


### PR DESCRIPTION
We finally got a new Vexflow release, and it fixes many layouting bugs:
* Delayed ornament x-shift
* Grace notes x-shift
* NoteSubGroup, In-Measure Clef x-shift
* (Dotted note dot y-shift, in previous master builds)

I used this version extensively, looked at most samples, and didn't notice breaking changes (that i didn't already fix).

(do npm install to use the new version)