### PR TITLE
Fix error loading empty score, improve error handling

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -141,7 +141,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
                 try {
                     openSheetMusicDisplay.render();
                 } catch (e) {
-                    console.warn(e.stack);
+                    errorLoadingOrRenderingSheet(e, "rendering");
                 }
                 enable();
             }
@@ -225,18 +225,24 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
                 return openSheetMusicDisplay.render();
             },
             function(e) {
-                console.warn(e.stack);
-                error("Error reading sheet: " + e);
+                errorLoadingOrRenderingSheet(e, "rendering");
             }
         ).then(
             function() {
                 return onLoadingEnd(isCustom);
             }, function(e) {
-                console.warn("Error rendering sheet: " + e + " StackTrace: \n" + e.stack);
-                error("Error rendering sheet: " + process.env.DEBUG ? e.stack : e);
+                errorLoadingOrRenderingSheet(e, "loading");
                 onLoadingEnd(isCustom);
             }
         );
+    }
+
+    function errorLoadingOrRenderingSheet(e, loadingOrRenderingString) {
+        var errorString = "Error " + loadingOrRenderingString + " sheet: " + e;
+        if (process.env.DEBUG) {
+            errorString += "\n" + "StackTrace: \n" + e.stack;
+        }
+        console.warn(errorString);
     }
 
     function onLoadingEnd(isCustom) {

--- a/demo/index.js
+++ b/demo/index.js
@@ -239,9 +239,9 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
 
     function errorLoadingOrRenderingSheet(e, loadingOrRenderingString) {
         var errorString = "Error " + loadingOrRenderingString + " sheet: " + e;
-        if (process.env.DEBUG) {
-            errorString += "\n" + "StackTrace: \n" + e.stack;
-        }
+        // if (process.env.DEBUG) { // people may not set an environment variable for debug.
+        errorString += "\n" + "StackTrace: \n" + e.stack;
+        // }
         console.warn(errorString);
     }
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -239,7 +239,9 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
 
     function errorLoadingOrRenderingSheet(e, loadingOrRenderingString) {
         var errorString = "Error " + loadingOrRenderingString + " sheet: " + e;
-        // if (process.env.DEBUG) { // people may not set an environment variable for debug.
+        // if (process.env.DEBUG) { // people may not set a debug environment variable for the demo.
+        // Always giving a StackTrace might give us more and better error reports.
+        // TODO for a release, StackTrace control could be reenabled
         errorString += "\n" + "StackTrace: \n" + e.stack;
         // }
         console.warn(errorString);

--- a/demo/index.js
+++ b/demo/index.js
@@ -113,7 +113,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
             openSheetMusicDisplay.DrawSkyLine = !openSheetMusicDisplay.DrawSkyLine;
         }
 
-        bottomlineDebug .onclick = function() {
+        bottomlineDebug.onclick = function() {
             openSheetMusicDisplay.DrawBottomLine = !openSheetMusicDisplay.DrawBottomLine;
         }
 
@@ -232,7 +232,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
             function() {
                 return onLoadingEnd(isCustom);
             }, function(e) {
-                console.warn(e.stack);
+                console.warn("Error rendering sheet: " + e + " StackTrace: \n" + e.stack);
                 error("Error rendering sheet: " + process.env.DEBUG ? e.stack : e);
                 onLoadingEnd(isCustom);
             }

--- a/external/vexflow/vexflow.d.ts
+++ b/external/vexflow/vexflow.d.ts
@@ -96,6 +96,7 @@ declare namespace Vex {
             public x_shift: number;
             public getAbsoluteX(): number;
             public addModifier(index: number, modifier: Modifier): StemmableNote;
+            public preFormatted: boolean;
         }
 
         export class GhostNote extends StemmableNote {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -644,6 +644,9 @@ export class VexFlowMeasure extends GraphicalMeasure {
         const voices: Voice[] = this.getVoicesWithinMeasure();
 
         for (const voice of voices) {
+            if (voice === undefined) {
+                continue;
+            }
             const isMainVoice: boolean = !(voice instanceof LinkedVoice);
 
             // add a vexFlow voice for this voice:

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -118,7 +118,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             }
         }
         if (voices.length === 0) {
-            log.warn("Found a measure with no voices... Continuing anyway.", mvoices);
+            log.info("Found a measure with no voices. Continuing anyway.", mvoices);
             continue;
         }
         // all voices that belong to one stave are collectively added to create a common context in VexFlow.

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -27,17 +27,11 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
         for (const gve of this.graphicalVoiceEntries as VexFlowVoiceEntry[]) {
             if (gve.vfStaveNote) {
                 gve.vfStaveNote.setStave(stave);
-                try {
-                    gve.applyBordersFromVexflow();
-                    this.PositionAndShape.RelativePosition.x = gve.vfStaveNote.getBoundingBox().x / unitInPixels;
-                } catch (ex) {
-                    if (ex.toString().indexOf("UnformattedNote") !== -1) {
-                        // can't call getBoundingBox on unformatted note. do nothing.
-                    } else {
-                        throw new Error(ex);
-                        // there shouldn't be other errors. If there are, we need to add handling of them
-                    }
+                if (!gve.vfStaveNote.preFormatted) {
+                    continue;
                 }
+                gve.applyBordersFromVexflow();
+                this.PositionAndShape.RelativePosition.x = gve.vfStaveNote.getBoundingBox().x / unitInPixels;
                 if (gve.PositionAndShape.BorderLeft < lastBorderLeft) {
                     lastBorderLeft = gve.PositionAndShape.BorderLeft;
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -27,8 +27,16 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
         for (const gve of this.graphicalVoiceEntries as VexFlowVoiceEntry[]) {
             if (gve.vfStaveNote) {
                 gve.vfStaveNote.setStave(stave);
-                gve.applyBordersFromVexflow();
-                this.PositionAndShape.RelativePosition.x = gve.vfStaveNote.getBoundingBox().x / unitInPixels;
+                try {
+                    gve.applyBordersFromVexflow();
+                    this.PositionAndShape.RelativePosition.x = gve.vfStaveNote.getBoundingBox().x / unitInPixels;
+                } catch (ex) {
+                    if (ex.toString().indexOf("UnformattedNote") !== -1) {
+                        // can't call getBoundingBox on unformatted note. do nothing.
+                    } else {
+                        throw new Error(ex); // TODO error handling
+                    }
+                }
                 if (gve.PositionAndShape.BorderLeft < lastBorderLeft) {
                     lastBorderLeft = gve.PositionAndShape.BorderLeft;
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -34,7 +34,8 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                     if (ex.toString().indexOf("UnformattedNote") !== -1) {
                         // can't call getBoundingBox on unformatted note. do nothing.
                     } else {
-                        throw new Error(ex); // TODO error handling
+                        throw new Error(ex);
+                        // there shouldn't be other errors. If there are, we need to add handling of them
                     }
                 }
                 if (gve.PositionAndShape.BorderLeft < lastBorderLeft) {

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -64,6 +64,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
             return this._createMusicSheet(root, path);
         } catch (e) {
             log.info("MusicSheetReader.CreateMusicSheet", e);
+            return undefined;
         }
     }
 
@@ -118,10 +119,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
         if (root === undefined) {
             throw new MusicSheetReadingException("Undefined root element");
         }
-        const pushSheetLabelsSuccess: boolean = this.pushSheetLabels(root, path);
-        if (!pushSheetLabelsSuccess) {
-            return undefined;
-        }
+        this.pushSheetLabels(root, path);
         const partlistNode: IXmlElement = root.element("part-list");
         if (partlistNode === undefined) {
             throw new MusicSheetReadingException("Undefined partListNode");
@@ -486,7 +484,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
      * @param root
      * @param filePath
      */
-    private pushSheetLabels(root: IXmlElement, filePath: string): boolean {
+    private pushSheetLabels(root: IXmlElement, filePath: string): void {
         this.readComposer(root);
         this.readTitle(root);
         try {
@@ -501,10 +499,8 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
                 const filenameSplits: string[] = filename.split(".", 1);
                 this.musicSheet.Title = new Label(filenameSplits[0]);
             }
-            return true;
         } catch (ex) {
             log.debug("MusicSheetReader.pushSheetLabels: ", ex);
-            return false;
         }
     }
 

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -500,7 +500,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
                 this.musicSheet.Title = new Label(filenameSplits[0]);
             }
         } catch (ex) {
-            log.debug("Error reading title or composer in MusicSheetReader.pushSheetLabels: ", ex);
+            log.info("MusicSheetReader.pushSheetLabels", "read title or composer", ex);
         }
     }
 
@@ -611,8 +611,13 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
         }
         let paperHeight: number = 0;
         let topSystemDistance: number = 0;
-        const defi: string = root.element("defaults").element("page-layout").element("page-height").value;
-        paperHeight = parseFloat(defi);
+        try {
+            const defi: string = root.element("defaults").element("page-layout").element("page-height").value;
+            paperHeight = parseFloat(defi);
+        } catch (e) {
+            log.info("MusicSheetReader.computeSystemYCoordinates(): couldn't find page height, not reading title/composer.");
+            return 0;
+        }
         let found: boolean = false;
         const parts: IXmlElement[] = root.elements("part");
         for (let idx: number = 0, len: number = parts.length; idx < len; ++idx) {

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -489,7 +489,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
         this.readTitle(root);
         try {
             if (this.musicSheet.Title === undefined || this.musicSheet.Composer === undefined) {
-                this.readTitleAndComposerFromCredits(root);
+                this.readTitleAndComposerFromCredits(root); // this can also throw an error
             }
             if (this.musicSheet.Title === undefined) {
                 const barI: number = Math.max(
@@ -500,7 +500,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
                 this.musicSheet.Title = new Label(filenameSplits[0]);
             }
         } catch (ex) {
-            log.debug("MusicSheetReader.pushSheetLabels: ", ex);
+            log.debug("Error reading title or composer in MusicSheetReader.pushSheetLabels: ", ex);
         }
     }
 

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -118,7 +118,10 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
         if (root === undefined) {
             throw new MusicSheetReadingException("Undefined root element");
         }
-        this.pushSheetLabels(root, path);
+        const pushSheetLabelsSuccess: boolean = this.pushSheetLabels(root, path);
+        if (!pushSheetLabelsSuccess) {
+            return undefined;
+        }
         const partlistNode: IXmlElement = root.element("part-list");
         if (partlistNode === undefined) {
             throw new MusicSheetReadingException("Undefined partListNode");
@@ -483,24 +486,25 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
      * @param root
      * @param filePath
      */
-    private pushSheetLabels(root: IXmlElement, filePath: string): void {
+    private pushSheetLabels(root: IXmlElement, filePath: string): boolean {
         this.readComposer(root);
         this.readTitle(root);
-        if (this.musicSheet.Title === undefined || this.musicSheet.Composer === undefined) {
-            this.readTitleAndComposerFromCredits(root);
-        }
-        if (this.musicSheet.Title === undefined) {
-            try {
+        try {
+            if (this.musicSheet.Title === undefined || this.musicSheet.Composer === undefined) {
+                this.readTitleAndComposerFromCredits(root);
+            }
+            if (this.musicSheet.Title === undefined) {
                 const barI: number = Math.max(
                     0, filePath.lastIndexOf("/"), filePath.lastIndexOf("\\")
                 );
                 const filename: string = filePath.substr(barI);
                 const filenameSplits: string[] = filename.split(".", 1);
                 this.musicSheet.Title = new Label(filenameSplits[0]);
-            } catch (ex) {
-                log.info("MusicSheetReader.pushSheetLabels: ", ex);
             }
-
+            return true;
+        } catch (ex) {
+            log.debug("MusicSheetReader.pushSheetLabels: ", ex);
+            return false;
         }
     }
 

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -491,6 +491,10 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
             if (this.musicSheet.Title === undefined || this.musicSheet.Composer === undefined) {
                 this.readTitleAndComposerFromCredits(root); // this can also throw an error
             }
+        } catch (ex) {
+            log.info("MusicSheetReader.pushSheetLabels", "readTitleAndComposerFromCredits", ex);
+        }
+        try {
             if (this.musicSheet.Title === undefined) {
                 const barI: number = Math.max(
                     0, filePath.lastIndexOf("/"), filePath.lastIndexOf("\\")
@@ -500,7 +504,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
                 this.musicSheet.Title = new Label(filenameSplits[0]);
             }
         } catch (ex) {
-            log.info("MusicSheetReader.pushSheetLabels", "read title or composer", ex);
+            log.info("MusicSheetReader.pushSheetLabels", "read title from file name", ex);
         }
     }
 

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -123,6 +123,10 @@ export class OpenSheetMusicDisplay {
         const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();
         const reader: MusicSheetReader = new MusicSheetReader();
         this.sheet = reader.createMusicSheet(score, "Unknown path");
+        if (this.sheet === undefined) {
+            // error loading sheet, probably already logged, do nothing
+            return Promise.reject(new Error("given music sheet was incomplete or could not be loaded."));
+        }
         this.graphic = new GraphicalMusicSheet(this.sheet, calc);
         this.cursor.init(this.sheet.MusicPartManager, this.graphic);
         log.info(`Loaded sheet ${this.sheet.TitleString} successfully.`);

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -122,7 +122,7 @@ export class OpenSheetMusicDisplay {
         const score: IXmlElement = new IXmlElement(elem);
         const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();
         const reader: MusicSheetReader = new MusicSheetReader();
-        this.sheet = reader.createMusicSheet(score, "Unknown path");
+        this.sheet = reader.createMusicSheet(score, "Untitled Score");
         if (this.sheet === undefined) {
             // error loading sheet, probably already logged, do nothing
             return Promise.reject(new Error("given music sheet was incomplete or could not be loaded."));


### PR DESCRIPTION
Can now render an empty score, Fixes #358 (see top comment there for XML sample)
![image](https://user-images.githubusercontent.com/33069673/45029723-e8d25600-b049-11e8-8a91-47d1eca54ecf.png)

Adds general improvements to error handling (undefined voices, parsing, calling getBoundingBox() on unformatted StaveNotes).

OSMD now returns an error if the MusicSheet read was undefined. Previously, this would cause random Errors and StackTraces in new GraphicalMusicSheet() (e.g. Staves undefined).

Also changed log.warn to log.info for a measure without voices in VexFlowMusicSheetCalculator.
log.warn produces warnings for the end user.

This still doesn't include XML verification, but one incomplete XML i tried simply gave another empty score, another returned an error "Error: given music sheet was incomplete or could not be loaded", as designed.
Discussion of validation in #358.