### PR TITLE
chore(debug-release): add osmd.debug.js to release

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "build:doc": "cross-env STATIC_FILES_SUBFOLDER=sheets npm run build",
     "build:webpack": "webpack --progress --colors --config webpack.prod.js",
     "build:webpack-dev": "webpack --progress --colors --config webpack.dev.js",
+    "build:webpack-common": "webpack --progress --colors --config webpack.common.js",
+    "stage": "npm run build && npm run build:webpack-dev",
     "start": "webpack-dev-server --progress --colors --config webpack.dev.js",
     "fix-memory-limit": "increase-memory-limit"
   },
@@ -25,6 +27,7 @@
   "files": [
     "build/dist/src",
     "build/opensheetmusicdisplay.min.js",
+    "build/opensheetmusicdisplay.debug.js",
     "AUTHORS",
     "CHANGELOG.md",
     "README.md",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,7 +1,47 @@
 var merge = require('webpack-merge')
+var path = require('path')
 var common = require('./webpack.common.js')
 
+// var webpack = require('webpack')
+// var Visualizer = require('webpack-visualizer-plugin')
+// const MinifyPlugin = require('babel-minify-webpack-plugin')
+
 module.exports = merge(common, {
-    devtool: 'inline-source-map',
-    mode: 'development'
+    output: {
+        path: path.resolve(__dirname, 'build'),
+        filename: '[name].debug.js',
+        library: 'opensheetmusicdisplay',
+        libraryTarget: 'umd'
+    },
+    optimization: {
+        minimize: false
+        // splitChunks: {
+        //     chunks: 'all',
+        //     name: false
+        // }
+    },
+    mode: 'development',
+    devtool: 'source-map', // inline-source-map makes the debug.js 7.5MB instead of 2.8MB
+    plugins: [
+        // build optimization plugins
+        /*
+        new webpack.LoaderOptionsPlugin({
+            minimize: false,
+            debug: false
+        }),
+        */
+
+        /* useful size statistics, enable this temporarily to check where the size of the debug file comes from
+        new Visualizer({
+            path: path.resolve(__dirname, 'build'),
+            filename: './statistics.html'
+        }),
+        */
+
+        /*
+        new MinifyPlugin(true, {
+            exclude: './src/*'
+        })
+        */
+    ]
 })

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -18,6 +18,7 @@ module.exports = merge(common, {
         libraryTarget: 'umd'
     },
     mode: 'production',
+    devtool: 'source-map',
     optimization: {
         minimize: true
         // splitChunks: {


### PR DESCRIPTION
As discussed in #333, it would be nice to have a non-minified debug release of OSMD, where people can inspect the code running in their installed node module of OSMD if they decide to use the debug.js.

For a new release, we can run `npm run stage`, which builds the minified and the debug release, like `grunt stage` in Vexflow. When we push the release to npm, the debug.js (2.8MB) should be included, along with the min.js (1.09MB).

An alternative to the debug release would be using the source map (3.8MB) and including it with the min.js in the release.

Vexflow releases a debug version too and it has helped me quickly test things by changing the debug release code in the node module folder.

I would have liked to selectively minify Vexflow (880KB) and/or other node modules (1.5MB total), but i didn't figure out how. The babel-minify-webpack-plugin has an exclude option, but i couldn't get it to work. I'm not really an expert on Webpack.

If you enable Webpack Visualizer in webpack.dev.js, you can [see space usage stats for the (debug) release](https://user-images.githubusercontent.com/33069673/44587772-3df1aa80-a7b4-11e8-943f-f179a1295b6d.png) in build/Statistics.html (12MB).
