### PR TITLE
feat: draw lyricsExtends, fix: lyricsSpacing

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -122,6 +122,7 @@ export class EngravingRules {
     private wedgeLineWidth: number;
     private tupletLineWidth: number;
     private lyricUnderscoreLineWidth: number;
+    private lyricUnderscoreLineWidthVexflow: number;
     private systemThinLineWidth: number;
     private systemBoldLineWidth: number;
     private systemRepetitionEndingLineWidth: number;
@@ -292,6 +293,7 @@ export class EngravingRules {
         this.wedgeLineWidth = 0.12;
         this.tupletLineWidth = 0.12;
         this.lyricUnderscoreLineWidth = 0.12;
+        this.lyricUnderscoreLineWidthVexflow = 1.3;
         this.systemThinLineWidth = 0.12;
         this.systemBoldLineWidth = EngravingRules.unit / 2.0;
         this.systemRepetitionEndingLineWidth = 0.12;
@@ -1020,6 +1022,12 @@ export class EngravingRules {
     }
     public set LyricUnderscoreLineWidth(value: number) {
         this.lyricUnderscoreLineWidth = value;
+    }
+    public get LyricUnderscoreLineWidthVexflow(): number {
+        return this.lyricUnderscoreLineWidthVexflow;
+    }
+    public set LyricUnderscoreLineWidthVexflow(value: number) {
+        this.LyricUnderscoreLineWidthVexflow = value;
     }
     public get SystemThinLineWidth(): number {
         return this.systemThinLineWidth;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -128,6 +128,7 @@ export class EngravingRules {
     private systemRepetitionEndingLineWidth: number;
     private systemDotWidth: number;
     private distanceBetweenVerticalSystemLines: number;
+    private noteHeadWidth: number; // estimated
     private distanceBetweenDotAndLine: number;
     private octaveShiftLineWidth: number;
     private octaveShiftVerticalLineLength: number;
@@ -275,7 +276,7 @@ export class EngravingRules {
         this.lyricsHeight = 2.0; // actually size of lyrics
         this.lyricsYOffsetToStaffHeight = 3.0; // distance between lyrics and staff. could partly be even lower/dynamic
         this.verticalBetweenLyricsDistance = 0.5;
-        this.horizontalBetweenLyricsDistance = 0.3;
+        this.horizontalBetweenLyricsDistance = 0.1;
         this.betweenSyllabelMaximumDistance = 10.0;
         this.betweenSyllabelMinimumDistance = 0.4;
         this.minimumDistanceBetweenDashes = 10;
@@ -299,6 +300,7 @@ export class EngravingRules {
         this.systemRepetitionEndingLineWidth = 0.12;
         this.systemDotWidth = EngravingRules.unit / 5.0;
         this.distanceBetweenVerticalSystemLines = 0.35;
+        this.noteHeadWidth = this.distanceBetweenVerticalSystemLines * 2; // estimated
         this.distanceBetweenDotAndLine = 0.7;
         this.octaveShiftLineWidth = 0.12;
         this.octaveShiftVerticalLineLength = EngravingRules.unit;
@@ -1058,6 +1060,12 @@ export class EngravingRules {
     }
     public set DistanceBetweenVerticalSystemLines(value: number) {
         this.distanceBetweenVerticalSystemLines = value;
+    }
+    public get NoteHeadWidth(): number {
+        return this.noteHeadWidth;
+    }
+    public set NoteHeadWidth(value: number) {
+        this.noteHeadWidth = value;
     }
     public get DistanceBetweenDotAndLine(): number {
         return this.distanceBetweenDotAndLine;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -500,7 +500,7 @@ export abstract class MusicSheetCalculator {
                         measureRelativePosition.x;
 
                     let minMarginLeft: number = Number.MAX_VALUE;
-                    let maxMarginRight: number = Number.MAX_VALUE;
+                    let maxMarginRight: number = Number.MIN_VALUE;
 
                     // if more than one LyricEntry in StaffEntry, find minMarginLeft, maxMarginRight of all corresponding Labels
                     for (let i: number = 0; i < staffEntry.LyricsEntries.length; i++) {
@@ -1873,15 +1873,17 @@ export abstract class MusicSheetCalculator {
         // if on the same StaffLine
         if (startStaffLine === endStaffLine) {
             // start- and End margins from the text Labels
-            const startX: number = startStaffEntry.parentMeasure.PositionAndShape.RelativePosition.x +
+            const startX: number = startStaffEntry.parentMeasure.PositionAndShape.AbsolutePosition.x +
                 startStaffEntry.PositionAndShape.RelativePosition.x +
-                lyricEntry.GraphicalLabel.PositionAndShape.BorderMarginRight;
+                //lyricEntry.GraphicalLabel.PositionAndShape.BorderMarginRight;
+                startStaffEntry.PositionAndShape.BorderMarginRight;
+            //const startX: number = lyricEntry.GraphicalLabel.PositionAndShape.AbsolutePosition.x;
             const endX: number = endStaffEntry.parentMeasure.PositionAndShape.RelativePosition.x +
                 endStaffEntry.PositionAndShape.RelativePosition.x +
                 endStaffEntry.PositionAndShape.BorderMarginRight;
-            // needed in order to line up with the Label's text bottom line (is the y psoition of the underscore)
+            // needed in order to line up with the Label's text bottom line (is the y position of the underscore)
             startY -= lyricEntry.GraphicalLabel.PositionAndShape.Size.height / 4;
-            // create a Line (as underscope after the LyricLabel's End)
+            // create a Line (as underscore after the LyricLabel's End)
             this.calculateSingleLyricWordWithUnderscore(startStaffLine, startX, endX, startY);
         } else { // start and end on different StaffLines
             // start margin from the text Label until the End of StaffLine

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1873,14 +1873,17 @@ export abstract class MusicSheetCalculator {
         // if on the same StaffLine
         if (startStaffLine === endStaffLine) {
             // start- and End margins from the text Labels
-            const startX: number = startStaffEntry.parentMeasure.PositionAndShape.AbsolutePosition.x +
+            const startX: number = startStaffEntry.parentMeasure.PositionAndShape.RelativePosition.x +
                 startStaffEntry.PositionAndShape.RelativePosition.x +
                 //lyricEntry.GraphicalLabel.PositionAndShape.BorderMarginRight;
                 startStaffEntry.PositionAndShape.BorderMarginRight;
-            //const startX: number = lyricEntry.GraphicalLabel.PositionAndShape.AbsolutePosition.x;
+                // + startStaffLine.PositionAndShape.AbsolutePosition.x; // doesn't work, done in drawer
             const endX: number = endStaffEntry.parentMeasure.PositionAndShape.RelativePosition.x +
                 endStaffEntry.PositionAndShape.RelativePosition.x +
-                endStaffEntry.PositionAndShape.BorderMarginRight;
+                endStaffEntry.PositionAndShape.BorderMarginRight +
+                // add width of following note
+                EngravingRules.Rules.NoteHeadWidth; // estimated. Bbox doesn't exist yet
+                // + endStaffLine.PositionAndShape.AbsolutePosition.x; // doesn't work, done in drawer
             // needed in order to line up with the Label's text bottom line (is the y position of the underscore)
             startY -= lyricEntry.GraphicalLabel.PositionAndShape.Size.height / 4;
             // create a Line (as underscore after the LyricLabel's End)

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1845,7 +1845,7 @@ export abstract class MusicSheetCalculator {
     private calculateLyricExtend(lyricEntry: GraphicalLyricEntry): void {
         let startY: number = lyricEntry.GraphicalLabel.PositionAndShape.RelativePosition.y;
         const startStaffEntry: GraphicalStaffEntry = lyricEntry.StaffEntryParent;
-        const startStaffLine: StaffLine = <StaffLine>lyricEntry.StaffEntryParent.parentMeasure.ParentStaffLine;
+        const startStaffLine: StaffLine = startStaffEntry.parentMeasure.ParentStaffLine;
 
         // find endstaffEntry and staffLine
         let endStaffEntry: GraphicalStaffEntry = undefined;

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -345,7 +345,7 @@ export abstract class MusicSheetDrawer {
 
         // draw lyric lines (e.g. LyricExtends: "dich,___")
         if (staffLine.LyricLines.length > 0) {
-            this.drawLyricLines(staffLine.LyricLines);
+            this.drawLyricLines(staffLine.LyricLines, staffLine);
         }
 
         if (this.skyLineVisible) {
@@ -357,8 +357,15 @@ export abstract class MusicSheetDrawer {
         }
     }
 
-    protected drawLyricLines(lyricLines: GraphicalLine[]): void {
-        lyricLines.forEach(lyricLine => this.drawGraphicalLine(lyricLine, EngravingRules.Rules.LyricUnderscoreLineWidthVexflow));
+    protected drawLyricLines(lyricLines: GraphicalLine[], staffLine: StaffLine): void {
+        staffLine.LyricLines.forEach(lyricLine => {
+            // TODO maybe we should put this in the calculation (MusicSheetCalculator.calculateLyricExtend)
+            lyricLine.Start.y += staffLine.PositionAndShape.AbsolutePosition.y;
+            lyricLine.End.y += staffLine.PositionAndShape.AbsolutePosition.y;
+            lyricLine.Start.x += staffLine.PositionAndShape.AbsolutePosition.x;
+            lyricLine.End.x += staffLine.PositionAndShape.AbsolutePosition.x;
+            this.drawGraphicalLine(lyricLine, EngravingRules.Rules.LyricUnderscoreLineWidthVexflow);
+        });
     }
 
     protected drawGraphicalLine(graphicalLine: GraphicalLine, lineWidth: number, colorOrStyle: string = "black"): void {

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -294,6 +294,16 @@ export abstract class MusicSheetDrawer {
         }
         for (const staffLine of musicSystem.StaffLines) {
             this.drawStaffLine(staffLine);
+
+            // draw lyric dashes
+            if (staffLine.LyricsDashes.length > 0) {
+                this.drawDashes(staffLine.LyricsDashes);
+            }
+
+            // draw lyric lines (e.g. LyricExtends: "dich,___")
+            if (staffLine.LyricLines.length > 0) {
+                this.drawLyricLines(staffLine.LyricLines, staffLine);
+            }
         }
         for (const systemLine of musicSystem.SystemLines) {
             this.drawSystemLineObject(systemLine);
@@ -339,15 +349,6 @@ export abstract class MusicSheetDrawer {
             this.drawMeasure(measure);
         }
 
-        if (staffLine.LyricsDashes.length > 0) {
-            this.drawDashes(staffLine.LyricsDashes);
-        }
-
-        // draw lyric lines (e.g. LyricExtends: "dich,___")
-        if (staffLine.LyricLines.length > 0) {
-            this.drawLyricLines(staffLine.LyricLines, staffLine);
-        }
-
         if (this.skyLineVisible) {
             this.drawSkyLine(staffLine);
         }
@@ -360,6 +361,8 @@ export abstract class MusicSheetDrawer {
     protected drawLyricLines(lyricLines: GraphicalLine[], staffLine: StaffLine): void {
         staffLine.LyricLines.forEach(lyricLine => {
             // TODO maybe we should put this in the calculation (MusicSheetCalculator.calculateLyricExtend)
+            // then we can also remove staffLine argument
+            // but same addition doesn't work in calculateLyricExtend
             lyricLine.Start.y += staffLine.PositionAndShape.AbsolutePosition.y;
             lyricLine.End.y += staffLine.PositionAndShape.AbsolutePosition.y;
             lyricLine.Start.x += staffLine.PositionAndShape.AbsolutePosition.x;

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -358,7 +358,20 @@ export abstract class MusicSheetDrawer {
     }
 
     protected drawLyricLines(lyricLines: GraphicalLine[]): void {
-        // throw new Error("not implemented");
+        lyricLines.forEach(lyricLine => this.drawGraphicalLine(lyricLine, EngravingRules.Rules.LyricUnderscoreLineWidthVexflow));
+    }
+
+    protected drawGraphicalLine(graphicalLine: GraphicalLine, lineWidth: number, colorOrStyle: string = "black"): void {
+        /* TODO
+        if (!this.isVisible(new BoundingBox(graphicalLine.Start,)) {
+            return;
+        }
+        */
+        this.drawLine(graphicalLine.Start, graphicalLine.End, colorOrStyle, lineWidth);
+    }
+
+    public drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number): void {
+        // implemented by subclass (VexFlowMusicSheetDrawer)
     }
 
     /**

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -362,7 +362,7 @@ export abstract class MusicSheetDrawer {
         staffLine.LyricLines.forEach(lyricLine => {
             // TODO maybe we should put this in the calculation (MusicSheetCalculator.calculateLyricExtend)
             // then we can also remove staffLine argument
-            // but same addition doesn't work in calculateLyricExtend
+            // but same addition doesn't work in calculateLyricExtend, because y-spacing happens after lyrics positioning
             lyricLine.Start.y += staffLine.PositionAndShape.AbsolutePosition.y;
             lyricLine.End.y += staffLine.PositionAndShape.AbsolutePosition.y;
             lyricLine.Start.x += staffLine.PositionAndShape.AbsolutePosition.x;
@@ -372,7 +372,7 @@ export abstract class MusicSheetDrawer {
     }
 
     protected drawGraphicalLine(graphicalLine: GraphicalLine, lineWidth: number, colorOrStyle: string = "black"): void {
-        /* TODO
+        /* TODO similar checks as in drawLabel
         if (!this.isVisible(new BoundingBox(graphicalLine.Start,)) {
             return;
         }

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -74,7 +74,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.canvasRenderingCtx.globalAlpha = 1;
     }
 
-    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF"): void {
+    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number= 2): void {
         const oldStyle: string | CanvasGradient | CanvasPattern = this.canvasRenderingCtx.strokeStyle;
         this.canvasRenderingCtx.strokeStyle = color;
         this.canvasRenderingCtx.beginPath();

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -67,14 +67,19 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.attributes["fill-opacity"] = 1;
     }
 
-    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF"): void {
+    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 2): void {
         this.ctx.save();
         this.ctx.beginPath();
         this.ctx.moveTo(start.x, start.y);
         this.ctx.lineTo(stop.x, stop.y);
+
         this.ctx.attributes.stroke = color;
-        this.ctx.lineWidth = 2;
-        this.ctx.attributes["stroke-linecap"] = "round";
+        //this.ctx.attributes.strokeStyle = color;
+        //this.ctx.attributes["font-weight"] = "bold";
+        //this.ctx.attributes["stroke-linecap"] = "round";
+
+        this.ctx.lineWidth = lineWidth;
+
         this.ctx.stroke();
         this.ctx.restore();
     }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -54,7 +54,7 @@ export abstract class VexFlowBackend {
    */
   public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number): void;
 
-  public abstract renderLine(start: PointF2D, stop: PointF2D, color: string): void;
+  public abstract renderLine(start: PointF2D, stop: PointF2D, color: string, lineWidth: number): void;
 
   public abstract getBackendType(): number;
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -302,7 +302,6 @@ export class VexFlowMeasure extends GraphicalMeasure {
         this.stave.setWidth(width * unitInPixels);
         // Force the width of the Begin Instructions
         //this.stave.setNoteStartX(this.beginInstructionsWidth * UnitInPixels);
-
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -153,6 +153,10 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         }
         // TODO choose biggest lyrics entry or handle each separately and take maximum elongation
         const lyricsEntry: GraphicalLyricEntry = staffEntry.LyricsEntries[0];
+        if (lyricsEntry.GetLyricsEntry.extend) {
+          // TODO handle extends
+          continue;
+        }
         let minLyricsSpacing: number = EngravingRules.Rules.HorizontalBetweenLyricsDistance;
 
         if (lyricsEntry.ParentLyricWord) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -160,6 +160,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
           continue;
         }
         // TODO handle each verse separately and take maximum spacing for elongation
+        // though this so far isn't needed for any piece and probably costs (some) performance
         const lyricsEntry: GraphicalLyricEntry = staffEntry.LyricsEntries[0]; // first verse, mostly sufficient
         if (lyricsEntry.GetLyricsEntry.extend) {
           // TODO handle extend, belongs to same lyrics entry as current word

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -159,8 +159,8 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         if (staffEntry.LyricsEntries.length === 0) {
           continue;
         }
-        // TODO choose biggest lyrics entry or handle each separately and take maximum elongation
-        const lyricsEntry: GraphicalLyricEntry = staffEntry.LyricsEntries[0];
+        // TODO handle each verse separately and take maximum spacing for elongation
+        const lyricsEntry: GraphicalLyricEntry = staffEntry.LyricsEntries[0]; // first verse, mostly sufficient
         if (lyricsEntry.GetLyricsEntry.extend) {
           // TODO handle extend, belongs to same lyrics entry as current word
           // lyricExtend = true;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -159,9 +159,10 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         }
         let minLyricsSpacing: number = EngravingRules.Rules.HorizontalBetweenLyricsDistance;
 
+        // spacing for multi-syllable words
         if (lyricsEntry.ParentLyricWord) {
-          if (lyricsEntry.GetLyricsEntry.SyllableIndex > 0) {
-            // give a little more spacing so that the dash between syllables fits
+          if (lyricsEntry.GetLyricsEntry.SyllableIndex > 0) { // syllables after first
+            // give a little more spacing for dash between syllables
             minLyricsSpacing = EngravingRules.Rules.BetweenSyllabelMinimumDistance;
           }
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -144,19 +144,28 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   public calculateMeasureWidthFromLyrics(measuresVertical: GraphicalMeasure[], oldMinimumStaffEntriesWidth: number): number {
     let lastLyricsLabelHalfWidth: number = 0; // TODO lyrics entries may not be ordered correctly, create a dictionary
     let lastStaffEntryXPosition: number = 0;
+    // let lastLyricsEntryText: string = ""; // for easier debug purposes
+    // let lyricsEntryText: string = ""; // for easier debug purposes
+    // let lyricExtend: boolean = false; // for easier debug purposes
     let elongationFactorMeasureWidth: number = 1;
     for (const measure of measuresVertical) {
-      for (let i: number = 0; i < measure.staffEntries.length; i++) {
-        const staffEntry: GraphicalStaffEntry = measure.staffEntries[i];
+      // sort staffEntries by position, so that we always compare neighboring staffEntries
+      const staffEntriesSorted: GraphicalStaffEntry[] = measure.staffEntries.sort(
+        (a: GraphicalStaffEntry, b: GraphicalStaffEntry) => {
+        return a.PositionAndShape.RelativePosition.x - b.PositionAndShape.RelativePosition.x;
+      });
+      for (let i: number = 0; i < staffEntriesSorted.length; i++) {
+        const staffEntry: GraphicalStaffEntry = staffEntriesSorted[i];
         if (staffEntry.LyricsEntries.length === 0) {
           continue;
         }
         // TODO choose biggest lyrics entry or handle each separately and take maximum elongation
         const lyricsEntry: GraphicalLyricEntry = staffEntry.LyricsEntries[0];
         if (lyricsEntry.GetLyricsEntry.extend) {
-          // TODO handle extends
-          continue;
+          // TODO handle extend, belongs to same lyrics entry as current word
+          // lyricExtend = true;
         }
+        // lyricsEntryText = lyricsEntry.GetLyricsEntry.Text;
         let minLyricsSpacing: number = EngravingRules.Rules.HorizontalBetweenLyricsDistance;
 
         // spacing for multi-syllable words
@@ -191,6 +200,8 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         // set up last measure information for next measure
         lastStaffEntryXPosition = staffEntryXPosition;
         lastLyricsLabelHalfWidth = lyricsLabelHalfWidth;
+        // lastLyricsEntryText = lyricsEntryText;
+        // lyricExtend = false; // reset for next measure
       }
     }
     return oldMinimumStaffEntriesWidth * elongationFactorMeasureWidth;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -90,10 +90,10 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     //     ctx.fillStyle = oldStyle;
     // }
 
-    public drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF"): void {
+    public drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 2): void {
         start = this.applyScreenTransformation(start);
         stop = this.applyScreenTransformation(stop);
-        this.backend.renderLine(start, stop, color);
+        this.backend.renderLine(start, stop, color, lineWidth);
     }
 
     protected drawSkyLine(staffline: StaffLine): void {

--- a/test/data/Schubert_An_die_Musik.xml
+++ b/test/data/Schubert_An_die_Musik.xml
@@ -5,8 +5,8 @@
     <rights>Franz Schubert: An die Musik
 (Mélisande on http://www.musescore.com)</rights>
     <encoding>
-      <software>MuseScore 2.3.1</software>
-      <encoding-date>2018-07-24</encoding-date>
+      <software>MuseScore 2.3.2</software>
+      <encoding-date>2018-08-13</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>
       <supports element="print" attribute="new-page" type="yes" value="yes"/>
@@ -40,13 +40,13 @@
     <lyric-font font-family="FreeSerif" font-size="11"/>
     </defaults>
   <credit page="1">
-    <credit-words default-x="595.238" default-y="1626.98" justify="center" valign="top" font-family="Times New Roman" font-size="24">An die Musik</credit-words>
+    <credit-words default-x="1133.79" default-y="1501.98" justify="right" valign="bottom" font-family="Times New Roman" font-size="12">Franz Schubert</credit-words>
     </credit>
   <credit page="1">
-    <credit-words default-x="1133.79" default-y="1526.98" justify="right" valign="bottom" font-family="Times New Roman" font-size="12">Franz Schubert</credit-words>
+    <credit-words default-x="595.24" default-y="1626.98" justify="center" valign="top" font-family="Times New Roman" font-size="24">An die Musik</credit-words>
     </credit>
   <credit page="1">
-    <credit-words default-x="595.238" default-y="113.379" justify="center" valign="bottom" font-size="8">Franz Schubert: An die Musik
+    <credit-words default-x="595.24" default-y="113.379" justify="center" valign="bottom" font-size="8">Franz Schubert: An die Musik
 (Mélisande on http://www.musescore.com)</credit-words>
     </credit>
   <part-list>
@@ -98,21 +98,21 @@
     <part-group type="stop" number="1"/>
     </part-list>
   <part id="P1">
-    <measure number="1" width="368.47">
+    <measure number="1" width="371.57">
       <print>
         <system-layout>
           <system-margins>
-            <left-margin>86.66</left-margin>
+            <left-margin>78.16</left-margin>
             <right-margin>0.00</right-margin>
             </system-margins>
-          <top-system-distance>160.00</top-system-distance>
+          <top-system-distance>195.00</top-system-distance>
           </system-layout>
         </print>
       <attributes>
         <divisions>2</divisions>
         <key>
           <fifths>2</fifths>
-	  <mode>major</mode>
+          <mode>major</mode>
           </key>
         <time symbol="cut">
           <beats>2</beats>
@@ -125,7 +125,7 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <words default-x="-35.74" default-y="40.00" relative-x="28.64" relative-y="-15.00" font-weight="bold" font-family="Times New Roman" font-size="12">Mäßig</words>
+          <words default-x="-35.74" default-y="40.00" font-weight="bold" font-family="Times New Roman" font-size="12">Mäßig</words>
           </direction-type>
         <sound tempo="112"/>
         </direction>
@@ -136,7 +136,7 @@
         <type>whole</type>
         </note>
       </measure>
-    <measure number="2" width="330.62">
+    <measure number="2" width="334.32">
       <note>
         <rest/>
         <duration>8</duration>
@@ -144,7 +144,7 @@
         <type>whole</type>
         </note>
       </measure>
-    <measure number="3" width="291.36">
+    <measure number="3" width="293.06">
       <barline location="left">
         <bar-style>heavy-light</bar-style>
         <repeat direction="forward"/>
@@ -155,7 +155,7 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="82.14" default-y="-25.00" dynamics="141.11">
+      <note default-x="82.57" default-y="-25.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -173,7 +173,7 @@
           <text font-family="Times New Roman">Oft</text>
           </lyric>
         </note>
-      <note default-x="151.35" default-y="-10.00" dynamics="141.11">
+      <note default-x="152.20" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -191,7 +191,7 @@
           <text font-family="Times New Roman">hat</text>
           </lyric>
         </note>
-      <note default-x="220.55" default-y="-10.00" dynamics="141.11">
+      <note default-x="221.83" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -210,17 +210,17 @@
           </lyric>
         </note>
       </measure>
-    <measure number="4" width="372.07">
+    <measure number="4" width="376.05">
       <print new-system="yes">
         <system-layout>
           <system-margins>
-            <left-margin>86.22</left-margin>
+            <left-margin>78.16</left-margin>
             <right-margin>0.00</right-margin>
             </system-margins>
           <system-distance>150.00</system-distance>
           </system-layout>
         </print>
-      <note default-x="96.20" default-y="-35.00">
+      <note default-x="97.60" default-y="-35.00">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -240,7 +240,7 @@
           <text font-family="Times New Roman">Seuf</text>
           </lyric>
         </note>
-      <note default-x="302.00" default-y="-20.00" dynamics="141.11">
+      <note default-x="305.33" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -259,8 +259,8 @@
           </lyric>
         </note>
       </measure>
-    <measure number="5" width="323.31">
-      <note default-x="8.80" default-y="-20.00">
+    <measure number="5" width="323.33">
+      <note default-x="7.75" default-y="-20.00">
         <grace/>
         <pitch>
           <step>B</step>
@@ -270,7 +270,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="28.74" default-y="-45.00">
+      <note default-x="26.19" default-y="-45.00">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -284,12 +284,12 @@
           <syllabic>single</syllabic>
           <text font-family="Times New Roman">wie</text>
           </lyric>
-        <lyric number="2" default-x="6.58" default-y="-106.00">
+        <lyric number="2" default-x="6.58" default-y="-106.00" relative-x="1.00">
           <syllabic>begin</syllabic>
           <text font-family="Times New Roman">dei</text>
           </lyric>
         </note>
-      <note default-x="134.48" default-y="-45.00" dynamics="141.11">
+      <note default-x="133.68" default-y="-45.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -307,7 +307,7 @@
           <text font-family="Times New Roman">ner</text>
           </lyric>
         </note>
-      <note default-x="169.73" default-y="-35.00" dynamics="141.11">
+      <note default-x="169.51" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -318,9 +318,9 @@
         <type>eighth</type>
         <stem>up</stem>
         <beam number="1">begin</beam>
-        <lyric number="1" default-x="17.54" default-y="-80.00">
+        <lyric number="1" default-x="17.11" default-y="-80.00">
           <syllabic>begin</syllabic>
-          <text font-family="Times New Roman">grau</text>
+          <text>grau</text>
           </lyric>
         <lyric number="2" default-x="20.12" default-y="-106.00">
           <syllabic>single</syllabic>
@@ -328,7 +328,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="215.97" default-y="-40.00" dynamics="141.11">
+      <note default-x="214.24" default-y="-40.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -339,7 +339,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="251.21" default-y="-45.00" dynamics="141.11">
+      <note default-x="250.07" default-y="-45.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -349,9 +349,9 @@
         <type>eighth</type>
         <stem>up</stem>
         <beam number="1">begin</beam>
-        <lyric number="1" default-x="8.38" default-y="-80.00">
-          <syllabic>end</syllabic>
-          <text font-family="Times New Roman">en</text>
+        <lyric number="1" default-x="8.26" default-y="-80.00">
+          <syllabic>single</syllabic>
+          <text>en</text>
           <extend/>
           </lyric>
         <lyric number="2" default-x="11.44" default-y="-106.00">
@@ -359,7 +359,7 @@
           <text font-family="Times New Roman">ent</text>
           </lyric>
         </note>
-      <note default-x="286.46" default-y="-40.00" dynamics="141.11">
+      <note default-x="285.90" default-y="-40.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -371,7 +371,7 @@
         <beam number="1">end</beam>
         </note>
       </measure>
-    <measure number="6" width="295.49">
+    <measure number="6" width="299.57">
       <note default-x="25.60" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
@@ -391,7 +391,7 @@
           <text font-family="Times New Roman">flo</text>
           </lyric>
         </note>
-      <note default-x="92.67" default-y="-45.00" dynamics="141.11">
+      <note default-x="93.69" default-y="-45.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -416,12 +416,12 @@
         <type>half</type>
         </note>
       </measure>
-    <measure number="7" width="349.82">
+    <measure number="7" width="353.44">
       <print new-system="yes">
         <system-layout>
           <system-margins>
-            <left-margin>86.22</left-margin>
-            <right-margin>0.00</right-margin>
+            <left-margin>78.16</left-margin>
+            <right-margin>-0.00</right-margin>
             </system-margins>
           <system-distance>150.00</system-distance>
           </system-layout>
@@ -432,7 +432,7 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="144.66" default-y="-25.00" dynamics="141.11">
+      <note default-x="146.61" default-y="-25.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -450,7 +450,7 @@
           <text font-family="Times New Roman">ein</text>
           </lyric>
         </note>
-      <note default-x="212.51" default-y="-20.00" dynamics="141.11">
+      <note default-x="215.02" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -468,7 +468,7 @@
           <text font-family="Times New Roman">sü</text>
           </lyric>
         </note>
-      <note default-x="280.36" default-y="-20.00" dynamics="141.11">
+      <note default-x="283.43" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -487,7 +487,7 @@
           </lyric>
         </note>
       </measure>
-    <measure number="8" width="295.18">
+    <measure number="8" width="297.40">
       <note default-x="18.86" default-y="-50.00">
         <pitch>
           <step>C</step>
@@ -508,7 +508,7 @@
           <text font-family="Times New Roman">hei</text>
           </lyric>
         </note>
-      <note default-x="120.21" default-y="-50.00" dynamics="141.11">
+      <note default-x="121.81" default-y="-50.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -527,7 +527,7 @@
           <text font-family="Times New Roman">li</text>
           </lyric>
         </note>
-      <note default-x="158.43" default-y="-45.00">
+      <note default-x="158.53" default-y="-45.00">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -546,7 +546,7 @@
           <text font-family="Times New Roman">ger</text>
           </lyric>
         </note>
-      <note default-x="259.79" default-y="-45.00" dynamics="141.11">
+      <note default-x="261.48" default-y="-45.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -565,7 +565,7 @@
           </lyric>
         </note>
       </measure>
-    <measure number="9" width="345.88">
+    <measure number="9" width="348.10">
       <note default-x="14.00" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
@@ -588,7 +588,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="63.64" default-y="-40.00" dynamics="141.11">
+      <note default-x="62.14" default-y="-40.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -599,7 +599,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="103.73" default-y="-45.00" dynamics="141.11">
+      <note default-x="102.76" default-y="-45.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -619,7 +619,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="143.82" default-y="-40.00" dynamics="141.11">
+      <note default-x="143.38" default-y="-40.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -630,7 +630,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="183.55" default-y="-35.00" dynamics="141.11">
+      <note default-x="183.65" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -650,14 +650,14 @@
           </lyric>
         </note>
       </measure>
-    <measure number="10" width="364.42">
+    <measure number="10" width="367.04">
       <print new-page="yes">
         <system-layout>
           <system-margins>
-            <left-margin>86.22</left-margin>
+            <left-margin>78.16</left-margin>
             <right-margin>0.00</right-margin>
             </system-margins>
-          <top-system-distance>50.00</top-system-distance>
+          <top-system-distance>70.00</top-system-distance>
           </system-layout>
         </print>
       <note>
@@ -667,14 +667,14 @@
         <type>whole</type>
         </note>
       </measure>
-    <measure number="11" width="312.51">
+    <measure number="11" width="315.23">
       <note>
         <rest/>
         <duration>2</duration>
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="87.05" default-y="-10.00" dynamics="141.11">
+      <note default-x="87.83" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -692,7 +692,7 @@
           <text font-family="Times New Roman">den</text>
           </lyric>
         </note>
-      <note default-x="161.16" default-y="-5.00">
+      <note default-x="162.72" default-y="-5.00">
         <pitch>
           <step>E</step>
           <octave>5</octave>
@@ -711,7 +711,7 @@
           <text font-family="Times New Roman">Him</text>
           </lyric>
         </note>
-      <note default-x="272.33" default-y="-30.00" dynamics="141.11">
+      <note default-x="275.05" default-y="-30.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -730,7 +730,7 @@
           </lyric>
         </note>
       </measure>
-    <measure number="12" width="313.95">
+    <measure number="12" width="316.67">
       <note default-x="14.00" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
@@ -754,7 +754,7 @@
           <text font-family="Times New Roman">bess'</text>
           </lyric>
         </note>
-      <note default-x="88.23" default-y="-25.00" dynamics="141.11">
+      <note default-x="88.91" default-y="-25.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -767,7 +767,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="237.76" default-y="-20.00" dynamics="141.11">
+      <note default-x="239.80" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -788,7 +788,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="275.05" default-y="-15.00" dynamics="141.11">
+      <note default-x="277.44" default-y="-15.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -801,17 +801,17 @@
         <beam number="1">end</beam>
         </note>
       </measure>
-    <measure number="13" width="374.36">
+    <measure number="13" width="377.84">
       <print new-system="yes">
         <system-layout>
           <system-margins>
-            <left-margin>86.22</left-margin>
+            <left-margin>78.16</left-margin>
             <right-margin>0.00</right-margin>
             </system-margins>
-          <system-distance>141.87</system-distance>
+          <system-distance>150.00</system-distance>
           </system-layout>
         </print>
-      <note default-x="85.76" default-y="-10.00">
+      <note default-x="87.16" default-y="-10.00">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -830,7 +830,7 @@
           <text font-family="Times New Roman">Zei</text>
           </lyric>
         </note>
-      <note default-x="190.73" default-y="0.00" dynamics="141.11">
+      <note default-x="191.80" default-y="0.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -849,7 +849,7 @@
           <text font-family="Times New Roman">ten</text>
           </lyric>
         </note>
-      <note default-x="232.77" default-y="-5.00" dynamics="141.11">
+      <note default-x="226.67" default-y="-5.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>5</octave>
@@ -859,9 +859,10 @@
         <type>eighth</type>
         <stem>down</stem>
         <beam number="1">begin</beam>
-        <lyric number="1" default-x="7.78" default-y="-80.00">
+        <lyric number="1" default-x="20.14" default-y="-80.00">
           <syllabic>single</syllabic>
           <text font-family="Times New Roman">Lieb'</text>
+          <extend/>
           </lyric>
         <lyric number="2" default-x="13.28" default-y="-106.00">
           <syllabic>single</syllabic>
@@ -869,7 +870,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="267.76" default-y="-15.00" dynamics="141.11">
+      <note default-x="271.45" default-y="-15.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -881,7 +882,7 @@
         <stem>down</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="302.74" default-y="-25.00" dynamics="141.11">
+      <note default-x="306.33" default-y="-25.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -900,7 +901,7 @@
           <text font-family="Times New Roman">er</text>
           </lyric>
         </note>
-      <note default-x="337.73" default-y="-30.00" dynamics="141.11">
+      <note default-x="341.21" default-y="-30.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -912,8 +913,8 @@
         <beam number="1">end</beam>
         </note>
       </measure>
-    <measure number="14" width="323.63">
-      <note default-x="8.80" default-y="-30.00">
+    <measure number="14" width="324.65">
+      <note default-x="7.75" default-y="-30.00">
         <grace/>
         <pitch>
           <step>G</step>
@@ -923,7 +924,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="28.74" default-y="-35.00" dynamics="141.11">
+      <note default-x="26.19" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -942,7 +943,7 @@
           <text font-family="Times New Roman">schlo</text>
           </lyric>
         </note>
-      <note default-x="101.96" default-y="-35.00" dynamics="141.11">
+      <note default-x="100.41" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -967,7 +968,7 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="248.39" default-y="-25.00" dynamics="141.11">
+      <note default-x="248.84" default-y="-25.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -986,7 +987,7 @@
           </lyric>
         </note>
       </measure>
-    <measure number="15" width="292.88">
+    <measure number="15" width="296.45">
       <note default-x="27.42" default-y="-20.00">
         <pitch>
           <step>B</step>
@@ -1006,7 +1007,7 @@
           <text font-family="Times New Roman">hol</text>
           </lyric>
         </note>
-      <note default-x="123.08" default-y="-20.00" dynamics="141.11">
+      <note default-x="125.25" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -1024,7 +1025,7 @@
           <text font-family="Times New Roman">de</text>
           </lyric>
         </note>
-      <note default-x="163.73" default-y="-20.00" dynamics="141.11">
+      <note default-x="164.41" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -1042,7 +1043,7 @@
           <text font-family="Times New Roman">Kunst</text>
           </lyric>
         </note>
-      <note default-x="227.51" default-y="-15.00" dynamics="141.11">
+      <note default-x="229.63" default-y="-15.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -1064,7 +1065,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="259.39" default-y="-10.00" dynamics="141.11">
+      <note default-x="262.24" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -1076,17 +1077,17 @@
         <beam number="1">end</beam>
         </note>
       </measure>
-    <measure number="16" width="298.00">
+    <measure number="16" width="365.96">
       <print new-system="yes">
         <system-layout>
           <system-margins>
-            <left-margin>86.22</left-margin>
+            <left-margin>78.16</left-margin>
             <right-margin>0.00</right-margin>
             </system-margins>
-          <system-distance>141.87</system-distance>
+          <system-distance>150.00</system-distance>
           </system-layout>
         </print>
-      <note default-x="89.00" default-y="-10.00">
+      <note default-x="90.40" default-y="-10.00">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -1105,7 +1106,7 @@
           <text font-family="Times New Roman">dan</text>
           </lyric>
         </note>
-      <note default-x="148.57" default-y="-10.00" dynamics="141.11">
+      <note default-x="192.80" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -1123,7 +1124,7 @@
           <text font-family="Times New Roman">ke</text>
           </lyric>
         </note>
-      <note default-x="183.45" default-y="0.00">
+      <note default-x="226.93" default-y="0.00">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -1143,7 +1144,7 @@
           <text font-family="Times New Roman">dir</text>
           </lyric>
         </note>
-      <note default-x="261.37" default-y="-5.00" dynamics="141.11">
+      <note default-x="329.32" default-y="-5.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>5</octave>
@@ -1162,8 +1163,8 @@
           </lyric>
         </note>
       </measure>
-    <measure number="17" width="223.18">
-      <note default-x="8.44" default-y="-5.00">
+    <measure number="17" width="290.96">
+      <note default-x="7.39" default-y="-5.00">
         <grace/>
         <pitch>
           <step>E</step>
@@ -1173,7 +1174,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="28.38" default-y="-10.00">
+      <note default-x="25.83" default-y="-10.00">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -1197,7 +1198,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="137.13" default-y="-20.00" dynamics="141.11">
+      <note default-x="190.67" default-y="-20.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -1206,6 +1207,7 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
+        <beam number="1">begin</beam>
         <lyric number="1" default-x="6.58" default-y="-80.00">
           <syllabic>single</syllabic>
           <text font-family="Times New Roman">in</text>
@@ -1215,7 +1217,7 @@
           <text font-family="Times New Roman">du</text>
           </lyric>
         </note>
-      <note default-x="166.18" default-y="-15.00" dynamics="141.11">
+      <note default-x="223.57" default-y="-15.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -1225,6 +1227,7 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
+        <beam number="1">continue</beam>
         <lyric number="1" default-x="6.58" default-y="-80.00">
           <syllabic>begin</syllabic>
           <text font-family="Times New Roman">ei</text>
@@ -1234,7 +1237,7 @@
           <text font-family="Times New Roman">hol</text>
           </lyric>
         </note>
-      <note default-x="194.62" default-y="-10.00" dynamics="141.11">
+      <note default-x="256.47" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>5</octave>
@@ -1243,6 +1246,7 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
+        <beam number="1">end</beam>
         <lyric number="1" default-x="6.58" default-y="-80.00">
           <syllabic>end</syllabic>
           <text font-family="Times New Roman">ne</text>
@@ -1253,7 +1257,7 @@
           </lyric>
         </note>
       </measure>
-    <measure number="18" width="280.67">
+    <measure number="18" width="342.02">
       <note default-x="14.00" default-y="-10.00" dynamics="141.11">
         <pitch>
           <step>D</step>
@@ -1276,7 +1280,7 @@
           <extend/>
           </lyric>
         </note>
-      <note default-x="75.26" default-y="-35.00" dynamics="141.11">
+      <note default-x="95.61" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -1286,11 +1290,12 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
+        <beam number="1">begin</beam>
         <notations>
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="108.89" default-y="-35.00" dynamics="141.11">
+      <note default-x="136.41" default-y="-35.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -1300,6 +1305,7 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
+        <beam number="1">end</beam>
         <lyric number="1" default-x="6.58" default-y="-80.00">
           <syllabic>end</syllabic>
           <text font-family="Times New Roman">re</text>
@@ -1309,7 +1315,7 @@
           <text font-family="Times New Roman">ich</text>
           </lyric>
         </note>
-      <note default-x="139.44" default-y="-25.00" dynamics="141.11">
+      <note default-x="177.21" default-y="-25.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -1330,7 +1336,7 @@
           <text font-family="Times New Roman">dan</text>
           </lyric>
         </note>
-      <note default-x="207.01" default-y="-50.00" dynamics="141.11">
+      <note default-x="258.82" default-y="-50.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -1340,11 +1346,12 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
+        <beam number="1">begin</beam>
         <notations>
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="244.04" default-y="-50.00" dynamics="141.11">
+      <note default-x="299.62" default-y="-50.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -1354,6 +1361,7 @@
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
+        <beam number="1">end</beam>
         <lyric number="1" default-x="6.58" default-y="-80.00">
           <syllabic>middle</syllabic>
           <text font-family="Times New Roman">ent</text>
@@ -1364,8 +1372,17 @@
           </lyric>
         </note>
       </measure>
-    <measure number="19" width="189.02">
-      <note default-x="28.65" default-y="-45.00" dynamics="141.11">
+    <measure number="19" width="998.94">
+      <print new-page="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>78.16</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>70.00</top-system-distance>
+          </system-layout>
+        </print>
+      <note default-x="93.92" default-y="-45.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -1390,42 +1407,50 @@
         <type>half</type>
         </note>
       </measure>
-    <measure number="20" width="256.63">
+    <measure number="20" width="255.67">
       <print new-system="yes">
         <system-layout>
           <system-margins>
-            <left-margin>86.22</left-margin>
-            <right-margin>0.00</right-margin>
+            <left-margin>78.16</left-margin>
+            <right-margin>-0.00</right-margin>
             </system-margins>
-          <system-distance>141.87</system-distance>
+          <system-distance>150.00</system-distance>
           </system-layout>
         </print>
-      <forward>
+      <note print-object="no">
+        <rest/>
         <duration>8</duration>
-        </forward>
+        <voice>1</voice>
+        </note>
       </measure>
-    <measure number="21" width="242.40">
-      <forward>
+    <measure number="21" width="240.04">
+      <note print-object="no">
+        <rest/>
         <duration>8</duration>
-        </forward>
+        <voice>1</voice>
+        </note>
       </measure>
-    <measure number="22" width="293.53">
-      <forward>
+    <measure number="22" width="293.17">
+      <note print-object="no">
+        <rest/>
         <duration>8</duration>
-        </forward>
+        <voice>1</voice>
+        </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         <repeat direction="backward"/>
         </barline>
       </measure>
-    <measure number="23" width="198.31">
-      <forward>
+    <measure number="23" width="210.07">
+      <note print-object="no">
+        <rest/>
         <duration>8</duration>
-        </forward>
+        <voice>1</voice>
+        </note>
       </measure>
     </part>
   <part id="P2">
-    <measure number="1" width="368.47">
+    <measure number="1" width="371.57">
       <print>
         <staff-layout number="1">
           <staff-distance>106.00</staff-distance>
@@ -1435,7 +1460,7 @@
         <divisions>2</divisions>
         <key>
           <fifths>2</fifths>
-	  <mode>major</mode>
+          <mode>major</mode>
           </key>
         <time symbol="cut">
           <beats>2</beats>
@@ -1446,7 +1471,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <note default-x="99.11" default-y="-206.00" dynamics="141.11">
+      <note default-x="100.51" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1457,7 +1482,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="99.11" default-y="-191.00" dynamics="141.11">
+      <note default-x="100.51" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1468,7 +1493,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="99.11" default-y="-181.00" dynamics="141.11">
+      <note default-x="100.51" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1480,7 +1505,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="132.58" default-y="-206.00" dynamics="141.11">
+      <note default-x="134.19" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1491,7 +1516,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="132.58" default-y="-191.00" dynamics="141.11">
+      <note default-x="134.19" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1502,7 +1527,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="132.58" default-y="-181.00" dynamics="141.11">
+      <note default-x="134.19" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1514,7 +1539,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="166.05" default-y="-206.00" dynamics="141.11">
+      <note default-x="167.88" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1525,7 +1550,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="166.05" default-y="-191.00" dynamics="141.11">
+      <note default-x="167.88" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1536,7 +1561,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="166.05" default-y="-181.00" dynamics="141.11">
+      <note default-x="167.88" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1548,7 +1573,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="199.52" default-y="-206.00" dynamics="141.11">
+      <note default-x="201.56" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1559,7 +1584,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="199.52" default-y="-191.00" dynamics="141.11">
+      <note default-x="201.56" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1570,7 +1595,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="199.52" default-y="-181.00" dynamics="141.11">
+      <note default-x="201.56" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1582,7 +1607,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="232.99" default-y="-206.00" dynamics="141.11">
+      <note default-x="235.24" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1593,7 +1618,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="232.99" default-y="-191.00" dynamics="141.11">
+      <note default-x="235.24" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1604,7 +1629,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="232.99" default-y="-181.00" dynamics="141.11">
+      <note default-x="235.24" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1616,7 +1641,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="266.46" default-y="-206.00" dynamics="141.11">
+      <note default-x="268.92" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1627,7 +1652,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="266.46" default-y="-191.00" dynamics="141.11">
+      <note default-x="268.92" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1638,7 +1663,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="266.46" default-y="-181.00" dynamics="141.11">
+      <note default-x="268.92" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1650,7 +1675,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="299.93" default-y="-206.00" dynamics="141.11">
+      <note default-x="302.60" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1661,7 +1686,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="299.93" default-y="-191.00" dynamics="141.11">
+      <note default-x="302.60" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1672,7 +1697,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="299.93" default-y="-181.00" dynamics="141.11">
+      <note default-x="302.60" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1684,7 +1709,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="333.40" default-y="-206.00" dynamics="141.11">
+      <note default-x="336.29" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1695,7 +1720,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="333.40" default-y="-191.00" dynamics="141.11">
+      <note default-x="336.29" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1706,7 +1731,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="333.40" default-y="-181.00" dynamics="141.11">
+      <note default-x="336.29" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -1719,7 +1744,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="2" width="330.62">
+    <measure number="2" width="334.32">
       <note default-x="12.36" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
@@ -1753,7 +1778,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="50.00" default-y="-206.00" dynamics="141.11">
+      <note default-x="50.21" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1764,7 +1789,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="50.00" default-y="-191.00" dynamics="141.11">
+      <note default-x="50.21" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1775,7 +1800,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="50.00" default-y="-171.00" dynamics="141.11">
+      <note default-x="50.21" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -1786,7 +1811,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="87.64" default-y="-206.00" dynamics="141.11">
+      <note default-x="88.07" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1797,7 +1822,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="87.64" default-y="-191.00" dynamics="141.11">
+      <note default-x="88.07" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1808,7 +1833,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="87.64" default-y="-171.00" dynamics="141.11">
+      <note default-x="88.07" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -1819,7 +1844,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="125.28" default-y="-206.00" dynamics="141.11">
+      <note default-x="125.92" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1830,7 +1855,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="125.28" default-y="-191.00" dynamics="141.11">
+      <note default-x="125.92" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -1841,7 +1866,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="125.28" default-y="-171.00" dynamics="141.11">
+      <note default-x="125.92" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -1852,7 +1877,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="162.92" default-y="-206.00" dynamics="141.11">
+      <note default-x="163.77" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1863,7 +1888,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="162.92" default-y="-196.00" dynamics="141.11">
+      <note default-x="163.77" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -1875,7 +1900,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="162.92" default-y="-176.00" dynamics="141.11">
+      <note default-x="163.77" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -1886,7 +1911,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="200.56" default-y="-206.00" dynamics="141.11">
+      <note default-x="201.63" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -1897,7 +1922,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="200.56" default-y="-196.00" dynamics="141.11">
+      <note default-x="201.63" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -1909,7 +1934,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="200.56" default-y="-176.00" dynamics="141.11">
+      <note default-x="201.63" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -1920,7 +1945,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="238.21" default-y="-211.00" dynamics="141.11">
+      <note default-x="239.48" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -1931,7 +1956,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="250.07" default-y="-206.00" dynamics="141.11">
+      <note default-x="251.35" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -1942,7 +1967,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="238.21" default-y="-196.00" dynamics="141.11">
+      <note default-x="239.48" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -1954,7 +1979,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="238.21" default-y="-186.00" dynamics="141.11">
+      <note default-x="239.48" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -1965,7 +1990,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="275.85" default-y="-211.00" dynamics="141.11">
+      <note default-x="277.33" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -1976,7 +2001,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="287.71" default-y="-206.00" dynamics="141.11">
+      <note default-x="289.20" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -1987,7 +2012,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="275.85" default-y="-196.00" dynamics="141.11">
+      <note default-x="277.33" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -1999,7 +2024,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="275.85" default-y="-186.00" dynamics="141.11">
+      <note default-x="277.33" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -2011,7 +2036,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="3" width="291.36">
+    <measure number="3" width="293.06">
       <barline location="left">
         <bar-style>heavy-light</bar-style>
         <repeat direction="forward"/>
@@ -2050,7 +2075,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="47.54" default-y="-206.00" dynamics="141.11">
+      <note default-x="47.75" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2061,7 +2086,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="47.54" default-y="-191.00" dynamics="141.11">
+      <note default-x="47.75" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2072,7 +2097,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="47.54" default-y="-181.00" dynamics="141.11">
+      <note default-x="47.75" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2084,7 +2109,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="82.14" default-y="-206.00" dynamics="141.11">
+      <note default-x="82.57" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2095,7 +2120,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="82.14" default-y="-191.00" dynamics="141.11">
+      <note default-x="82.57" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2106,7 +2131,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="82.14" default-y="-181.00" dynamics="141.11">
+      <note default-x="82.57" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2118,7 +2143,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="116.74" default-y="-206.00" dynamics="141.11">
+      <note default-x="117.38" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2129,7 +2154,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="116.74" default-y="-191.00" dynamics="141.11">
+      <note default-x="117.38" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2140,7 +2165,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="116.74" default-y="-181.00" dynamics="141.11">
+      <note default-x="117.38" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2152,7 +2177,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="151.35" default-y="-206.00" dynamics="141.11">
+      <note default-x="152.20" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2163,7 +2188,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="151.35" default-y="-191.00" dynamics="141.11">
+      <note default-x="152.20" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2174,7 +2199,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="151.35" default-y="-181.00" dynamics="141.11">
+      <note default-x="152.20" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2186,7 +2211,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="185.95" default-y="-206.00" dynamics="141.11">
+      <note default-x="187.01" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2197,7 +2222,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="185.95" default-y="-191.00" dynamics="141.11">
+      <note default-x="187.01" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2208,7 +2233,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="185.95" default-y="-181.00" dynamics="141.11">
+      <note default-x="187.01" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2220,7 +2245,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="220.55" default-y="-206.00" dynamics="141.11">
+      <note default-x="221.83" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2231,7 +2256,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="220.55" default-y="-191.00" dynamics="141.11">
+      <note default-x="221.83" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2242,7 +2267,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="220.55" default-y="-181.00" dynamics="141.11">
+      <note default-x="221.83" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2254,7 +2279,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="255.15" default-y="-206.00" dynamics="141.11">
+      <note default-x="256.64" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2265,7 +2290,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="255.15" default-y="-191.00" dynamics="141.11">
+      <note default-x="256.64" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2276,7 +2301,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="255.15" default-y="-181.00" dynamics="141.11">
+      <note default-x="256.64" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2289,13 +2314,13 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="4" width="372.07">
+    <measure number="4" width="376.05">
       <print new-system="yes">
         <staff-layout number="1">
           <staff-distance>106.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="96.56" default-y="-206.00" dynamics="141.11">
+      <note default-x="97.96" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2306,7 +2331,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="96.56" default-y="-191.00" dynamics="141.11">
+      <note default-x="97.96" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2317,7 +2342,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="96.56" default-y="-181.00" dynamics="141.11">
+      <note default-x="97.96" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2329,7 +2354,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="130.80" default-y="-206.00" dynamics="141.11">
+      <note default-x="132.52" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2340,7 +2365,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="130.80" default-y="-191.00" dynamics="141.11">
+      <note default-x="132.52" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2351,7 +2376,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="130.80" default-y="-181.00" dynamics="141.11">
+      <note default-x="132.52" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2363,7 +2388,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="165.04" default-y="-206.00" dynamics="141.11">
+      <note default-x="167.09" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2374,7 +2399,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="165.04" default-y="-191.00" dynamics="141.11">
+      <note default-x="167.09" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2385,7 +2410,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="165.04" default-y="-181.00" dynamics="141.11">
+      <note default-x="167.09" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2397,7 +2422,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="199.28" default-y="-206.00" dynamics="141.11">
+      <note default-x="201.65" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2408,7 +2433,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="199.28" default-y="-191.00" dynamics="141.11">
+      <note default-x="201.65" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2419,7 +2444,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="199.28" default-y="-181.00" dynamics="141.11">
+      <note default-x="201.65" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2431,7 +2456,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="233.52" default-y="-216.00" dynamics="141.11">
+      <note default-x="236.21" default-y="-216.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -2443,7 +2468,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="233.52" default-y="-191.00" dynamics="141.11">
+      <note default-x="236.21" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2454,7 +2479,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="233.52" default-y="-181.00" dynamics="141.11">
+      <note default-x="236.21" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2466,7 +2491,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="267.76" default-y="-216.00" dynamics="141.11">
+      <note default-x="270.77" default-y="-216.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -2478,7 +2503,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="267.76" default-y="-181.00" dynamics="141.11">
+      <note default-x="270.77" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2490,7 +2515,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="302.00" default-y="-201.00" dynamics="141.11">
+      <note default-x="305.33" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -2501,7 +2526,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="302.00" default-y="-191.00" dynamics="141.11">
+      <note default-x="305.33" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2512,7 +2537,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="302.00" default-y="-181.00" dynamics="141.11">
+      <note default-x="305.33" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2524,7 +2549,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="336.24" default-y="-201.00" dynamics="141.11">
+      <note default-x="339.89" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -2535,7 +2560,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="336.24" default-y="-191.00" dynamics="141.11">
+      <note default-x="339.89" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2546,7 +2571,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="336.24" default-y="-181.00" dynamics="141.11">
+      <note default-x="339.89" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2559,14 +2584,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="5" width="323.31">
+    <measure number="5" width="323.33">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="63.99" default-y="-206.00" dynamics="141.11">
+      <note default-x="62.02" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2577,7 +2602,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="63.99" default-y="-191.00" dynamics="141.11">
+      <note default-x="62.02" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2588,7 +2613,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="63.99" default-y="-181.00" dynamics="141.11">
+      <note default-x="62.02" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2600,7 +2625,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="99.24" default-y="-206.00" dynamics="141.11">
+      <note default-x="97.85" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2611,7 +2636,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="99.24" default-y="-191.00" dynamics="141.11">
+      <note default-x="97.85" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2622,7 +2647,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="99.24" default-y="-181.00" dynamics="141.11">
+      <note default-x="97.85" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2634,7 +2659,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="134.48" default-y="-206.00" dynamics="141.11">
+      <note default-x="133.68" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2645,7 +2670,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="134.48" default-y="-191.00" dynamics="141.11">
+      <note default-x="133.68" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2656,7 +2681,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="134.48" default-y="-181.00" dynamics="141.11">
+      <note default-x="133.68" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2674,7 +2699,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="215.97" default-y="-206.00" dynamics="141.11">
+      <note default-x="214.24" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2685,7 +2710,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="215.97" default-y="-196.00" dynamics="141.11">
+      <note default-x="214.24" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -2697,7 +2722,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="215.97" default-y="-176.00" dynamics="141.11">
+      <note default-x="214.24" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -2708,7 +2733,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="251.21" default-y="-206.00" dynamics="141.11">
+      <note default-x="250.07" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2719,7 +2744,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="251.21" default-y="-196.00" dynamics="141.11">
+      <note default-x="250.07" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -2731,7 +2756,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="251.21" default-y="-176.00" dynamics="141.11">
+      <note default-x="250.07" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -2742,7 +2767,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="286.46" default-y="-206.00" dynamics="141.11">
+      <note default-x="285.90" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2753,7 +2778,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="286.46" default-y="-196.00" dynamics="141.11">
+      <note default-x="285.90" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -2765,7 +2790,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="286.46" default-y="-176.00" dynamics="141.11">
+      <note default-x="285.90" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -2777,14 +2802,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="6" width="295.49">
+    <measure number="6" width="299.57">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="59.13" default-y="-206.00" dynamics="141.11">
+      <note default-x="59.64" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2795,7 +2820,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="59.13" default-y="-191.00" dynamics="141.11">
+      <note default-x="59.64" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2806,7 +2831,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="59.13" default-y="-181.00" dynamics="141.11">
+      <note default-x="59.64" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2818,7 +2843,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="92.67" default-y="-206.00" dynamics="141.11">
+      <note default-x="93.69" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2829,7 +2854,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="92.67" default-y="-191.00" dynamics="141.11">
+      <note default-x="93.69" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2840,7 +2865,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="92.67" default-y="-181.00" dynamics="141.11">
+      <note default-x="93.69" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2852,7 +2877,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="126.21" default-y="-206.00" dynamics="141.11">
+      <note default-x="127.73" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2863,7 +2888,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="126.21" default-y="-191.00" dynamics="141.11">
+      <note default-x="127.73" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2874,7 +2899,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="126.21" default-y="-181.00" dynamics="141.11">
+      <note default-x="127.73" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2886,7 +2911,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="159.74" default-y="-206.00" dynamics="141.11">
+      <note default-x="161.78" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2897,7 +2922,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="159.74" default-y="-191.00" dynamics="141.11">
+      <note default-x="161.78" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2908,7 +2933,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="159.74" default-y="-181.00" dynamics="141.11">
+      <note default-x="161.78" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2920,7 +2945,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="193.28" default-y="-206.00" dynamics="141.11">
+      <note default-x="195.83" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2931,7 +2956,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="193.28" default-y="-191.00" dynamics="141.11">
+      <note default-x="195.83" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2942,7 +2967,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="193.28" default-y="-181.00" dynamics="141.11">
+      <note default-x="195.83" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2954,7 +2979,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="226.82" default-y="-206.00" dynamics="141.11">
+      <note default-x="229.87" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2965,7 +2990,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="226.82" default-y="-191.00" dynamics="141.11">
+      <note default-x="229.87" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -2976,7 +3001,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="226.82" default-y="-181.00" dynamics="141.11">
+      <note default-x="229.87" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -2988,7 +3013,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="260.36" default-y="-206.00" dynamics="141.11">
+      <note default-x="263.92" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -2999,7 +3024,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="260.36" default-y="-191.00" dynamics="141.11">
+      <note default-x="263.92" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3010,7 +3035,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="260.36" default-y="-181.00" dynamics="141.11">
+      <note default-x="263.92" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3023,13 +3048,13 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="7" width="349.82">
+    <measure number="7" width="353.44">
       <print new-system="yes">
         <staff-layout number="1">
           <staff-distance>106.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="76.81" default-y="-206.00" dynamics="141.11">
+      <note default-x="78.21" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3040,7 +3065,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="76.81" default-y="-191.00" dynamics="141.11">
+      <note default-x="78.21" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3051,7 +3076,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="76.81" default-y="-171.00" dynamics="141.11">
+      <note default-x="78.21" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3062,7 +3087,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="110.73" default-y="-206.00" dynamics="141.11">
+      <note default-x="112.41" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3073,7 +3098,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="110.73" default-y="-191.00" dynamics="141.11">
+      <note default-x="112.41" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3084,7 +3109,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="110.73" default-y="-171.00" dynamics="141.11">
+      <note default-x="112.41" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3095,7 +3120,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="144.66" default-y="-206.00" dynamics="141.11">
+      <note default-x="146.61" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3106,7 +3131,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="144.66" default-y="-191.00" dynamics="141.11">
+      <note default-x="146.61" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3117,7 +3142,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="144.66" default-y="-171.00" dynamics="141.11">
+      <note default-x="146.61" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3128,7 +3153,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="178.58" default-y="-206.00" dynamics="141.11">
+      <note default-x="180.82" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3139,7 +3164,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="178.58" default-y="-191.00" dynamics="141.11">
+      <note default-x="180.82" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3150,7 +3175,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="178.58" default-y="-171.00" dynamics="141.11">
+      <note default-x="180.82" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3161,7 +3186,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="212.51" default-y="-201.00" dynamics="141.11">
+      <note default-x="215.02" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -3172,7 +3197,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="212.51" default-y="-191.00" dynamics="141.11">
+      <note default-x="215.02" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3183,7 +3208,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="212.51" default-y="-166.00" dynamics="141.11">
+      <note default-x="215.02" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -3194,7 +3219,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="246.44" default-y="-201.00" dynamics="141.11">
+      <note default-x="249.23" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -3205,7 +3230,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="246.44" default-y="-191.00" dynamics="141.11">
+      <note default-x="249.23" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3216,7 +3241,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="246.44" default-y="-166.00" dynamics="141.11">
+      <note default-x="249.23" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -3227,7 +3252,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="280.36" default-y="-201.00" dynamics="141.11">
+      <note default-x="283.43" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -3238,7 +3263,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="280.36" default-y="-191.00" dynamics="141.11">
+      <note default-x="283.43" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3249,7 +3274,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="280.36" default-y="-166.00" dynamics="141.11">
+      <note default-x="283.43" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -3260,7 +3285,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="314.29" default-y="-201.00" dynamics="141.11">
+      <note default-x="317.64" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -3271,7 +3296,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="314.29" default-y="-191.00" dynamics="141.11">
+      <note default-x="317.64" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3282,7 +3307,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="314.29" default-y="-166.00" dynamics="141.11">
+      <note default-x="317.64" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -3294,14 +3319,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="8" width="295.18">
+    <measure number="8" width="297.40">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="52.64" default-y="-221.00" dynamics="141.11">
+      <note default-x="53.17" default-y="-221.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>3</octave>
@@ -3312,7 +3337,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="52.64" default-y="-211.00" dynamics="141.11">
+      <note default-x="53.17" default-y="-211.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -3323,7 +3348,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="52.64" default-y="-196.00" dynamics="141.11">
+      <note default-x="53.17" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3335,7 +3360,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="86.43" default-y="-221.00" dynamics="141.11">
+      <note default-x="87.49" default-y="-221.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>3</octave>
@@ -3346,7 +3371,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="86.43" default-y="-211.00" dynamics="141.11">
+      <note default-x="87.49" default-y="-211.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -3357,7 +3382,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="86.43" default-y="-196.00" dynamics="141.11">
+      <note default-x="87.49" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3369,7 +3394,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="120.21" default-y="-221.00" dynamics="141.11">
+      <note default-x="121.81" default-y="-221.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>3</octave>
@@ -3380,7 +3405,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="120.21" default-y="-211.00" dynamics="141.11">
+      <note default-x="121.81" default-y="-211.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -3391,7 +3416,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="120.21" default-y="-196.00" dynamics="141.11">
+      <note default-x="121.81" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3409,7 +3434,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="192.22" default-y="-226.00" dynamics="141.11">
+      <note default-x="192.85" default-y="-226.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -3420,7 +3445,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="192.22" default-y="-216.00" dynamics="141.11">
+      <note default-x="192.85" default-y="-216.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3432,7 +3457,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="192.22" default-y="-191.00" dynamics="141.11">
+      <note default-x="192.85" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3443,7 +3468,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="226.01" default-y="-226.00" dynamics="141.11">
+      <note default-x="227.16" default-y="-226.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -3454,7 +3479,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="226.01" default-y="-216.00" dynamics="141.11">
+      <note default-x="227.16" default-y="-216.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3466,7 +3491,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="226.01" default-y="-191.00" dynamics="141.11">
+      <note default-x="227.16" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3477,7 +3502,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="259.79" default-y="-226.00" dynamics="141.11">
+      <note default-x="261.48" default-y="-226.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -3488,7 +3513,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="259.79" default-y="-216.00" dynamics="141.11">
+      <note default-x="261.48" default-y="-216.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3500,7 +3525,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="259.79" default-y="-191.00" dynamics="141.11">
+      <note default-x="261.48" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3512,14 +3537,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="9" width="345.88">
+    <measure number="9" width="348.10">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="63.64" default-y="-211.00" dynamics="141.11">
+      <note default-x="62.14" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -3530,7 +3555,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="75.50" default-y="-206.00" dynamics="141.11">
+      <note default-x="74.00" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3541,7 +3566,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="63.64" default-y="-186.00" dynamics="141.11">
+      <note default-x="62.14" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3552,7 +3577,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="103.73" default-y="-211.00" dynamics="141.11">
+      <note default-x="102.76" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -3563,7 +3588,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="115.59" default-y="-206.00" dynamics="141.11">
+      <note default-x="114.63" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3574,7 +3599,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="103.73" default-y="-186.00" dynamics="141.11">
+      <note default-x="102.76" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3585,7 +3610,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="143.82" default-y="-211.00" dynamics="141.11">
+      <note default-x="143.38" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -3596,7 +3621,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="155.69" default-y="-206.00" dynamics="141.11">
+      <note default-x="155.25" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3607,7 +3632,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="143.82" default-y="-186.00" dynamics="141.11">
+      <note default-x="143.38" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3624,7 +3649,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="224.01" default-y="-216.00" dynamics="141.11">
+      <note default-x="224.63" default-y="-216.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -3636,7 +3661,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="224.01" default-y="-206.00" dynamics="141.11">
+      <note default-x="224.63" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3647,7 +3672,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="224.01" default-y="-181.00" dynamics="141.11">
+      <note default-x="224.63" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3659,7 +3684,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="264.10" default-y="-216.00" dynamics="141.11">
+      <note default-x="265.26" default-y="-216.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -3671,7 +3696,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="264.10" default-y="-206.00" dynamics="141.11">
+      <note default-x="265.26" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3682,7 +3707,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="264.10" default-y="-181.00" dynamics="141.11">
+      <note default-x="265.26" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3694,7 +3719,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="304.19" default-y="-216.00" dynamics="141.11">
+      <note default-x="305.88" default-y="-216.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -3706,7 +3731,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="304.19" default-y="-206.00" dynamics="141.11">
+      <note default-x="305.88" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3717,7 +3742,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="304.19" default-y="-181.00" dynamics="141.11">
+      <note default-x="305.88" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -3730,13 +3755,13 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="10" width="364.42">
+    <measure number="10" width="367.04">
       <print new-page="yes">
         <staff-layout number="1">
           <staff-distance>106.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="75.87" default-y="-206.00" dynamics="141.11">
+      <note default-x="77.27" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3747,7 +3772,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="75.87" default-y="-196.00" dynamics="141.11">
+      <note default-x="77.27" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3759,7 +3784,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="75.87" default-y="-186.00" dynamics="141.11">
+      <note default-x="77.27" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3770,7 +3795,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="111.74" default-y="-206.00" dynamics="141.11">
+      <note default-x="113.29" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3781,7 +3806,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="111.74" default-y="-196.00" dynamics="141.11">
+      <note default-x="113.29" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3793,7 +3818,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="111.74" default-y="-186.00" dynamics="141.11">
+      <note default-x="113.29" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3804,7 +3829,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="147.61" default-y="-206.00" dynamics="141.11">
+      <note default-x="149.31" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3815,7 +3840,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="147.61" default-y="-196.00" dynamics="141.11">
+      <note default-x="149.31" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3827,7 +3852,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="147.61" default-y="-171.00" dynamics="141.11">
+      <note default-x="149.31" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3838,7 +3863,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="183.48" default-y="-206.00" dynamics="141.11">
+      <note default-x="185.33" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -3849,7 +3874,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="183.48" default-y="-196.00" dynamics="141.11">
+      <note default-x="185.33" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -3861,7 +3886,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="183.48" default-y="-171.00" dynamics="141.11">
+      <note default-x="185.33" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3872,7 +3897,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="219.34" default-y="-201.00" dynamics="141.11">
+      <note default-x="221.36" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -3883,7 +3908,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="219.34" default-y="-191.00" dynamics="141.11">
+      <note default-x="221.36" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3894,7 +3919,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="219.34" default-y="-171.00" dynamics="141.11">
+      <note default-x="221.36" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3905,7 +3930,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="255.21" default-y="-201.00" dynamics="141.11">
+      <note default-x="257.38" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -3916,7 +3941,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="255.21" default-y="-191.00" dynamics="141.11">
+      <note default-x="257.38" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -3927,7 +3952,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="255.21" default-y="-171.00" dynamics="141.11">
+      <note default-x="257.38" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3938,7 +3963,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="291.08" default-y="-196.00" dynamics="141.11">
+      <note default-x="293.40" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -3950,7 +3975,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="291.08" default-y="-186.00" dynamics="141.11">
+      <note default-x="293.40" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3961,7 +3986,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="291.08" default-y="-171.00" dynamics="141.11">
+      <note default-x="293.40" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -3972,7 +3997,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="326.95" default-y="-196.00" dynamics="141.11">
+      <note default-x="329.42" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -3984,7 +4009,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="326.95" default-y="-186.00" dynamics="141.11">
+      <note default-x="329.42" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -3995,7 +4020,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="326.95" default-y="-171.00" dynamics="141.11">
+      <note default-x="329.42" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4007,7 +4032,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="11" width="312.51">
+    <measure number="11" width="315.23">
       <note default-x="12.94" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
@@ -4042,7 +4067,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="49.99" default-y="-191.00" dynamics="141.11">
+      <note default-x="50.38" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4053,7 +4078,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="49.99" default-y="-181.00" dynamics="141.11">
+      <note default-x="50.38" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4065,7 +4090,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="49.99" default-y="-171.00" dynamics="141.11">
+      <note default-x="50.38" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4076,7 +4101,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="87.05" default-y="-191.00" dynamics="141.11">
+      <note default-x="87.83" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4087,7 +4112,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="87.05" default-y="-181.00" dynamics="141.11">
+      <note default-x="87.83" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4099,7 +4124,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="87.05" default-y="-171.00" dynamics="141.11">
+      <note default-x="87.83" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4110,7 +4135,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="124.10" default-y="-191.00" dynamics="141.11">
+      <note default-x="125.27" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4121,7 +4146,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="124.10" default-y="-181.00" dynamics="141.11">
+      <note default-x="125.27" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4133,7 +4158,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="124.10" default-y="-171.00" dynamics="141.11">
+      <note default-x="125.27" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4144,7 +4169,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="161.16" default-y="-186.00" dynamics="141.11">
+      <note default-x="162.72" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4155,7 +4180,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="161.16" default-y="-176.00" dynamics="141.11">
+      <note default-x="162.72" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4166,7 +4191,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="173.03" default-y="-171.00" dynamics="141.11">
+      <note default-x="174.58" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4177,7 +4202,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="198.22" default-y="-186.00" dynamics="141.11">
+      <note default-x="200.16" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4188,7 +4213,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="198.22" default-y="-176.00" dynamics="141.11">
+      <note default-x="200.16" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4199,7 +4224,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="210.08" default-y="-171.00" dynamics="141.11">
+      <note default-x="212.03" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4210,7 +4235,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="235.27" default-y="-186.00" dynamics="141.11">
+      <note default-x="237.61" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4221,7 +4246,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="235.27" default-y="-176.00" dynamics="141.11">
+      <note default-x="237.61" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4232,7 +4257,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="247.14" default-y="-171.00" dynamics="141.11">
+      <note default-x="249.47" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4243,7 +4268,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="272.33" default-y="-186.00" dynamics="141.11">
+      <note default-x="275.05" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4254,7 +4279,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="272.33" default-y="-176.00" dynamics="141.11">
+      <note default-x="275.05" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4265,7 +4290,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="284.19" default-y="-171.00" dynamics="141.11">
+      <note default-x="286.92" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4277,7 +4302,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="12" width="313.95">
+    <measure number="12" width="316.67">
       <note default-x="14.00" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
@@ -4312,7 +4337,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="51.29" default-y="-191.00" dynamics="141.11">
+      <note default-x="51.63" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4323,7 +4348,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="51.29" default-y="-181.00" dynamics="141.11">
+      <note default-x="51.63" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4335,7 +4360,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="51.29" default-y="-171.00" dynamics="141.11">
+      <note default-x="51.63" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4346,7 +4371,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="88.59" default-y="-196.00" dynamics="141.11">
+      <note default-x="89.27" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -4358,7 +4383,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="88.59" default-y="-186.00" dynamics="141.11">
+      <note default-x="89.27" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -4369,7 +4394,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="88.59" default-y="-171.00" dynamics="141.11">
+      <note default-x="89.27" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4380,7 +4405,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="125.88" default-y="-196.00" dynamics="141.11">
+      <note default-x="126.90" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -4392,7 +4417,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="125.88" default-y="-186.00" dynamics="141.11">
+      <note default-x="126.90" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -4403,7 +4428,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="125.88" default-y="-171.00" dynamics="141.11">
+      <note default-x="126.90" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4414,7 +4439,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="163.17" default-y="-201.00" dynamics="141.11">
+      <note default-x="164.53" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -4425,7 +4450,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="163.17" default-y="-191.00" dynamics="141.11">
+      <note default-x="164.53" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -4436,7 +4461,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="163.17" default-y="-171.00" dynamics="141.11">
+      <note default-x="164.53" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4447,7 +4472,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="200.47" default-y="-201.00" dynamics="141.11">
+      <note default-x="202.17" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -4458,7 +4483,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="200.47" default-y="-191.00" dynamics="141.11">
+      <note default-x="202.17" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -4469,7 +4494,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="200.47" default-y="-171.00" dynamics="141.11">
+      <note default-x="202.17" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4480,7 +4505,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="237.76" default-y="-196.00" dynamics="141.11">
+      <note default-x="239.80" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -4492,7 +4517,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="237.76" default-y="-186.00" dynamics="141.11">
+      <note default-x="239.80" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -4503,7 +4528,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="237.76" default-y="-171.00" dynamics="141.11">
+      <note default-x="239.80" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4514,7 +4539,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="275.05" default-y="-196.00" dynamics="141.11">
+      <note default-x="277.44" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -4526,7 +4551,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="275.05" default-y="-186.00" dynamics="141.11">
+      <note default-x="277.44" default-y="-186.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -4537,7 +4562,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="275.05" default-y="-171.00" dynamics="141.11">
+      <note default-x="277.44" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4549,13 +4574,13 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="13" width="374.36">
+    <measure number="13" width="377.84">
       <print new-system="yes">
         <staff-layout number="1">
           <staff-distance>106.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="85.76" default-y="-191.00" dynamics="141.11">
+      <note default-x="87.16" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4566,7 +4591,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="85.76" default-y="-181.00" dynamics="141.11">
+      <note default-x="87.16" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4578,7 +4603,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="85.76" default-y="-171.00" dynamics="141.11">
+      <note default-x="87.16" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4589,7 +4614,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="120.75" default-y="-191.00" dynamics="141.11">
+      <note default-x="122.04" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4600,7 +4625,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="120.75" default-y="-181.00" dynamics="141.11">
+      <note default-x="122.04" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4612,7 +4637,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="120.75" default-y="-171.00" dynamics="141.11">
+      <note default-x="122.04" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4623,7 +4648,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="155.74" default-y="-191.00" dynamics="141.11">
+      <note default-x="156.92" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4634,7 +4659,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="155.74" default-y="-181.00" dynamics="141.11">
+      <note default-x="156.92" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4646,7 +4671,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="155.74" default-y="-171.00" dynamics="141.11">
+      <note default-x="156.92" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4657,7 +4682,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="190.73" default-y="-191.00" dynamics="141.11">
+      <note default-x="191.80" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -4668,7 +4693,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="190.73" default-y="-181.00" dynamics="141.11">
+      <note default-x="191.80" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4680,7 +4705,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="190.73" default-y="-171.00" dynamics="141.11">
+      <note default-x="191.80" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4691,7 +4716,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="232.77" default-y="-186.00" dynamics="141.11">
+      <note default-x="226.67" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4702,7 +4727,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="232.77" default-y="-176.00" dynamics="141.11">
+      <note default-x="226.67" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4713,7 +4738,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="244.63" default-y="-171.00" dynamics="141.11">
+      <note default-x="238.54" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4724,7 +4749,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="267.76" default-y="-186.00" dynamics="141.11">
+      <note default-x="271.45" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4735,7 +4760,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="267.76" default-y="-176.00" dynamics="141.11">
+      <note default-x="271.45" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4746,7 +4771,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="279.62" default-y="-171.00" dynamics="141.11">
+      <note default-x="283.32" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4757,7 +4782,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="302.74" default-y="-186.00" dynamics="141.11">
+      <note default-x="306.33" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4768,7 +4793,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="302.74" default-y="-176.00" dynamics="141.11">
+      <note default-x="306.33" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4779,7 +4804,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="314.61" default-y="-171.00" dynamics="141.11">
+      <note default-x="318.19" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4790,7 +4815,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="337.73" default-y="-186.00" dynamics="141.11">
+      <note default-x="341.21" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -4801,7 +4826,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="337.73" default-y="-176.00" dynamics="141.11">
+      <note default-x="341.21" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4812,7 +4837,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="349.60" default-y="-171.00" dynamics="141.11">
+      <note default-x="353.07" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -4824,14 +4849,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="14" width="323.63">
+    <measure number="14" width="324.65">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="65.35" default-y="-206.00" dynamics="141.11">
+      <note default-x="63.30" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -4842,7 +4867,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="65.35" default-y="-191.00" dynamics="141.11">
+      <note default-x="63.30" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -4853,7 +4878,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="65.35" default-y="-181.00" dynamics="141.11">
+      <note default-x="63.30" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4865,7 +4890,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="101.96" default-y="-206.00" dynamics="141.11">
+      <note default-x="100.41" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -4876,7 +4901,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="101.96" default-y="-191.00" dynamics="141.11">
+      <note default-x="100.41" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -4887,7 +4912,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="101.96" default-y="-181.00" dynamics="141.11">
+      <note default-x="100.41" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4899,7 +4924,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="138.57" default-y="-206.00" dynamics="141.11">
+      <note default-x="137.52" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -4910,7 +4935,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="138.57" default-y="-191.00" dynamics="141.11">
+      <note default-x="137.52" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -4921,7 +4946,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="138.57" default-y="-181.00" dynamics="141.11">
+      <note default-x="137.52" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -4933,7 +4958,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="175.18" default-y="-206.00" dynamics="141.11">
+      <note default-x="174.62" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -4944,7 +4969,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="175.18" default-y="-196.00" dynamics="141.11">
+      <note default-x="174.62" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -4956,7 +4981,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="175.18" default-y="-176.00" dynamics="141.11">
+      <note default-x="174.62" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -4967,7 +4992,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="211.78" default-y="-206.00" dynamics="141.11">
+      <note default-x="211.73" default-y="-206.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -4978,7 +5003,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="211.78" default-y="-196.00" dynamics="141.11">
+      <note default-x="211.73" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -4990,7 +5015,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="211.78" default-y="-176.00" dynamics="141.11">
+      <note default-x="211.73" default-y="-176.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -5001,7 +5026,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="248.39" default-y="-196.00" dynamics="141.11">
+      <note default-x="248.84" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <octave>4</octave>
@@ -5013,7 +5038,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="260.26" default-y="-191.00" dynamics="141.11">
+      <note default-x="260.70" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5024,7 +5049,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="248.39" default-y="-171.00" dynamics="141.11">
+      <note default-x="248.84" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5035,7 +5060,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="285.42" default-y="-196.00" dynamics="141.11">
+      <note default-x="285.95" default-y="-196.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <octave>4</octave>
@@ -5046,7 +5071,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="297.29" default-y="-191.00" dynamics="141.11">
+      <note default-x="297.81" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5057,7 +5082,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="285.42" default-y="-171.00" dynamics="141.11">
+      <note default-x="285.95" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5069,14 +5094,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="15" width="292.88">
+    <measure number="15" width="296.45">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="59.30" default-y="-201.00" dynamics="141.11">
+      <note default-x="60.03" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -5087,7 +5112,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="59.30" default-y="-191.00" dynamics="141.11">
+      <note default-x="60.03" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5098,7 +5123,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="59.30" default-y="-166.00" dynamics="141.11">
+      <note default-x="60.03" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5109,7 +5134,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="91.19" default-y="-201.00" dynamics="141.11">
+      <note default-x="92.64" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -5120,7 +5145,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="91.19" default-y="-191.00" dynamics="141.11">
+      <note default-x="92.64" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5131,7 +5156,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="91.19" default-y="-166.00" dynamics="141.11">
+      <note default-x="92.64" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5142,7 +5167,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="123.08" default-y="-201.00" dynamics="141.11">
+      <note default-x="125.25" default-y="-201.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -5153,7 +5178,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="123.08" default-y="-191.00" dynamics="141.11">
+      <note default-x="125.25" default-y="-191.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5164,7 +5189,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="123.08" default-y="-166.00" dynamics="141.11">
+      <note default-x="125.25" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5177,7 +5202,7 @@
         </note>
       <direction placement="below">
         <direction-type>
-          <dynamics default-x="5.06" default-y="-80.00" relative-x="4.23" relative-y="10.21">
+          <dynamics default-x="5.06" default-y="-80.00" relative-y="6.00">
             <p/>
             </dynamics>
           </direction-type>
@@ -5189,7 +5214,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="195.62" default-y="-191.00" dynamics="141.11">
+      <note default-x="197.02" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5200,7 +5225,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="195.62" default-y="-181.00" dynamics="141.11">
+      <note default-x="197.02" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5212,7 +5237,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="195.62" default-y="-166.00" dynamics="141.11">
+      <note default-x="197.02" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5223,7 +5248,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="227.51" default-y="-191.00" dynamics="141.11">
+      <note default-x="229.63" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5234,7 +5259,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="227.51" default-y="-181.00" dynamics="141.11">
+      <note default-x="229.63" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5246,7 +5271,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="227.51" default-y="-166.00" dynamics="141.11">
+      <note default-x="229.63" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5257,7 +5282,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="259.39" default-y="-191.00" dynamics="141.11">
+      <note default-x="262.24" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5268,7 +5293,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="259.39" default-y="-181.00" dynamics="141.11">
+      <note default-x="262.24" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5280,7 +5305,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="259.39" default-y="-166.00" dynamics="141.11">
+      <note default-x="262.24" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5292,7 +5317,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="16" width="298.00">
+    <measure number="16" width="365.96">
       <print new-system="yes">
         <staff-layout number="1">
           <staff-distance>106.00</staff-distance>
@@ -5304,7 +5329,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="108.86" default-y="-191.00" dynamics="141.11">
+      <note default-x="124.54" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5315,7 +5340,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="108.86" default-y="-181.00" dynamics="141.11">
+      <note default-x="124.54" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5327,7 +5352,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="108.86" default-y="-171.00" dynamics="141.11">
+      <note default-x="124.54" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5338,7 +5363,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="128.72" default-y="-191.00" dynamics="141.11">
+      <note default-x="158.67" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5349,7 +5374,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="128.72" default-y="-181.00" dynamics="141.11">
+      <note default-x="158.67" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5361,7 +5386,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="128.72" default-y="-171.00" dynamics="141.11">
+      <note default-x="158.67" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5372,7 +5397,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="148.57" default-y="-191.00" dynamics="141.11">
+      <note default-x="192.80" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5383,7 +5408,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="148.57" default-y="-181.00" dynamics="141.11">
+      <note default-x="192.80" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5395,7 +5420,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="148.57" default-y="-171.00" dynamics="141.11">
+      <note default-x="192.80" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5412,7 +5437,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="203.30" default-y="-186.00" dynamics="141.11">
+      <note default-x="261.06" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -5423,7 +5448,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="215.17" default-y="-181.00" dynamics="141.11">
+      <note default-x="272.93" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5435,7 +5460,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="203.30" default-y="-161.00" dynamics="141.11">
+      <note default-x="261.06" default-y="-161.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -5447,7 +5472,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="232.33" default-y="-186.00" dynamics="141.11">
+      <note default-x="295.19" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -5458,7 +5483,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="244.20" default-y="-181.00" dynamics="141.11">
+      <note default-x="307.06" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5470,7 +5495,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="232.33" default-y="-161.00" dynamics="141.11">
+      <note default-x="295.19" default-y="-161.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -5482,7 +5507,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="261.37" default-y="-186.00" dynamics="141.11">
+      <note default-x="329.32" default-y="-186.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -5493,7 +5518,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="273.23" default-y="-181.00" dynamics="141.11">
+      <note default-x="341.19" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5505,7 +5530,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="261.37" default-y="-161.00" dynamics="141.11">
+      <note default-x="329.32" default-y="-161.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -5518,14 +5543,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="17" width="223.18">
+    <measure number="17" width="290.96">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="49.52" default-y="-191.00" dynamics="141.11">
+      <note default-x="59.09" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5536,7 +5561,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="49.52" default-y="-181.00" dynamics="141.11">
+      <note default-x="59.09" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5548,7 +5573,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="49.52" default-y="-156.00" dynamics="141.11">
+      <note default-x="59.09" default-y="-156.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5559,7 +5584,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="70.30" default-y="-191.00" dynamics="141.11">
+      <note default-x="91.99" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5570,7 +5595,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="70.30" default-y="-181.00" dynamics="141.11">
+      <note default-x="91.99" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5582,7 +5607,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="70.30" default-y="-156.00" dynamics="141.11">
+      <note default-x="91.99" default-y="-156.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5593,7 +5618,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="91.07" default-y="-191.00" dynamics="141.11">
+      <note default-x="124.88" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5604,7 +5629,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="91.07" default-y="-181.00" dynamics="141.11">
+      <note default-x="124.88" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5616,7 +5641,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="91.07" default-y="-156.00" dynamics="141.11">
+      <note default-x="124.88" default-y="-156.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -5633,7 +5658,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="137.13" default-y="-191.00" dynamics="141.11">
+      <note default-x="190.67" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5644,7 +5669,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="137.13" default-y="-181.00" dynamics="141.11">
+      <note default-x="190.67" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5656,7 +5681,7 @@
         <accidental>natural</accidental>
         <stem>up</stem>
         </note>
-      <note default-x="137.13" default-y="-166.00" dynamics="141.11">
+      <note default-x="190.67" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5667,7 +5692,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="166.18" default-y="-191.00" dynamics="141.11">
+      <note default-x="223.57" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5678,7 +5703,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="166.18" default-y="-181.00" dynamics="141.11">
+      <note default-x="223.57" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5689,7 +5714,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="166.18" default-y="-166.00" dynamics="141.11">
+      <note default-x="223.57" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5700,7 +5725,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="194.62" default-y="-191.00" dynamics="141.11">
+      <note default-x="256.47" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5711,7 +5736,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="194.62" default-y="-181.00" dynamics="141.11">
+      <note default-x="256.47" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5722,7 +5747,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="194.62" default-y="-166.00" dynamics="141.11">
+      <note default-x="256.47" default-y="-166.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -5734,14 +5759,14 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="18" width="280.67">
+    <measure number="18" width="342.02">
       <note>
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="44.54" default-y="-191.00" dynamics="141.11">
+      <note default-x="54.80" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5752,7 +5777,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="44.54" default-y="-181.00" dynamics="141.11">
+      <note default-x="54.80" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5765,7 +5790,7 @@
         <accidental>sharp</accidental>
         <stem>up</stem>
         </note>
-      <note default-x="44.54" default-y="-171.00" dynamics="141.11">
+      <note default-x="54.80" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5776,7 +5801,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="75.26" default-y="-191.00" dynamics="141.11">
+      <note default-x="95.61" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5787,7 +5812,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="75.26" default-y="-181.00" dynamics="141.11">
+      <note default-x="95.61" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5799,7 +5824,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="75.26" default-y="-171.00" dynamics="141.11">
+      <note default-x="95.61" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5810,7 +5835,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="108.89" default-y="-191.00" dynamics="141.11">
+      <note default-x="136.41" default-y="-191.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -5821,7 +5846,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="108.89" default-y="-181.00" dynamics="141.11">
+      <note default-x="136.41" default-y="-181.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -5833,7 +5858,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="108.89" default-y="-171.00" dynamics="141.11">
+      <note default-x="136.41" default-y="-171.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5850,7 +5875,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="169.98" default-y="-211.00" dynamics="141.11">
+      <note default-x="218.02" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -5861,7 +5886,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="181.84" default-y="-206.00" dynamics="141.11">
+      <note default-x="229.88" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5872,7 +5897,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="169.98" default-y="-196.00" dynamics="141.11">
+      <note default-x="218.02" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -5884,7 +5909,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="207.01" default-y="-211.00" dynamics="141.11">
+      <note default-x="258.82" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -5895,7 +5920,7 @@
         <stem>up</stem>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="218.87" default-y="-206.00" dynamics="141.11">
+      <note default-x="270.68" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5906,7 +5931,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="207.01" default-y="-196.00" dynamics="141.11">
+      <note default-x="258.82" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -5918,7 +5943,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="244.04" default-y="-211.00" dynamics="141.11">
+      <note default-x="299.62" default-y="-211.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -5929,7 +5954,7 @@
         <stem>up</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="255.91" default-y="-206.00" dynamics="141.11">
+      <note default-x="311.49" default-y="-206.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -5940,7 +5965,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="244.04" default-y="-196.00" dynamics="141.11">
+      <note default-x="299.62" default-y="-196.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -5953,287 +5978,292 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="19" width="189.02">
-      <note default-x="29.02" default-y="-216.00" dynamics="141.11">
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>3</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">begin</beam>
-        </note>
-      <note default-x="29.02" default-y="-206.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>A</step>
-          <octave>3</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="29.02" default-y="-191.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="48.34" default-y="-191.00" dynamics="141.11">
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <note default-x="48.34" default-y="-181.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="48.34" default-y="-156.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="67.66" default-y="-191.00" dynamics="141.11">
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <note default-x="67.66" default-y="-181.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="67.66" default-y="-156.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="86.98" default-y="-191.00" dynamics="141.11">
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">end</beam>
-        </note>
-      <note default-x="86.98" default-y="-181.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="86.98" default-y="-156.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="106.30" default-y="-191.00" dynamics="141.11">
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">begin</beam>
-        </note>
-      <note default-x="106.30" default-y="-181.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="106.30" default-y="-156.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="125.62" default-y="-191.00" dynamics="141.11">
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <note default-x="125.62" default-y="-181.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="125.62" default-y="-156.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="144.94" default-y="-186.00" dynamics="141.11">
-        <pitch>
-          <step>E</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <note default-x="144.94" default-y="-176.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="144.94" default-y="-161.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>C</step>
-          <alter>1</alter>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="164.26" default-y="-181.00" dynamics="141.11">
-        <pitch>
-          <step>F</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">end</beam>
-        </note>
-      <note default-x="164.26" default-y="-171.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="164.26" default-y="-156.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      </measure>
-    <measure number="20" width="256.63">
-      <print new-system="yes">
+    <measure number="19" width="998.94">
+      <print new-page="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>106.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="76.23" default-y="-45.00" dynamics="141.11">
+      <note default-x="94.28" default-y="-216.00" dynamics="141.11">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        </note>
+      <note default-x="94.28" default-y="-206.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="94.28" default-y="-191.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="207.17" default-y="-191.00" dynamics="141.11">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="207.17" default-y="-181.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="207.17" default-y="-156.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="320.05" default-y="-191.00" dynamics="141.11">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="320.05" default-y="-181.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="320.05" default-y="-156.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="432.93" default-y="-191.00" dynamics="141.11">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="432.93" default-y="-181.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="432.93" default-y="-156.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="545.81" default-y="-191.00" dynamics="141.11">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        </note>
+      <note default-x="545.81" default-y="-181.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="545.81" default-y="-156.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="658.70" default-y="-191.00" dynamics="141.11">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="658.70" default-y="-181.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="658.70" default-y="-156.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="771.58" default-y="-186.00" dynamics="141.11">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="771.58" default-y="-176.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="771.58" default-y="-161.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="884.46" default-y="-181.00" dynamics="141.11">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="884.46" default-y="-171.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="884.46" default-y="-156.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="20" width="255.67">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="77.63" default-y="-150.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -6247,7 +6277,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="76.23" default-y="-25.00" dynamics="141.11">
+      <note default-x="77.63" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6258,7 +6288,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="76.23" default-y="-15.00" dynamics="141.11">
+      <note default-x="77.63" default-y="-120.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -6270,7 +6300,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="98.46" default-y="-30.00" dynamics="141.11">
+      <note default-x="99.53" default-y="-135.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -6284,7 +6314,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="98.46" default-y="-20.00" dynamics="141.11">
+      <note default-x="99.53" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6295,7 +6325,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="120.70" default-y="-45.00" dynamics="141.11">
+      <note default-x="121.42" default-y="-150.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -6311,7 +6341,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="120.70" default-y="-30.00" dynamics="141.11">
+      <note default-x="121.42" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6322,7 +6352,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="120.70" default-y="-20.00" dynamics="141.11">
+      <note default-x="121.42" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6333,7 +6363,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="142.93" default-y="-45.00" dynamics="141.11">
+      <note default-x="143.32" default-y="-150.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -6349,7 +6379,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="142.93" default-y="-30.00" dynamics="141.11">
+      <note default-x="143.32" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6360,7 +6390,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="142.93" default-y="-20.00" dynamics="141.11">
+      <note default-x="143.32" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6371,7 +6401,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="165.16" default-y="-45.00" dynamics="141.11">
+      <note default-x="165.21" default-y="-150.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -6387,7 +6417,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="165.16" default-y="-30.00" dynamics="141.11">
+      <note default-x="165.21" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6398,7 +6428,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="165.16" default-y="-20.00" dynamics="141.11">
+      <note default-x="165.21" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6409,7 +6439,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="187.40" default-y="-55.00" dynamics="141.11">
+      <note default-x="187.11" default-y="-160.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -6425,7 +6455,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="187.40" default-y="-30.00" dynamics="141.11">
+      <note default-x="187.11" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6436,7 +6466,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="187.40" default-y="-20.00" dynamics="141.11">
+      <note default-x="187.11" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6447,7 +6477,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="209.63" default-y="-45.00" dynamics="141.11">
+      <note default-x="209.01" default-y="-150.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -6463,7 +6493,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="209.63" default-y="-30.00" dynamics="141.11">
+      <note default-x="209.01" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6474,7 +6504,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="209.63" default-y="-20.00" dynamics="141.11">
+      <note default-x="209.01" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6485,7 +6515,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="231.87" default-y="-40.00" dynamics="141.11">
+      <note default-x="230.90" default-y="-145.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -6501,7 +6531,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="231.87" default-y="-30.00" dynamics="141.11">
+      <note default-x="230.90" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6512,7 +6542,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="231.87" default-y="-20.00" dynamics="141.11">
+      <note default-x="230.90" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6524,8 +6554,8 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="21" width="242.40">
-      <note default-x="12.36" default-y="-30.00" dynamics="141.11">
+    <measure number="21" width="240.04">
+      <note default-x="12.36" default-y="-135.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -6539,7 +6569,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="12.36" default-y="-20.00" dynamics="141.11">
+      <note default-x="12.36" default-y="-125.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>B</step>
@@ -6550,7 +6580,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="40.92" default-y="-60.00" dynamics="141.11">
+      <note default-x="40.62" default-y="-165.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -6564,7 +6594,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="40.92" default-y="-35.00" dynamics="141.11">
+      <note default-x="40.62" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6576,7 +6606,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="40.92" default-y="-25.00" dynamics="141.11">
+      <note default-x="40.62" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6587,7 +6617,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="69.47" default-y="-60.00" dynamics="141.11">
+      <note default-x="68.88" default-y="-165.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -6603,7 +6633,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="69.47" default-y="-35.00" dynamics="141.11">
+      <note default-x="68.88" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6615,7 +6645,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="69.47" default-y="-25.00" dynamics="141.11">
+      <note default-x="68.88" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6626,7 +6656,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="98.03" default-y="-60.00" dynamics="141.11">
+      <note default-x="97.14" default-y="-165.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -6642,7 +6672,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="98.03" default-y="-35.00" dynamics="141.11">
+      <note default-x="97.14" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6654,7 +6684,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="98.03" default-y="-25.00" dynamics="141.11">
+      <note default-x="97.14" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6665,7 +6695,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="126.58" default-y="-60.00" dynamics="141.11">
+      <note default-x="125.40" default-y="-165.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -6681,7 +6711,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="126.58" default-y="-35.00" dynamics="141.11">
+      <note default-x="125.40" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6693,7 +6723,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="126.58" default-y="-25.00" dynamics="141.11">
+      <note default-x="125.40" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6704,7 +6734,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="155.14" default-y="-60.00" dynamics="141.11">
+      <note default-x="153.66" default-y="-165.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -6720,7 +6750,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="155.14" default-y="-35.00" dynamics="141.11">
+      <note default-x="153.66" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6732,7 +6762,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="155.14" default-y="-25.00" dynamics="141.11">
+      <note default-x="153.66" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6743,7 +6773,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="183.69" default-y="-50.00" dynamics="141.11">
+      <note default-x="181.92" default-y="-155.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -6760,7 +6790,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="183.69" default-y="-35.00" dynamics="141.11">
+      <note default-x="181.92" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6772,7 +6802,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="183.69" default-y="-25.00" dynamics="141.11">
+      <note default-x="181.92" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6783,7 +6813,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="212.25" default-y="-45.00" dynamics="141.11">
+      <note default-x="210.18" default-y="-150.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -6799,7 +6829,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="212.25" default-y="-35.00" dynamics="141.11">
+      <note default-x="210.18" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6811,7 +6841,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="212.25" default-y="-25.00" dynamics="141.11">
+      <note default-x="210.18" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6823,8 +6853,8 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="22" width="293.53">
-      <note default-x="18.42" default-y="-55.00" dynamics="141.11">
+    <measure number="22" width="293.17">
+      <note default-x="18.42" default-y="-160.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -6838,7 +6868,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="18.42" default-y="-45.00" dynamics="141.11">
+      <note default-x="18.42" default-y="-150.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -6851,7 +6881,7 @@
         <accidental>sharp</accidental>
         <stem>up</stem>
         </note>
-      <note default-x="18.42" default-y="-35.00" dynamics="141.11">
+      <note default-x="18.42" default-y="-140.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>F</step>
@@ -6863,7 +6893,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="18.42" default-y="-25.00" dynamics="141.11">
+      <note default-x="18.42" default-y="-130.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -6874,7 +6904,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="48.19" default-y="-40.00" dynamics="141.11">
+      <note default-x="48.32" default-y="-145.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -6888,7 +6918,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="48.19" default-y="-30.00" dynamics="141.11">
+      <note default-x="48.32" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6899,7 +6929,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="77.97" default-y="-55.00" dynamics="141.11">
+      <note default-x="78.23" default-y="-160.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -6915,7 +6945,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="77.97" default-y="-40.00" dynamics="141.11">
+      <note default-x="78.23" default-y="-145.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -6926,7 +6956,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="77.97" default-y="-30.00" dynamics="141.11">
+      <note default-x="78.23" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6937,7 +6967,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="107.75" default-y="-55.00" dynamics="141.11">
+      <note default-x="108.13" default-y="-160.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -6953,7 +6983,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="107.75" default-y="-40.00" dynamics="141.11">
+      <note default-x="108.13" default-y="-145.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -6964,7 +6994,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="107.75" default-y="-30.00" dynamics="141.11">
+      <note default-x="108.13" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -6975,7 +7005,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="137.53" default-y="-50.00" dynamics="141.11">
+      <note default-x="138.04" default-y="-155.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -6992,7 +7022,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="137.53" default-y="-40.00" dynamics="141.11">
+      <note default-x="138.04" default-y="-145.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -7003,7 +7033,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="137.53" default-y="-30.00" dynamics="141.11">
+      <note default-x="138.04" default-y="-135.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -7014,57 +7044,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="167.30" default-y="-65.00" dynamics="141.11">
-        <pitch>
-          <step>G</step>
-          <octave>3</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        <notations>
-          <articulations>
-            <staccato/>
-            </articulations>
-          </notations>
-        </note>
-      <note default-x="179.17" default-y="-60.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>A</step>
-          <octave>3</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="167.30" default-y="-50.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>C</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="167.30" default-y="-40.00" dynamics="141.11">
-        <chord/>
-        <pitch>
-          <step>E</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="204.34" default-y="-65.00" dynamics="141.11">
+      <note default-x="167.94" default-y="-170.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -7080,7 +7060,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="216.20" default-y="-60.00" dynamics="141.11">
+      <note default-x="179.81" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7091,7 +7071,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="204.34" default-y="-50.00" dynamics="141.11">
+      <note default-x="167.94" default-y="-155.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -7103,7 +7083,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="204.34" default-y="-40.00" dynamics="141.11">
+      <note default-x="167.94" default-y="-145.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -7114,7 +7094,57 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="241.37" default-y="-65.00" dynamics="141.11">
+      <note default-x="203.47" default-y="-170.00" dynamics="141.11">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <articulations>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="215.34" default-y="-165.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="203.47" default-y="-155.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="203.47" default-y="-145.00" dynamics="141.11">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="239.00" default-y="-170.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -7130,7 +7160,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="253.23" default-y="-60.00" dynamics="141.11">
+      <note default-x="250.87" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7141,7 +7171,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="241.37" default-y="-50.00" dynamics="141.11">
+      <note default-x="239.00" default-y="-155.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -7153,7 +7183,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="241.37" default-y="-40.00" dynamics="141.11">
+      <note default-x="239.00" default-y="-145.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -7169,8 +7199,8 @@
         <repeat direction="backward"/>
         </barline>
       </measure>
-    <measure number="23" width="198.31">
-      <note default-x="12.36" default-y="-65.00" dynamics="141.11">
+    <measure number="23" width="210.07">
+      <note default-x="12.36" default-y="-170.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -7184,7 +7214,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="24.23" default-y="-60.00" dynamics="141.11">
+      <note default-x="24.23" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7195,7 +7225,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="12.36" default-y="-50.00" dynamics="141.11">
+      <note default-x="12.36" default-y="-155.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>C</step>
@@ -7207,7 +7237,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="12.36" default-y="-40.00" dynamics="141.11">
+      <note default-x="12.36" default-y="-145.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>E</step>
@@ -7218,7 +7248,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="49.39" default-y="-70.00" dynamics="141.11">
+      <note default-x="47.89" default-y="-175.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7233,7 +7263,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="49.39" default-y="-60.00" dynamics="141.11">
+      <note default-x="47.89" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7244,7 +7274,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="49.39" default-y="-45.00" dynamics="141.11">
+      <note default-x="47.89" default-y="-150.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -7255,7 +7285,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="74.56" default-y="-70.00" dynamics="141.11">
+      <note default-x="73.79" default-y="-175.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7272,7 +7302,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="74.56" default-y="-60.00" dynamics="141.11">
+      <note default-x="73.79" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7283,7 +7313,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="74.56" default-y="-45.00" dynamics="141.11">
+      <note default-x="73.79" default-y="-150.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -7294,7 +7324,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="99.72" default-y="-70.00" dynamics="141.11">
+      <note default-x="99.69" default-y="-175.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7311,7 +7341,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="99.72" default-y="-60.00" dynamics="141.11">
+      <note default-x="99.69" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7322,7 +7352,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="99.72" default-y="-45.00" dynamics="141.11">
+      <note default-x="99.69" default-y="-150.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -7333,7 +7363,7 @@
         <type>eighth</type>
         <stem>up</stem>
         </note>
-      <note default-x="124.89" default-y="-70.00" dynamics="141.11">
+      <note default-x="125.59" default-y="-175.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7344,7 +7374,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="124.89" default-y="-60.00" dynamics="141.11">
+      <note default-x="125.59" default-y="-165.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>A</step>
@@ -7355,7 +7385,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="124.89" default-y="-45.00" dynamics="141.11">
+      <note default-x="125.59" default-y="-150.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -7375,17 +7405,17 @@
       </measure>
     </part>
   <part id="P3">
-    <measure number="1" width="368.47">
+    <measure number="1" width="371.57">
       <print>
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
       <attributes>
         <divisions>2</divisions>
         <key>
           <fifths>2</fifths>
-	  <mode>major</mode>
+          <mode>major</mode>
           </key>
         <time symbol="cut">
           <beats>2</beats>
@@ -7398,7 +7428,7 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <dynamics default-x="5.33" default-y="-80.00" relative-x="-7.77" relative-y="94.64">
+          <dynamics default-x="5.33" default-y="-80.00" relative-y="95.99">
             <p/>
             </dynamics>
           </direction-type>
@@ -7410,7 +7440,7 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="166.05" default-y="-281.00" dynamics="141.11">
+      <note default-x="167.88" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7423,7 +7453,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="232.99" default-y="-266.00" dynamics="141.11">
+      <note default-x="235.24" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7436,7 +7466,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="299.93" default-y="-266.00" dynamics="141.11">
+      <note default-x="302.60" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7452,8 +7482,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="2" width="330.62">
-      <note default-x="12.00" default-y="-291.00" dynamics="141.11">
+    <measure number="2" width="334.32">
+      <note default-x="12.00" default-y="-296.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7469,7 +7499,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="162.92" default-y="-281.00" dynamics="141.11">
+      <note default-x="163.77" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7484,7 +7514,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="238.21" default-y="-316.00" dynamics="141.11">
+      <note default-x="239.48" default-y="-321.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>1</octave>
@@ -7500,20 +7530,20 @@
           </notations>
         </note>
       </measure>
-    <measure number="3" width="291.36">
+    <measure number="3" width="293.06">
       <barline location="left">
         <bar-style>heavy-light</bar-style>
         <repeat direction="forward"/>
         </barline>
       <direction placement="above">
         <direction-type>
-          <dynamics default-x="6.58" default-y="-80.00" relative-x="12.21" relative-y="89.85">
+          <dynamics default-x="6.58" default-y="-80.00" relative-y="95.99">
             <pp/>
             </dynamics>
           </direction-type>
         <sound dynamics="55.56"/>
         </direction>
-      <note default-x="12.94" default-y="-301.00" dynamics="141.11">
+      <note default-x="12.94" default-y="-306.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>2</octave>
@@ -7536,10 +7566,10 @@
         <type>half</type>
         </note>
       </measure>
-    <measure number="4" width="372.07">
+    <measure number="4" width="376.05">
       <print new-system="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
       <note>
@@ -7548,7 +7578,7 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="165.04" default-y="-291.00" dynamics="141.11">
+      <note default-x="167.09" default-y="-296.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7562,7 +7592,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="233.52" default-y="-276.00" dynamics="141.11">
+      <note default-x="236.21" default-y="-281.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>2</octave>
@@ -7575,7 +7605,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="302.00" default-y="-286.00" dynamics="141.11">
+      <note default-x="305.33" default-y="-291.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <alter>1</alter>
@@ -7593,8 +7623,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="5" width="323.31">
-      <note default-x="28.74" default-y="-281.00" dynamics="141.11">
+    <measure number="5" width="323.33">
+      <note default-x="26.19" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7610,7 +7640,7 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="169.73" default-y="-281.00" dynamics="141.11">
+      <note default-x="169.51" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7627,8 +7657,8 @@
         <type>quarter</type>
         </note>
       </measure>
-    <measure number="6" width="295.49">
-      <note default-x="25.60" default-y="-266.00" dynamics="141.11">
+    <measure number="6" width="299.57">
+      <note default-x="25.60" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7643,7 +7673,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="92.67" default-y="-281.00" dynamics="141.11">
+      <note default-x="93.69" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7656,7 +7686,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="159.74" default-y="-266.00" dynamics="141.11">
+      <note default-x="161.78" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7669,7 +7699,7 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note default-x="226.82" default-y="-266.00" dynamics="141.11">
+      <note default-x="229.87" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7685,13 +7715,13 @@
           </notations>
         </note>
       </measure>
-    <measure number="7" width="349.82">
+    <measure number="7" width="353.44">
       <print new-system="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="76.45" default-y="-291.00" dynamics="141.11">
+      <note default-x="77.85" default-y="-296.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7705,7 +7735,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="212.15" default-y="-286.00" dynamics="141.11">
+      <note default-x="214.66" default-y="-291.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>2</octave>
@@ -7719,8 +7749,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="8" width="295.18">
-      <note default-x="18.86" default-y="-281.00" dynamics="141.11">
+    <measure number="8" width="297.40">
+      <note default-x="18.86" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7733,7 +7763,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="86.43" default-y="-281.00" dynamics="141.11">
+      <note default-x="87.49" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <alter>1</alter>
@@ -7745,7 +7775,7 @@
         <accidental>sharp</accidental>
         <stem>up</stem>
         </note>
-      <note default-x="158.07" default-y="-276.00" dynamics="141.11">
+      <note default-x="158.17" default-y="-281.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>2</octave>
@@ -7759,8 +7789,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="9" width="345.88">
-      <note default-x="13.64" default-y="-271.00" dynamics="141.11">
+    <measure number="9" width="348.10">
+      <note default-x="13.64" default-y="-276.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -7774,7 +7804,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="183.55" default-y="-266.00" dynamics="141.11">
+      <note default-x="183.65" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7788,13 +7818,13 @@
           </notations>
         </note>
       </measure>
-    <measure number="10" width="364.42">
+    <measure number="10" width="367.04">
       <print new-page="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="75.87" default-y="-281.00" dynamics="141.11">
+      <note default-x="77.27" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7807,7 +7837,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="147.61" default-y="-246.00" dynamics="141.11">
+      <note default-x="149.31" default-y="-251.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -7817,7 +7847,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="219.34" default-y="-251.00" dynamics="141.11">
+      <note default-x="221.36" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <alter>1</alter>
@@ -7829,7 +7859,7 @@
         <accidental>sharp</accidental>
         <stem>down</stem>
         </note>
-      <note default-x="291.08" default-y="-251.00" dynamics="141.11">
+      <note default-x="293.40" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -7844,8 +7874,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="11" width="312.51">
-      <note default-x="12.94" default-y="-256.00" dynamics="141.11">
+    <measure number="11" width="315.23">
+      <note default-x="12.94" default-y="-261.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7859,7 +7889,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="87.05" default-y="-266.00" dynamics="141.11">
+      <note default-x="87.83" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7869,7 +7899,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="161.16" default-y="-271.00" dynamics="141.11">
+      <note default-x="162.72" default-y="-276.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -7880,7 +7910,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="235.27" default-y="-281.00" dynamics="141.11">
+      <note default-x="237.61" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7894,8 +7924,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="12" width="313.95">
-      <note default-x="14.00" default-y="-266.00" dynamics="141.11">
+    <measure number="12" width="316.67">
+      <note default-x="14.00" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7908,7 +7938,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="88.59" default-y="-281.00" dynamics="141.11">
+      <note default-x="89.27" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -7919,7 +7949,7 @@
         <stem>down</stem>
         <beam number="1">begin</beam>
         </note>
-      <note default-x="125.88" default-y="-246.00">
+      <note default-x="126.90" default-y="-251.00">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -7930,7 +7960,7 @@
         <stem>down</stem>
         <beam number="1">end</beam>
         </note>
-      <note default-x="163.17" default-y="-251.00" dynamics="141.11">
+      <note default-x="164.53" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <alter>1</alter>
@@ -7942,7 +7972,7 @@
         <accidental>sharp</accidental>
         <stem>down</stem>
         </note>
-      <note default-x="237.76" default-y="-251.00" dynamics="141.11">
+      <note default-x="239.80" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -7957,13 +7987,13 @@
           </notations>
         </note>
       </measure>
-    <measure number="13" width="374.36">
+    <measure number="13" width="377.84">
       <print new-system="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
-      <note default-x="85.76" default-y="-256.00" dynamics="141.11">
+      <note default-x="87.16" default-y="-261.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -7977,7 +8007,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="155.74" default-y="-266.00" dynamics="141.11">
+      <note default-x="156.92" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -7987,7 +8017,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="232.77" default-y="-271.00">
+      <note default-x="226.67" default-y="-276.00">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -7999,7 +8029,7 @@
         <dot/>
         <stem>up</stem>
         </note>
-      <note default-x="337.73" default-y="-281.00" dynamics="141.11">
+      <note default-x="341.21" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -8013,8 +8043,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="14" width="323.63">
-      <note default-x="28.38" default-y="-266.00" dynamics="141.11">
+    <measure number="14" width="324.65">
+      <note default-x="25.83" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -8027,7 +8057,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="175.18" default-y="-261.00" dynamics="141.11">
+      <note default-x="174.62" default-y="-266.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>3</octave>
@@ -8039,12 +8069,12 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <dynamics default-x="3.29" default-y="-80.00" relative-x="-9.00" relative-y="98.99">
+          <dynamics default-x="3.29" default-y="-80.00" relative-y="95.99">
             <other-dynamics>cresc.</other-dynamics>
             </dynamics>
           </direction-type>
         </direction>
-      <note default-x="248.39" default-y="-256.00" dynamics="141.11">
+      <note default-x="248.84" default-y="-261.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -8059,8 +8089,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="15" width="292.88">
-      <note default-x="27.05" default-y="-251.00" dynamics="141.11">
+    <measure number="15" width="296.45">
+      <note default-x="27.05" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -8073,7 +8103,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="163.37" default-y="-251.00" dynamics="141.11">
+      <note default-x="164.05" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <alter>1</alter>
@@ -8089,18 +8119,18 @@
           </notations>
         </note>
       </measure>
-    <measure number="16" width="298.00">
+    <measure number="16" width="365.96">
       <print new-system="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
       <direction placement="above">
         <direction-type>
-          <wedge type="crescendo" number="1" default-y="35.97" relative-x="-20.12"/>
+          <wedge type="crescendo" number="1" default-y="25.00"/>
           </direction-type>
         </direction>
-      <note default-x="88.64" default-y="-246.00" dynamics="141.11">
+      <note default-x="90.04" default-y="-251.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -8115,15 +8145,15 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <wedge type="stop" number="1" relative-x="-92.11"/>
+          <wedge type="stop" number="1"/>
           </direction-type>
         </direction>
       <direction placement="above">
         <direction-type>
-          <wedge type="diminuendo" number="1" default-y="36.26" relative-x="-4.53"/>
+          <wedge type="diminuendo" number="1" default-y="25.00"/>
           </direction-type>
         </direction>
-      <note default-x="183.09" default-y="-246.00" dynamics="141.11">
+      <note default-x="226.57" default-y="-251.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <alter>1</alter>
@@ -8140,12 +8170,12 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <wedge type="stop" number="1" relative-x="-4.53"/>
+          <wedge type="stop" number="1"/>
           </direction-type>
         </direction>
       </measure>
-    <measure number="17" width="223.18">
-      <note default-x="28.38" default-y="-241.00" dynamics="141.11">
+    <measure number="17" width="290.96">
+      <note default-x="25.83" default-y="-246.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -8160,13 +8190,13 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <dynamics default-x="3.29" default-y="-80.00" relative-x="0.85" relative-y="108.48">
+          <dynamics default-x="3.29" default-y="-80.00" relative-y="95.99">
             <p/>
             </dynamics>
           </direction-type>
         <sound dynamics="66.67"/>
         </direction>
-      <note default-x="111.49" default-y="-251.00" dynamics="141.11">
+      <note default-x="157.42" default-y="-256.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <alter>1</alter>
@@ -8182,8 +8212,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="18" width="280.67">
-      <note default-x="13.64" default-y="-246.00" dynamics="141.11">
+    <measure number="18" width="342.02">
+      <note default-x="13.64" default-y="-251.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -8196,7 +8226,7 @@
           <slur type="start" number="1"/>
           </notations>
         </note>
-      <note default-x="139.08" default-y="-281.00" dynamics="141.11">
+      <note default-x="176.85" default-y="-286.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -8210,13 +8240,18 @@
           </notations>
         </note>
       </measure>
-    <measure number="19" width="189.02">
+    <measure number="19" width="998.94">
+      <print new-page="yes">
+        <staff-layout number="1">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
       <direction placement="above">
         <direction-type>
-          <wedge type="crescendo" number="1" default-y="20.50" relative-x="-14.46"/>
+          <wedge type="crescendo" number="1" default-y="25.00"/>
           </direction-type>
         </direction>
-      <note default-x="29.02" default-y="-266.00" dynamics="141.11">
+      <note default-x="94.28" default-y="-271.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -8240,24 +8275,24 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <wedge type="stop" number="1" relative-x="-14.46"/>
+          <wedge type="stop" number="1"/>
           </direction-type>
         </direction>
       </measure>
-    <measure number="20" width="256.63">
+    <measure number="20" width="255.67">
       <print new-system="yes">
         <staff-layout number="1">
-          <staff-distance>60.00</staff-distance>
+          <staff-distance>65.00</staff-distance>
           </staff-layout>
         </print>
       <direction placement="above">
         <direction-type>
-          <dynamics default-x="6.58" default-y="-80.00" relative-x="1.48" relative-y="93.60">
+          <dynamics default-x="6.58" default-y="-80.00" relative-y="95.99">
             <fp/>
             </dynamics>
           </direction-type>
         </direction>
-      <note default-x="75.87" default-y="-175.00" dynamics="141.11">
+      <note default-x="77.27" default-y="-285.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>1</octave>
@@ -8267,7 +8302,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="75.87" default-y="-140.00" dynamics="141.11">
+      <note default-x="77.27" default-y="-250.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -8280,7 +8315,7 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <wedge type="diminuendo" number="1" default-y="22.22" relative-x="-27.26"/>
+          <wedge type="diminuendo" number="1" default-y="25.00"/>
           </direction-type>
         </direction>
       <note>
@@ -8289,7 +8324,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="187.40" default-y="-140.00" dynamics="141.11">
+      <note default-x="187.11" default-y="-250.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>2</octave>
@@ -8305,7 +8340,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="209.63" default-y="-130.00" dynamics="141.11">
+      <note default-x="209.01" default-y="-240.00" dynamics="141.11">
         <pitch>
           <step>B</step>
           <octave>2</octave>
@@ -8321,7 +8356,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="231.87" default-y="-125.00" dynamics="141.11">
+      <note default-x="230.90" default-y="-235.00" dynamics="141.11">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -8340,19 +8375,19 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <wedge type="stop" number="1" relative-x="-57.26"/>
+          <wedge type="stop" number="1"/>
           </direction-type>
         </direction>
       </measure>
-    <measure number="21" width="242.40">
+    <measure number="21" width="240.04">
       <direction placement="above">
         <direction-type>
-          <dynamics default-x="6.58" default-y="-80.00" relative-x="-27.98" relative-y="100.79">
+          <dynamics default-x="6.58" default-y="-80.00" relative-y="95.99">
             <fp/>
             </dynamics>
           </direction-type>
         </direction>
-      <note default-x="12.00" default-y="-155.00" dynamics="141.11">
+      <note default-x="12.00" default-y="-265.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>2</octave>
@@ -8362,7 +8397,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="12.00" default-y="-120.00" dynamics="141.11">
+      <note default-x="12.00" default-y="-230.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>D</step>
@@ -8379,7 +8414,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note default-x="155.14" default-y="-120.00" dynamics="141.11">
+      <note default-x="153.66" default-y="-230.00" dynamics="141.11">
         <pitch>
           <step>D</step>
           <octave>3</octave>
@@ -8395,7 +8430,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="183.69" default-y="-115.00" dynamics="141.11">
+      <note default-x="181.92" default-y="-225.00" dynamics="141.11">
         <pitch>
           <step>E</step>
           <octave>3</octave>
@@ -8411,7 +8446,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="212.25" default-y="-110.00" dynamics="141.11">
+      <note default-x="210.18" default-y="-220.00" dynamics="141.11">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -8429,8 +8464,8 @@
           </notations>
         </note>
       </measure>
-    <measure number="22" width="293.53">
-      <note default-x="18.05" default-y="-140.00" dynamics="141.11">
+    <measure number="22" width="293.17">
+      <note default-x="18.05" default-y="-250.00" dynamics="141.11">
         <pitch>
           <step>G</step>
           <octave>2</octave>
@@ -8445,7 +8480,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="18.05" default-y="-105.00" dynamics="141.11">
+      <note default-x="18.05" default-y="-215.00" dynamics="141.11">
         <chord/>
         <pitch>
           <step>G</step>
@@ -8456,7 +8491,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="137.17" default-y="-135.00" dynamics="141.11">
+      <note default-x="137.68" default-y="-245.00" dynamics="141.11">
         <pitch>
           <step>A</step>
           <octave>2</octave>
@@ -8476,8 +8511,8 @@
         <repeat direction="backward"/>
         </barline>
       </measure>
-    <measure number="23" width="198.31">
-      <note default-x="12.00" default-y="-155.00">
+    <measure number="23" width="210.07">
+      <note default-x="12.00" default-y="-265.00">
         <pitch>
           <step>D</step>
           <octave>2</octave>
@@ -8493,7 +8528,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="12.00" default-y="-120.00">
+      <note default-x="12.00" default-y="-230.00">
         <chord/>
         <pitch>
           <step>D</step>


### PR DESCRIPTION
LyricExtends are now drawn correctly, previously weren't at all:
![image](https://user-images.githubusercontent.com/33069673/44034272-fc0c13a8-9f0c-11e8-98e5-ed10b9487866.png)

see #317, which discusses some of the changes.

lyricsSpacing was reduced, less necessary as lyricsEntries are now correctly sorted before spacing
also contains some refactors and improved comments.

No breaking changes as far as i can see, tested all demo samples with lyrics.
