### PR TITLE
feat: options interface for osmd constructor

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -121,7 +121,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
         openSheetMusicDisplay = new OpenSheetMusicDisplay(canvas, {
             autoResize: false,
             backend: backendSelect.value,
-            drawingParametersString: "default",
+            drawingParameters: "default",
             disableCursor: false,
         });
         openSheetMusicDisplay.setLogLevel('info');

--- a/demo/index.js
+++ b/demo/index.js
@@ -113,12 +113,17 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
             openSheetMusicDisplay.DrawSkyLine = !openSheetMusicDisplay.DrawSkyLine;
         }
 
-        bottomlineDebug .onclick = function() {
+        bottomlineDebug.onclick = function() {
             openSheetMusicDisplay.DrawBottomLine = !openSheetMusicDisplay.DrawBottomLine;
         }
 
         // Create OSMD object and canvas
-        openSheetMusicDisplay = new OpenSheetMusicDisplay(canvas, false, backendSelect.value);
+        openSheetMusicDisplay = new OpenSheetMusicDisplay(canvas, {
+            autoResize: false,
+            backend: backendSelect.value,
+            drawingParametersString: "default",
+            disableCursor: false,
+        });
         openSheetMusicDisplay.setLogLevel('info');
         document.body.appendChild(canvas);
 
@@ -163,7 +168,11 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
             openSheetMusicDisplay.cursor.hide();
         });
         showCursorBtn.addEventListener("click", function() {
-            openSheetMusicDisplay.cursor.show();
+            if (openSheetMusicDisplay.cursor) {
+                openSheetMusicDisplay.cursor.show();
+            } else {
+                console.info("can't show cursor, cursor was disabled by drawingParameters!");
+            }
         });
 
         backendSelect.addEventListener("change", function(e) {

--- a/demo/index.js
+++ b/demo/index.js
@@ -119,7 +119,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
 
         // Create OSMD object and canvas
         openSheetMusicDisplay = new OpenSheetMusicDisplay(canvas, {
-            autoResize: false,
+            autoResize: true,
             backend: backendSelect.value,
             drawingParameters: "default",
             disableCursor: false,
@@ -187,7 +187,6 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
     }
 
     function Resize(startCallback, endCallback) {
-
       var rtime;
       var timeout = false;
       var delta = 200;

--- a/demo/index.js
+++ b/demo/index.js
@@ -171,7 +171,7 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
             if (openSheetMusicDisplay.cursor) {
                 openSheetMusicDisplay.cursor.show();
             } else {
-                console.info("can't show cursor, cursor was disabled by drawingParameters!");
+                console.info("Can't show cursor, as it was disabled (e.g. by drawingParameters).");
             }
         });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,7 +81,7 @@ module.exports = function (config) {
         client: {
             captureConsole: true,
             mocha: {
-                timeout: process.env.timeout || 2000
+                timeout: process.env.timeout || 6000
             }
         },
 

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -38,16 +38,14 @@ export class DrawingParameters {
     public set DrawingParametersEnum(drawingParametersEnum: DrawingParametersEnum) {
         this.drawingParametersEnum = drawingParametersEnum;
         switch (drawingParametersEnum) {
-            case DrawingParametersEnum.Default:
-            case DrawingParametersEnum.AllOn:
-                this.setForAllOn();
-                break;
             case DrawingParametersEnum.Thumbnail:
-                this.setForThumbnail();
-                break;
+            this.setForThumbnail();
+            break;
             case DrawingParametersEnum.Leadsheet:
-                this.setForLeadsheet();
-                break;
+            this.setForLeadsheet();
+            break;
+            case DrawingParametersEnum.AllOn:
+            case DrawingParametersEnum.Default:
             default:
                 this.setForAllOn();
         }

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -1,4 +1,13 @@
+export enum DrawingParametersEnum {
+    AllOn,
+    Default, // default is AllOn for now
+    Leadsheet,
+    Preview,
+    Thumbnail,
+}
+
 export class DrawingParameters {
+    private drawingParametersEnum: DrawingParametersEnum; // will control other settings if changed with set method
     public drawHighlights: boolean;
     public drawErrors: boolean;
     public drawSelectionStartSymbol: boolean;
@@ -8,6 +17,45 @@ export class DrawingParameters {
     public drawScrollIndicator: boolean;
     public drawComments: boolean;
     public drawMarkedAreas: boolean;
+
+    public static DrawingParametersStringToEnum(stringParameter: string): DrawingParametersEnum {
+        switch (stringParameter.toLowerCase()) {
+            case "allOn":
+                return DrawingParametersEnum.AllOn;
+            case "default":
+                return DrawingParametersEnum.Default;
+            case "leadsheet":
+                return DrawingParametersEnum.Leadsheet;
+            case "preview":
+                return DrawingParametersEnum.Preview;
+            case "thumbnail":
+                return DrawingParametersEnum.Thumbnail;
+            default:
+                return DrawingParametersEnum.Default;
+        }
+    }
+
+    public set DrawingParametersEnum(drawingParametersEnum: DrawingParametersEnum) {
+        this.drawingParametersEnum = drawingParametersEnum;
+        switch (drawingParametersEnum) {
+            case DrawingParametersEnum.Default:
+            case DrawingParametersEnum.AllOn:
+                this.setForAllOn();
+                break;
+            case DrawingParametersEnum.Thumbnail:
+                this.setForThumbnail();
+                break;
+            case DrawingParametersEnum.Leadsheet:
+                this.setForLeadsheet();
+                break;
+            default:
+                this.setForAllOn();
+        }
+    }
+
+    public get DrawingParametersEnum(): DrawingParametersEnum {
+        return this.drawingParametersEnum;
+    }
 
     public setForAllOn(): void {
         this.drawHighlights = true;
@@ -21,7 +69,7 @@ export class DrawingParameters {
         this.drawMarkedAreas = true;
     }
 
-    public setForThumbmail(): void {
+    public setForThumbnail(): void {
         this.drawHighlights = false;
         this.drawErrors = false;
         this.drawSelectionStartSymbol = false;

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -24,6 +24,8 @@ export class DrawingParameters {
     public drawPartName: boolean = true;
     /** Draw notes set to be invisible (print-object="no" in XML). */
     public drawHiddenNotes: boolean = false;
+    public defaultColorNoteHead: string; // TODO not yet supported
+    public defaultColorStem: string; // TODO not yet supported
 
     constructor(drawingParameters: DrawingParametersEnum = DrawingParametersEnum.Default) {
         this.DrawingParametersEnum = drawingParameters;

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -19,6 +19,10 @@ export class DrawingParameters {
     public drawComments: boolean;
     public drawMarkedAreas: boolean;
 
+    constructor(drawingParameters: DrawingParametersEnum = DrawingParametersEnum.Default) {
+        this.DrawingParametersEnum = drawingParameters;
+    }
+
     public set DrawingParametersEnum(drawingParametersEnum: DrawingParametersEnum) {
         this.drawingParametersEnum = drawingParametersEnum;
         switch (drawingParametersEnum) {

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -1,5 +1,6 @@
 export enum DrawingParametersEnum {
     AllOn = "allon",
+    Compact = "compact",
     Default = "default", // default is AllOn for now
     Leadsheet = "leadsheet",
     Preview = "preview",
@@ -18,11 +19,15 @@ export class DrawingParameters {
     public drawScrollIndicator: boolean;
     public drawComments: boolean;
     public drawMarkedAreas: boolean;
+    public drawTitle: boolean = true;
+    public drawCredits: boolean = true;
+    public drawPartName: boolean = true;
 
     constructor(drawingParameters: DrawingParametersEnum = DrawingParametersEnum.Default) {
         this.DrawingParametersEnum = drawingParameters;
     }
 
+    /** Sets drawing parameters enum and changes settings flags accordingly. */
     public set DrawingParametersEnum(drawingParametersEnum: DrawingParametersEnum) {
         this.drawingParametersEnum = drawingParametersEnum;
         switch (drawingParametersEnum) {
@@ -31,6 +36,9 @@ export class DrawingParameters {
                 break;
             case DrawingParametersEnum.Leadsheet:
                 this.setForLeadsheet();
+                break;
+            case DrawingParametersEnum.Compact:
+                this.setForCompactMode();
                 break;
             case DrawingParametersEnum.AllOn:
             case DrawingParametersEnum.Default:
@@ -53,6 +61,9 @@ export class DrawingParameters {
         this.drawScrollIndicator = true;
         this.drawComments = true;
         this.drawMarkedAreas = true;
+        this.drawTitle = true;
+        this.drawCredits = true;
+        this.drawPartName = true;
     }
 
     public setForThumbnail(): void {
@@ -65,6 +76,12 @@ export class DrawingParameters {
         this.drawScrollIndicator = false;
         this.drawComments = true;
         this.drawMarkedAreas = true;
+    }
+
+    public setForCompactMode(): void {
+        this.drawTitle = false;
+        this.drawCredits = false;
+        this.drawPartName = false;
     }
 
     public setForLeadsheet(): void {

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -1,7 +1,7 @@
 export enum DrawingParametersEnum {
     AllOn = "allon",
     Compact = "compact",
-    Default = "default", // default is AllOn for now
+    Default = "default",
     Leadsheet = "leadsheet",
     Preview = "preview",
     Thumbnail = "thumbnail",
@@ -22,6 +22,8 @@ export class DrawingParameters {
     public drawTitle: boolean = true;
     public drawCredits: boolean = true;
     public drawPartName: boolean = true;
+    /** Draw notes set to be invisible (print-object="no" in XML). */
+    public drawHiddenNotes: boolean = false;
 
     constructor(drawingParameters: DrawingParametersEnum = DrawingParametersEnum.Default) {
         this.DrawingParametersEnum = drawingParameters;
@@ -31,6 +33,9 @@ export class DrawingParameters {
     public set DrawingParametersEnum(drawingParametersEnum: DrawingParametersEnum) {
         this.drawingParametersEnum = drawingParametersEnum;
         switch (drawingParametersEnum) {
+            case DrawingParametersEnum.AllOn:
+                this.setForAllOn();
+                break;
             case DrawingParametersEnum.Thumbnail:
                 this.setForThumbnail();
                 break;
@@ -40,10 +45,9 @@ export class DrawingParameters {
             case DrawingParametersEnum.Compact:
                 this.setForCompactMode();
                 break;
-            case DrawingParametersEnum.AllOn:
             case DrawingParametersEnum.Default:
             default:
-                this.setForAllOn();
+                this.setForDefault();
         }
     }
 
@@ -64,6 +68,12 @@ export class DrawingParameters {
         this.drawTitle = true;
         this.drawCredits = true;
         this.drawPartName = true;
+        this.drawHiddenNotes = true;
+    }
+
+    public setForDefault(): void {
+        this.setForAllOn();
+        this.drawHiddenNotes = false;
     }
 
     public setForThumbnail(): void {
@@ -76,12 +86,14 @@ export class DrawingParameters {
         this.drawScrollIndicator = false;
         this.drawComments = true;
         this.drawMarkedAreas = true;
+        this.drawHiddenNotes = false;
     }
 
     public setForCompactMode(): void {
         this.drawTitle = false;
         this.drawCredits = false;
         this.drawPartName = false;
+        this.drawHiddenNotes = false;
     }
 
     public setForLeadsheet(): void {

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -1,9 +1,9 @@
 export enum DrawingParametersEnum {
-    AllOn,
-    Default, // default is AllOn for now
-    Leadsheet,
-    Preview,
-    Thumbnail,
+    AllOn = "allon",
+    Default = "default", // default is AllOn for now
+    Leadsheet = "leadsheet",
+    Preview = "preview",
+    Thumbnail = "thumbnail",
 }
 
 export class DrawingParameters {
@@ -18,23 +18,6 @@ export class DrawingParameters {
     public drawScrollIndicator: boolean;
     public drawComments: boolean;
     public drawMarkedAreas: boolean;
-
-    public static DrawingParametersStringToEnum(stringParameter: string): DrawingParametersEnum {
-        switch (stringParameter.toLowerCase()) {
-            case "allOn":
-                return DrawingParametersEnum.AllOn;
-            case "default":
-                return DrawingParametersEnum.Default;
-            case "leadsheet":
-                return DrawingParametersEnum.Leadsheet;
-            case "preview":
-                return DrawingParametersEnum.Preview;
-            case "thumbnail":
-                return DrawingParametersEnum.Thumbnail;
-            default:
-                return DrawingParametersEnum.Default;
-        }
-    }
 
     public set DrawingParametersEnum(drawingParametersEnum: DrawingParametersEnum) {
         this.drawingParametersEnum = drawingParametersEnum;

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -7,7 +7,8 @@ export enum DrawingParametersEnum {
 }
 
 export class DrawingParameters {
-    private drawingParametersEnum: DrawingParametersEnum; // will control other settings if changed with set method
+    /** will set other settings if changed with set method */
+    private drawingParametersEnum: DrawingParametersEnum;
     public drawHighlights: boolean;
     public drawErrors: boolean;
     public drawSelectionStartSymbol: boolean;
@@ -39,11 +40,11 @@ export class DrawingParameters {
         this.drawingParametersEnum = drawingParametersEnum;
         switch (drawingParametersEnum) {
             case DrawingParametersEnum.Thumbnail:
-            this.setForThumbnail();
-            break;
+                this.setForThumbnail();
+                break;
             case DrawingParametersEnum.Leadsheet:
-            this.setForLeadsheet();
-            break;
+                this.setForLeadsheet();
+                break;
             case DrawingParametersEnum.AllOn:
             case DrawingParametersEnum.Default:
             default:

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -53,14 +53,10 @@ export abstract class MusicSheetDrawer {
     private phonicScoreMode: PhonicScoreModes = PhonicScoreModes.Manual;
 
     constructor(textMeasurer: ITextMeasurer,
-                isPreviewImageDrawer: boolean = false) {
+                drawingParameters: DrawingParameters) {
         this.textMeasurer = textMeasurer;
         this.splitScreenLineColor = -1;
-        if (isPreviewImageDrawer) {
-            this.drawingParameters.setForThumbmail();
-        } else {
-            this.drawingParameters.setForAllOn();
-        }
+        this.drawingParameters = drawingParameters;
     }
 
     public set Mode(value: PhonicScoreModes) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -23,7 +23,7 @@ import { PlacementEnum } from "../../VoiceData/Expressions/AbstractExpression";
 import {GraphicalInstantaneousTempoExpression} from "../GraphicalInstantaneousTempoExpression";
 import {GraphicalInstantaneousDynamicExpression} from "../GraphicalInstantaneousDynamicExpression";
 import log = require("loglevel");
-import { DrawingParameters } from "../DrawingParameters";
+import {DrawingParameters} from "../DrawingParameters";
 
 /**
  * This is a global constant which denotes the height in pixels of the space between two lines of the stave
@@ -38,7 +38,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
 
     constructor(element: HTMLElement,
                 backend: VexFlowBackend,
-                drawingParameters: DrawingParameters) {
+                drawingParameters: DrawingParameters = new DrawingParameters()) {
         super(new VexFlowTextMeasurer(), drawingParameters);
         this.backend = backend;
     }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -23,6 +23,7 @@ import { PlacementEnum } from "../../VoiceData/Expressions/AbstractExpression";
 import {GraphicalInstantaneousTempoExpression} from "../GraphicalInstantaneousTempoExpression";
 import {GraphicalInstantaneousDynamicExpression} from "../GraphicalInstantaneousDynamicExpression";
 import log = require("loglevel");
+import { DrawingParameters } from "../DrawingParameters";
 
 /**
  * This is a global constant which denotes the height in pixels of the space between two lines of the stave
@@ -37,8 +38,8 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
 
     constructor(element: HTMLElement,
                 backend: VexFlowBackend,
-                isPreviewImageDrawer: boolean = false) {
-        super(new VexFlowTextMeasurer(), isPreviewImageDrawer);
+                drawingParameters: DrawingParameters) {
+        super(new VexFlowTextMeasurer(), drawingParameters);
         this.backend = backend;
     }
 

--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -28,6 +28,7 @@ export class Cursor {
   private hidden: boolean = true;
   private cursorElement: HTMLImageElement;
 
+  /** Initialize the cursor. Necessary before using functions like show() and next(). */
   public init(manager: MusicPartManager, graphic: GraphicalMusicSheet): void {
     this.manager = manager;
     this.reset();
@@ -42,9 +43,6 @@ export class Cursor {
   public show(): void {
     this.hidden = false;
     this.update();
-    // Forcing the sheet to re-render is not necessary anymore,
-    // since the cursor is an HTML element.
-    // this.openSheetMusicDisplay.render();
   }
 
   private getStaffEntriesFromVoiceEntry(voiceEntry: VoiceEntry): VexFlowStaffEntry {

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -20,6 +20,12 @@ export interface IOSMDOptions {
     defaultColorNoteHead?: string;
     /** Default color for a note stem. Default black. Not yet supported. */ // TODO
     defaultColorStem?: string;
+    /** Whether to draw the title of the piece. Not yet supported. */ // TODO
+    drawTitle?: boolean;
+    /** Whether to draw credits (title, composer, arranger, copyright etc., see <credit>. Not yet supported. */ // TODO
+    drawCredits?: boolean;
+    /** Whether to draw part (instrument) names. Not yet supported. */ // TODO
+    drawPartName?: boolean;
 }
 
 /** Handles [[IOSMDOptions]], e.g. returning default options with OSMDOptionsStandard() */

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -2,11 +2,11 @@ import { DrawingParametersEnum } from "../MusicalScore/Graphical/DrawingParamete
 
 /** Possible options for the OpenSheetMusicDisplay constructor, none are mandatory. */
 export interface IOSMDOptions {
-    /** Not yet supported. Will always beam automatically. */
+    /** Not yet supported. Will always beam automatically. */ // TODO
     autoBeam?: boolean;
     /** Automatically resize score with canvas size. Default is true. */
     autoResize?: boolean;
-    /** Not yet supported. Will always place stems automatically. */
+    /** Not yet supported. Will always place stems automatically. */ // TODO
     autoStem?: boolean;
     /** Render Backend, will be SVG if given undefined, SVG or svg, otherwise Canvas. */
     backend?: string;
@@ -14,6 +14,12 @@ export interface IOSMDOptions {
     disableCursor?: boolean;
     /** Parameters like drawing a Leadsheet or (Thumbnail) Preview, disabling Cursor. */
     drawingParameters?: string | DrawingParametersEnum;
+    /** Whether to draw hidden/invisible notes (print-object="no" in XML). Default false. Not yet supported. */ // TODO
+    drawHiddenNotes?: boolean;
+    /** Default color for a note head (without stem). Default black. Not yet supported. */ // TODO
+    defaultColorNoteHead?: string;
+    /** Default color for a note stem. Default black. Not yet supported. */ // TODO
+    defaultColorStem?: string;
 }
 
 /** Handles [[IOSMDOptions]], e.g. returning default options with OSMDOptionsStandard() */

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -18,7 +18,9 @@ export interface IOSMDOptions {
 
 /** Handles [[IOSMDOptions]], e.g. returning default options with OSMDOptionsStandard() */
 export class OSMDOptions {
-    /** Returns the default options for OSMD used if no options are given in the constructor. */
+    /** Returns the default options for OSMD.
+     * These are e.g. used if no options are given in the [[OpenSheetMusicDisplay]] constructor.
+     */
     public static OSMDOptionsStandard(): IOSMDOptions {
         return {
             autoResize: true,

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -1,0 +1,25 @@
+import { DrawingParametersEnum } from "../MusicalScore/Graphical/DrawingParameters";
+
+/** Possible options for the OpenSheetMusicDisplay constructor, none are mandatory. */
+export interface IOSMDOptions {
+    autoBeam?: boolean; // not yet supported. will always autoBeam.
+    autoResize?: boolean; // default is true
+    autoStem?: boolean; // not yet supported. will always autoStem
+    backend?: string; // Backend will be SVG if backend.toLowerCase === "svg", otherwise Canvas
+    disableCursor?: boolean; // will override this part of drawingParameters
+    drawingParametersEnum?: DrawingParametersEnum; // alternative to using the enum. only need to set one of these.
+    drawingParametersString?: string; // alternative to using the enum. only need to set one of these.
+    // drawingParameters?: DrawingParametersEnum | string; // alternative to using the enum. only need to set one of these.
+}
+
+/** Handles [[IOSMDOptions]], e.g. returning default options with OSMDOptionsStandard() */
+export class OSMDOptions {
+    /** Returns the default options for OSMD used if no options are given in the constructor. */
+    public static OSMDOptionsStandard(): IOSMDOptions {
+        return {
+            autoResize: true,
+            backend: "svg",
+            drawingParametersEnum: DrawingParametersEnum.Default,
+        };
+    }
+}

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -2,14 +2,18 @@ import { DrawingParametersEnum } from "../MusicalScore/Graphical/DrawingParamete
 
 /** Possible options for the OpenSheetMusicDisplay constructor, none are mandatory. */
 export interface IOSMDOptions {
-    autoBeam?: boolean; // not yet supported. will always autoBeam.
-    autoResize?: boolean; // default is true
-    autoStem?: boolean; // not yet supported. will always autoStem
-    backend?: string; // Backend will be SVG if backend.toLowerCase === "svg", otherwise Canvas
-    disableCursor?: boolean; // will override this part of drawingParameters
-    drawingParametersEnum?: DrawingParametersEnum; // alternative to using the enum. only need to set one of these.
-    drawingParametersString?: string; // alternative to using the enum. only need to set one of these.
-    // drawingParameters?: DrawingParametersEnum | string; // alternative to using the enum. only need to set one of these.
+    /** Not yet supported. Will always beam automatically. */
+    autoBeam?: boolean;
+    /** Automatically resize score with canvas size. Default is true. */
+    autoResize?: boolean;
+    /** Not yet supported. Will always place stems automatically. */
+    autoStem?: boolean;
+    /** Render Backend, will be SVG if given undefined, SVG or svg, otherwise Canvas. */
+    backend?: string;
+    /** Don't show/load cursor. Will override disableCursor in drawingParameters. */
+    disableCursor?: boolean;
+    /** Parameters like drawing a Leadsheet or (Thumbnail) Preview, disabling Cursor. */
+    drawingParameters?: string | DrawingParametersEnum;
 }
 
 /** Handles [[IOSMDOptions]], e.g. returning default options with OSMDOptionsStandard() */
@@ -19,7 +23,7 @@ export class OSMDOptions {
         return {
             autoResize: true,
             backend: "svg",
-            drawingParametersEnum: DrawingParametersEnum.Default,
+            drawingParameters: DrawingParametersEnum.Default,
         };
     }
 }

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -36,7 +36,7 @@ export class OpenSheetMusicDisplay {
             throw new Error("Please pass a valid div container to OpenSheetMusicDisplay");
         }
 
-        if (options.backend.toLowerCase() === "svg" || options.backend === undefined) {
+        if (options.backend === undefined || options.backend.toLowerCase() === "svg") {
             this.backend = new SvgVexFlowBackend();
         } else {
             this.backend = new CanvasVexFlowBackend();

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -16,11 +16,20 @@ import * as log from "loglevel";
 import {DrawingParametersEnum, DrawingParameters} from "../MusicalScore/Graphical/DrawingParameters";
 import {IOSMDOptions, OSMDOptions} from "./OSMDOptions";
 
+/**
+ * The main class and control point of OpenSheetMusicDisplay.<br>
+ * It can display MusicXML sheet music files in an HTML element container.<br>
+ * After the constructor, use load() and render() to load and render a MusicXML file.
+ */
 export class OpenSheetMusicDisplay {
     /**
-     * The easy way of displaying a MusicXML sheet music file
-     * @param container is either the ID, or the actual "div" element which will host the music sheet
-     * @param options an options object, see interface [[OSMDOptions]] and the OSMDOptionsStandard method.
+     * Creates and attaches an OpenSheetMusicDisplay object to an HTML element container.<br>
+     * After the constructor, use load() and render() to load and render a MusicXML file.
+     * @param container The container element OSMD will be rendered into.<br>
+     *                  Either a string specifying the ID of an HTML container element,<br>
+     *                  or a reference to the HTML element itself (e.g. div)
+     * @param options An object for rendering options like the backend (svg/canvas) or autoResize.<br>
+     *                For defaults see the OSMDOptionsStandard method in the [[OSMDOptions]] class.
      */
     constructor(container: string|HTMLElement,
                 options: IOSMDOptions = OSMDOptions.OSMDOptionsStandard()) {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -13,20 +13,17 @@ import {MXLHelper} from "../Common/FileIO/Mxl";
 import {Promise} from "es6-promise";
 import {AJAX} from "./AJAX";
 import * as log from "loglevel";
-import { DrawingParametersEnum, DrawingParameters } from "../MusicalScore/Graphical/DrawingParameters";
+import {DrawingParametersEnum, DrawingParameters} from "../MusicalScore/Graphical/DrawingParameters";
+import {IOSMDOptions, OSMDOptions} from "./OSMDOptions";
 
 export class OpenSheetMusicDisplay {
     /**
      * The easy way of displaying a MusicXML sheet music file
      * @param container is either the ID, or the actual "div" element which will host the music sheet
-     * @autoResize automatically resize the sheet to full page width on window resize
+     * @param options an options object, see interface [[OSMDOptions]] and the OSMDOptionsStandard method.
      */
     constructor(container: string|HTMLElement,
-                options: OSMDOptions = {
-                    autoResize: false,
-                    backend: "svg",
-                    drawingParametersEnum: DrawingParametersEnum.Default,
-                }) {
+                options: IOSMDOptions = OSMDOptions.OSMDOptionsStandard()) {
         // Store container element
         if (typeof container === "string") {
             // ID passed
@@ -330,14 +327,4 @@ export class OpenSheetMusicDisplay {
         return this.drawer.drawableBoundingBoxElement;
     }
     //#endregion
-}
-
-export interface OSMDOptions {
-    autoBeam?: boolean; // not yet supported. will always autoBeam.
-    autoResize?: boolean; // default is false
-    autoStem?: boolean; // not yet supported. will always autoStem
-    backend?: string; // Backend will be SVG if backend === "svg", otherwise Canvas
-    disableCursor?: boolean; // will override this part of drawingParameters
-    drawingParametersEnum?: DrawingParametersEnum;
-    drawingParametersString?: string; // alternative to using the enum. only need to set one of these.
 }

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -43,12 +43,11 @@ export class OpenSheetMusicDisplay {
         }
 
         this.drawingParameters = new DrawingParameters();
-        if (options.drawingParametersEnum) {
-            this.drawingParameters.DrawingParametersEnum = options.drawingParametersEnum;
-        } else if (options.drawingParametersString) {
-            this.drawingParameters.DrawingParametersEnum =
-                DrawingParameters.DrawingParametersStringToEnum(options.drawingParametersString);
-        } else {
+        if (options.drawingParameters) {
+            this.drawingParameters.DrawingParametersEnum = DrawingParametersEnum[options.drawingParameters];
+            // can be undefined if invalid value (or none) given in options
+        }
+        if (this.drawingParameters.DrawingParametersEnum === undefined) {
             this.drawingParameters.DrawingParametersEnum = DrawingParametersEnum.Default;
         }
 

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -45,10 +45,6 @@ export class OpenSheetMusicDisplay {
         this.drawingParameters = new DrawingParameters();
         if (options.drawingParameters) {
             this.drawingParameters.DrawingParametersEnum = DrawingParametersEnum[options.drawingParameters];
-            // can be undefined if invalid value (or none) given in options
-        }
-        if (this.drawingParameters.DrawingParametersEnum === undefined) {
-            this.drawingParameters.DrawingParametersEnum = DrawingParametersEnum.Default;
         }
 
         if (options.disableCursor) {
@@ -233,6 +229,7 @@ export class OpenSheetMusicDisplay {
      * Attach the appropriate handler to the window.onResize event
      */
     private autoResize(): void {
+
         const self: OpenSheetMusicDisplay = this;
         this.handleResize(
             () => {
@@ -249,7 +246,9 @@ export class OpenSheetMusicDisplay {
                 //    document.documentElement.offsetWidth
                 //);
                 //self.container.style.width = width + "px";
-                self.render();
+                if (this.graphic !== undefined) {
+                    self.render();
+                }
             }
         );
     }
@@ -260,6 +259,9 @@ export class OpenSheetMusicDisplay {
      * @param endCallback is the function called when resizing (kind-of) ends
      */
     private handleResize(startCallback: () => void, endCallback: () => void): void {
+        if (this.graphic === undefined) {
+            return;
+        }
         let rtime: number;
         let timeout: number = undefined;
         const delta: number = 200;

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -39,7 +39,7 @@ export class OpenSheetMusicDisplay {
             throw new Error("Please pass a valid div container to OpenSheetMusicDisplay");
         }
 
-        if (options.backend === "svg" || options.backend === undefined) {
+        if (options.backend.toLowerCase() === "svg" || options.backend === undefined) {
             this.backend = new SvgVexFlowBackend();
         } else {
             this.backend = new CanvasVexFlowBackend();
@@ -334,10 +334,10 @@ export class OpenSheetMusicDisplay {
 
 export interface OSMDOptions {
     autoBeam?: boolean; // not yet supported. will always autoBeam.
-    autoResize?: boolean;
+    autoResize?: boolean; // default is false
     autoStem?: boolean; // not yet supported. will always autoStem
-    backend?: string;
+    backend?: string; // Backend will be SVG if backend === "svg", otherwise Canvas
     disableCursor?: boolean; // will override this part of drawingParameters
     drawingParametersEnum?: DrawingParametersEnum;
     drawingParametersString?: string; // alternative to using the enum. only need to set one of these.
-  }
+}

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -331,6 +331,15 @@ export class OpenSheetMusicDisplay {
         if (options.drawHiddenNotes) {
             this.drawingParameters.drawHiddenNotes = true;
         }
+        if (options.drawTitle !== undefined) {
+            this.drawingParameters.drawTitle = options.drawTitle;
+        }
+        if (options.drawPartName !== undefined) {
+            this.drawingParameters.drawPartName = options.drawPartName;
+        }
+        if (options.drawCredits !== undefined) {
+            this.drawingParameters.drawCredits = options.drawCredits;
+        }
         if (options.defaultColorNoteHead) {
             this.drawingParameters.defaultColorNoteHead = options.defaultColorNoteHead;
         }

--- a/test/Common/FileIO/Xml_Test.ts
+++ b/test/Common/FileIO/Xml_Test.ts
@@ -48,7 +48,11 @@ describe("XML interface", () => {
             // Load the xml file content
             const score: Document = TestUtils.getScore(scoreName);
             const div: HTMLElement = document.createElement("div");
-            const openSheetMusicDisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+            const openSheetMusicDisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(
+                div,
+                {
+                    autoResize: false
+                });
             openSheetMusicDisplay.load(score);
             done();
         }).timeout(3000);

--- a/test/Common/FileIO/Xml_Test.ts
+++ b/test/Common/FileIO/Xml_Test.ts
@@ -48,11 +48,8 @@ describe("XML interface", () => {
             // Load the xml file content
             const score: Document = TestUtils.getScore(scoreName);
             const div: HTMLElement = document.createElement("div");
-            const openSheetMusicDisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(
-                div,
-                {
-                    autoResize: false
-                });
+            const openSheetMusicDisplay: OpenSheetMusicDisplay =
+                TestUtils.createOpenSheetMusicDisplay(div);
             openSheetMusicDisplay.load(score);
             done();
         }).timeout(3000);

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -2,6 +2,14 @@ import chai = require("chai");
 import {OpenSheetMusicDisplay} from "../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
 import {TestUtils} from "../../Util/TestUtils";
 
+function createOpenSheetMusicDisplay(div: HTMLElement): OpenSheetMusicDisplay {
+    return new OpenSheetMusicDisplay(
+        div,
+        {
+            autoResize: false
+        }
+    );
+}
 
 describe("OpenSheetMusicDisplay Main Export", () => {
     let container1: HTMLElement;
@@ -24,7 +32,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load MXL from string", (done: MochaDone) => {
         const mxl: string = TestUtils.getMXL("Mozart_Clarinet_Quintet_Excerpt.mxl");
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(mxl).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -37,7 +45,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load invalid MXL from string", (done: MochaDone) => {
         const mxl: string = "\x50\x4b\x03\x04";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(mxl).then(
             (_: {}) => {
                 done(new Error("Corrupted MXL appears to be loaded correctly"));
@@ -56,7 +64,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         const xml: string = new XMLSerializer().serializeToString(score);
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(xml).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -69,7 +77,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load XML Document", (done: MochaDone) => {
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(score).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -82,7 +90,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load MXL Document by URL", (done: MochaDone) => {
         const url: string = "base/test/data/Mozart_Clarinet_Quintet_Excerpt.mxl";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(url).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -95,7 +103,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load something invalid by URL", (done: MochaDone) => {
         const url: string = "https://www.google.com";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(url).then(
             (_: {}) => {
                 done(new Error("Invalid URL appears to be loaded correctly"));
@@ -113,7 +121,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load invalid URL", (done: MochaDone) => {
         const url: string = "https://www.afjkhfjkauu2ui3z2uiu.com";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(url).then(
             (_: {}) => {
                 done(new Error("Invalid URL appears to be loaded correctly"));
@@ -131,7 +139,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load invalid XML string", (done: MochaDone) => {
         const xml: string = "<?xml";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(xml).then(
             (_: {}) => {
                 done(new Error("Corrupted XML appears to be loaded correctly"));
@@ -148,7 +156,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
 
     it("render without loading", (done: MochaDone) => {
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         chai.expect(() => {
             return opensheetmusicdisplay.render();
         }).to.throw(/load/);
@@ -167,7 +175,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("test width 500", (done: MochaDone) => {
         const div: HTMLElement = container1;
         div.style.width = "500px";
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         opensheetmusicdisplay.load(score).then(
             (_: {}) => {
@@ -182,7 +190,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("test width 200", (done: MochaDone) => {
         const div: HTMLElement = container1;
         div.style.width = "200px";
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         opensheetmusicdisplay.load(score).then(
             (_: {}) => {

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -2,15 +2,6 @@ import chai = require("chai");
 import {OpenSheetMusicDisplay} from "../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
 import {TestUtils} from "../../Util/TestUtils";
 
-function createOpenSheetMusicDisplay(div: HTMLElement): OpenSheetMusicDisplay {
-    return new OpenSheetMusicDisplay(
-        div,
-        {
-            autoResize: false
-        }
-    );
-}
-
 describe("OpenSheetMusicDisplay Main Export", () => {
     let container1: HTMLElement;
 
@@ -32,7 +23,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load MXL from string", (done: MochaDone) => {
         const mxl: string = TestUtils.getMXL("Mozart_Clarinet_Quintet_Excerpt.mxl");
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(mxl).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -45,7 +36,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load invalid MXL from string", (done: MochaDone) => {
         const mxl: string = "\x50\x4b\x03\x04";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(mxl).then(
             (_: {}) => {
                 done(new Error("Corrupted MXL appears to be loaded correctly"));
@@ -64,7 +55,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         const xml: string = new XMLSerializer().serializeToString(score);
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(xml).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -77,7 +68,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load XML Document", (done: MochaDone) => {
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(score).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -90,7 +81,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load MXL Document by URL", (done: MochaDone) => {
         const url: string = "base/test/data/Mozart_Clarinet_Quintet_Excerpt.mxl";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(url).then(
             (_: {}) => {
                 opensheetmusicdisplay.render();
@@ -103,7 +94,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load something invalid by URL", (done: MochaDone) => {
         const url: string = "https://www.google.com";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(url).then(
             (_: {}) => {
                 done(new Error("Invalid URL appears to be loaded correctly"));
@@ -121,7 +112,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load invalid URL", (done: MochaDone) => {
         const url: string = "https://www.afjkhfjkauu2ui3z2uiu.com";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(url).then(
             (_: {}) => {
                 done(new Error("Invalid URL appears to be loaded correctly"));
@@ -139,7 +130,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("load invalid XML string", (done: MochaDone) => {
         const xml: string = "<?xml";
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         opensheetmusicdisplay.load(xml).then(
             (_: {}) => {
                 done(new Error("Corrupted XML appears to be loaded correctly"));
@@ -156,7 +147,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
 
     it("render without loading", (done: MochaDone) => {
         const div: HTMLElement = TestUtils.getDivElement(document);
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         chai.expect(() => {
             return opensheetmusicdisplay.render();
         }).to.throw(/load/);
@@ -175,7 +166,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("test width 500", (done: MochaDone) => {
         const div: HTMLElement = container1;
         div.style.width = "500px";
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         opensheetmusicdisplay.load(score).then(
             (_: {}) => {
@@ -190,7 +181,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
     it("test width 200", (done: MochaDone) => {
         const div: HTMLElement = container1;
         div.style.width = "200px";
-        const opensheetmusicdisplay: OpenSheetMusicDisplay = createOpenSheetMusicDisplay(div);
+        const opensheetmusicdisplay: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
         const score: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
         opensheetmusicdisplay.load(score).then(
             (_: {}) => {

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer_Test.ts
@@ -9,6 +9,7 @@ import {IXmlElement} from "../../../../src/Common/FileIO/Xml";
 import {Fraction} from "../../../../src/Common/DataObjects/Fraction";
 import {VexFlowBackend} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowBackend";
 import {CanvasVexFlowBackend} from "../../../../src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend";
+import { DrawingParameters } from "../../../../src/MusicalScore/Graphical/DrawingParameters";
 
 /* tslint:disable:no-unused-expression */
 describe("VexFlow Music Sheet Drawer", () => {
@@ -27,7 +28,7 @@ describe("VexFlow Music Sheet Drawer", () => {
         const canvas: HTMLCanvasElement = document.createElement("canvas");
         const backend: VexFlowBackend = new CanvasVexFlowBackend();
         backend.initialize(canvas);
-        const drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend);
+        const drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend, new DrawingParameters());
         drawer.drawSheet(gms);
         done();
     });
@@ -47,7 +48,7 @@ describe("VexFlow Music Sheet Drawer", () => {
         const canvas: HTMLCanvasElement = document.createElement("canvas");
         const backend: VexFlowBackend = new CanvasVexFlowBackend();
         backend.initialize(canvas);
-        const drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend);
+        const drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend, new DrawingParameters());
         drawer.drawSheet(gms);
         done();
     });

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer_Test.ts
@@ -9,7 +9,7 @@ import {IXmlElement} from "../../../../src/Common/FileIO/Xml";
 import {Fraction} from "../../../../src/Common/DataObjects/Fraction";
 import {VexFlowBackend} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowBackend";
 import {CanvasVexFlowBackend} from "../../../../src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend";
-import { DrawingParameters } from "../../../../src/MusicalScore/Graphical/DrawingParameters";
+import {DrawingParameters} from "../../../../src/MusicalScore/Graphical/DrawingParameters";
 
 /* tslint:disable:no-unused-expression */
 describe("VexFlow Music Sheet Drawer", () => {
@@ -28,7 +28,7 @@ describe("VexFlow Music Sheet Drawer", () => {
         const canvas: HTMLCanvasElement = document.createElement("canvas");
         const backend: VexFlowBackend = new CanvasVexFlowBackend();
         backend.initialize(canvas);
-        const drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend, new DrawingParameters());
+        const drawer: VexFlowMusicSheetDrawer = new VexFlowMusicSheetDrawer(canvas, backend);
         drawer.drawSheet(gms);
         done();
     });

--- a/test/Util/TestUtils.ts
+++ b/test/Util/TestUtils.ts
@@ -1,3 +1,5 @@
+import { OpenSheetMusicDisplay } from "../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
+
 /**
  * This class collects useful methods to interact with test data.
  * During tests, XML and MXL documents are preprocessed by karma,
@@ -37,4 +39,12 @@ export class TestUtils {
         }
     }
 
+    public static createOpenSheetMusicDisplay(div: HTMLElement): OpenSheetMusicDisplay {
+        return new OpenSheetMusicDisplay(
+            div,
+            {
+                autoResize: false
+            }
+        );
+    }
 }

--- a/test/Util/TestUtils.ts
+++ b/test/Util/TestUtils.ts
@@ -40,11 +40,6 @@ export class TestUtils {
     }
 
     public static createOpenSheetMusicDisplay(div: HTMLElement): OpenSheetMusicDisplay {
-        return new OpenSheetMusicDisplay(
-            div,
-            {
-                autoResize: false
-            }
-        );
+        return new OpenSheetMusicDisplay(div);
     }
 }

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -35,6 +35,6 @@ module.exports = merge(common, {
             path: path.resolve(__dirname, 'build'),
             filename: './statistics.html'
         }),
-        new Cleaner(pathsToClean, {verbose: true, dry: false})
+        new Cleaner(pathsToClean, { verbose: true, dry: false })
     ]
 })


### PR DESCRIPTION
Resolves #288

Adds an interface for options that replaces the individual options parameters in the OpenSheetMusicDisplay() constructor, as @sebastianhaas suggested in #288.
Any changes you and @bneumann want to see?

I added the interface to OpenSheetMusicDisplay.ts and exported it, so i hope people using OSMD with TypeScript can import the interface as well.
But this may not be the best way to go about it, maybe it should go into a new file.

```javascript
export interface IOSMDOptions {
    autoBeam?: boolean; // not yet supported. will always autoBeam.
    autoResize?: boolean; // default is false
    autoStem?: boolean; // not yet supported. will always autoStem
    backend?: string; // Backend will be SVG if backend === "svg", otherwise Canvas
    disableCursor?: boolean; // will override this part of drawingParameters
    drawingParametersEnum?: DrawingParametersEnum;
    drawingParametersString?: string; // alternative to using the enum. only need to set one of these.
}
```

Right now we don't have too many working options. Not sure if we could implement disabling autoStem or autoBeam, for example.

In any case, this works for now, and enables disabling the cursor, which @p-himik requested in #5.