### PR TITLE
fix(demo): fix console warning on init

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -4,6 +4,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
 (function () {
     "use strict";
     var openSheetMusicDisplay;
+    var sampleLoaded = false;
     // folder of the sample files
     var sampleFolder = process.env.STATIC_FILES_SUBFOLDER ? process.env.STATIC_FILES_SUBFOLDER + "/" : "",
     samples = {
@@ -122,6 +123,11 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
         // Set resize event handler
         new Resize(
             function(){
+                if (!sampleLoaded) {
+                    return;
+                }
+            },
+            function(){
                 disable();
             },
             function() {
@@ -229,6 +235,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
     }
 
     function onLoadingEnd(isCustom) {
+        sampleLoaded = true;
         // Remove option from select
         if (!isCustom && custom.parentElement === selectSample) {
             selectSample.removeChild(custom);

--- a/demo/index.js
+++ b/demo/index.js
@@ -126,11 +126,14 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
                 if (!sampleLoaded) {
                     return;
                 }
-            },
-            function(){
+
                 disable();
-            },
-            function() {
+                },
+            function(){
+                if (!sampleLoaded) {
+                    return;
+                }
+
                 var width = document.body.clientWidth;
                 canvas.width = width;
                 try {

--- a/demo/index.js
+++ b/demo/index.js
@@ -126,6 +126,8 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
                 if (!sampleLoaded) {
                     return;
                 }
+            },
+            function(){
                 disable();
             },
             function() {

--- a/demo/index.js
+++ b/demo/index.js
@@ -126,8 +126,6 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
                 if (!sampleLoaded) {
                     return;
                 }
-            },
-            function(){
                 disable();
             },
             function() {


### PR DESCRIPTION
Without the fix right now we get an error in the console when starting the demo, which is a bit annoying:
![image](https://user-images.githubusercontent.com/33069673/44478256-673bfa80-a63d-11e8-9d07-0683a0d80e67.png)
(see StackTrace at bottom)

This is because in index.js.init(), we call index.js.Resize(...,endCallback), which calls opensheetmusicdisplay.render(), before we loaded a sample.

Of course the demo doesn't have to be perfectly coded, but it's a bit strange to call new Resize() (index.js:194) on a function Resize(), which gets executed immediately, and the error is annoying. (We only recently started showing this error with console.warn() in index.js:133)

In any case, i used a sampleLoaded boolean and this fixes the error on initialization.

<details>
  <summary>
    StackTrace
  </summary>
```
Error: OpenSheetMusicDisplay: Before rendering a music sheet, please load a MusicXML file
    at OpenSheetMusicDisplay../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts.OpenSheetMusicDisplay.render (OpenSheetMusicDisplay.ts:137)
    at index.js:131
(anonymous) @ index.js:133
setTimeout (async)
Resize @ index.js:194
init @ index.js:123
(anonymous) @ index.js:277
load (async)
(anonymous) @ index.js:276
./demo/index.js @ index.js:314
__webpack_require__ @ bootstrap:19
2 @ demo.js:82981
__webpack_require__ @ bootstrap:19
(anonymous) @ bootstrap:83
(anonymous) @ bootstrap:83
webpackUniversalModuleDefinition @ universalModuleDefinition:9
(anonymous) @ universalModuleDefinition:10