### PR TITLE
Fix RepetitionReader RegExes, RepetitionCalculator crash

### DIFF
--- a/src/Common/Strings/StringUtil.ts
+++ b/src/Common/Strings/StringUtil.ts
@@ -1,9 +1,9 @@
 ﻿export class StringUtil {
-  public static StringContainsSeparatedWord(str: string, word: string): boolean {
-    if (str === word ||
-      str.search(" " + word) !== -1 ||
-      str.search(word + " ") !== -1 ||
-      str.search(word + ".") !== -1) {
+  public static StringContainsSeparatedWord(str: string, wordRegExString: string): boolean {
+    if (new RegExp("^" + wordRegExString + "$").test(str) ||
+      new RegExp(" " + wordRegExString).test(str) ||
+      new RegExp(wordRegExString + " ").test(str) ||
+      new RegExp(wordRegExString + "\\.").test(str)) {
       return true;
     }
     return false;

--- a/src/Common/Strings/StringUtil.ts
+++ b/src/Common/Strings/StringUtil.ts
@@ -1,9 +1,6 @@
 ﻿export class StringUtil {
   public static StringContainsSeparatedWord(str: string, wordRegExString: string): boolean {
-    if (new RegExp("(^" + wordRegExString + "$)|" + // exact match
-      "( " + wordRegExString + ")|" + // " " + str
-      "(" + wordRegExString + "[ .])" // str + " " or "."
-      ).test(str)) {
+    if (new RegExp("( |^)" + wordRegExString + "([ .]|$)").test(str)) {
       return true;
     }
     return false;

--- a/src/Common/Strings/StringUtil.ts
+++ b/src/Common/Strings/StringUtil.ts
@@ -1,9 +1,9 @@
 ﻿export class StringUtil {
   public static StringContainsSeparatedWord(str: string, wordRegExString: string): boolean {
-    if (new RegExp("^" + wordRegExString + "$").test(str) ||
-      new RegExp(" " + wordRegExString).test(str) ||
-      new RegExp(wordRegExString + " ").test(str) ||
-      new RegExp(wordRegExString + "\\.").test(str)) {
+    if (new RegExp("(^" + wordRegExString + "$)|" + // exact match
+      "( " + wordRegExString + ")|" + // " " + str
+      "(" + wordRegExString + "[ .])" // str + " " or "."
+      ).test(str)) {
       return true;
     }
     return false;

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
@@ -42,6 +42,9 @@ export class RepetitionCalculator {
   }
 
   private handleRepetitionInstructions(currentRepetitionInstruction: RepetitionInstruction): boolean {
+    if (!this.currentMeasure) {
+      return false;
+    }
     switch (currentRepetitionInstruction.type) {
       case RepetitionInstructionEnum.StartLine:
         this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
@@ -121,10 +121,10 @@ export class RepetitionInstructionReader {
   public handleRepetitionInstructionsFromWordsOrSymbols(directionTypeNode: IXmlElement, relativeMeasurePosition: number): boolean {
     const wordsNode: IXmlElement = directionTypeNode.element("words");
     if (wordsNode !== undefined) {
+      const dsRegEx: string = "d\s?\.s\.";
       // must Trim string and ToLower before compare
       const innerText: string = wordsNode.value.trim().toLowerCase();
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d.s. al fine") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "d. s. al fine")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, dsRegEx + " al fine")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5 && this.currentMeasureIndex < this.xmlMeasureList[0].length - 1) { // not in last measure
           measureIndex--;
@@ -133,8 +133,8 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d.s. al coda") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "d. s. al coda")) {
+      const dcRegEx: string = "d\.\s?c\.";
+      if (StringUtil.StringContainsSeparatedWord(innerText, dcRegEx + " al coda")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5) {
           measureIndex--;
@@ -143,8 +143,7 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d.c. al fine") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "d. c. al fine")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, dcRegEx + " al fine")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5 && this.currentMeasureIndex < this.xmlMeasureList[0].length - 1) { // not in last measure
           measureIndex--;
@@ -153,8 +152,7 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d.c. al coda") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "d. c. al coda")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, "d\.\s?c\. al coda")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5) {
           measureIndex--;
@@ -163,10 +161,8 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d.c.") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "d. c.") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "dacapo") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "da capo")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, dcRegEx) ||
+        StringUtil.StringContainsSeparatedWord(innerText, "da\s?capo")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5 && this.currentMeasureIndex < this.xmlMeasureList[0].length - 1) { // not in last measure
           measureIndex--;
@@ -175,10 +171,8 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d.s.") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "d. s.") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "dalsegno") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "dal segno")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, dsRegEx) ||
+        StringUtil.StringContainsSeparatedWord(innerText, "dal\s?segno")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5 && this.currentMeasureIndex < this.xmlMeasureList[0].length - 1) { // not in last measure
           measureIndex--;
@@ -187,10 +181,8 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "tocoda") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "to coda") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "a coda") ||
-        StringUtil.StringContainsSeparatedWord(innerText, "a la coda")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, "to\s?coda") ||
+        StringUtil.StringContainsSeparatedWord(innerText, "a (la )?coda")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5) {
           measureIndex--;

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
@@ -152,7 +152,7 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "d\.\s?c\. al coda")) {
+      if (StringUtil.StringContainsSeparatedWord(innerText, dcRegEx + " al coda")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5) {
           measureIndex--;

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
@@ -121,7 +121,7 @@ export class RepetitionInstructionReader {
   public handleRepetitionInstructionsFromWordsOrSymbols(directionTypeNode: IXmlElement, relativeMeasurePosition: number): boolean {
     const wordsNode: IXmlElement = directionTypeNode.element("words");
     if (wordsNode !== undefined) {
-      const dsRegEx: string = "d\\s?\\.s\\."; // TS eliminates the first \
+      const dsRegEx: string = "d\\s?\\.s\\."; // Input for new RegExp(). TS eliminates the first \
       // must Trim string and ToLower before compare
       const innerText: string = wordsNode.value.trim().toLowerCase();
       if (StringUtil.StringContainsSeparatedWord(innerText, dsRegEx + " al fine")) {

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionInstructionReader.ts
@@ -121,7 +121,7 @@ export class RepetitionInstructionReader {
   public handleRepetitionInstructionsFromWordsOrSymbols(directionTypeNode: IXmlElement, relativeMeasurePosition: number): boolean {
     const wordsNode: IXmlElement = directionTypeNode.element("words");
     if (wordsNode !== undefined) {
-      const dsRegEx: string = "d\s?\.s\.";
+      const dsRegEx: string = "d\\s?\\.s\\."; // TS eliminates the first \
       // must Trim string and ToLower before compare
       const innerText: string = wordsNode.value.trim().toLowerCase();
       if (StringUtil.StringContainsSeparatedWord(innerText, dsRegEx + " al fine")) {
@@ -133,7 +133,7 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      const dcRegEx: string = "d\.\s?c\.";
+      const dcRegEx: string = "d\\.\\s?c\\.";
       if (StringUtil.StringContainsSeparatedWord(innerText, dcRegEx + " al coda")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5) {
@@ -162,7 +162,7 @@ export class RepetitionInstructionReader {
         return true;
       }
       if (StringUtil.StringContainsSeparatedWord(innerText, dcRegEx) ||
-        StringUtil.StringContainsSeparatedWord(innerText, "da\s?capo")) {
+        StringUtil.StringContainsSeparatedWord(innerText, "da\\s?capo")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5 && this.currentMeasureIndex < this.xmlMeasureList[0].length - 1) { // not in last measure
           measureIndex--;
@@ -172,7 +172,7 @@ export class RepetitionInstructionReader {
         return true;
       }
       if (StringUtil.StringContainsSeparatedWord(innerText, dsRegEx) ||
-        StringUtil.StringContainsSeparatedWord(innerText, "dal\s?segno")) {
+        StringUtil.StringContainsSeparatedWord(innerText, "dal\\s?segno")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5 && this.currentMeasureIndex < this.xmlMeasureList[0].length - 1) { // not in last measure
           measureIndex--;
@@ -181,7 +181,7 @@ export class RepetitionInstructionReader {
         this.addInstruction(this.repetitionInstructions, newInstruction);
         return true;
       }
-      if (StringUtil.StringContainsSeparatedWord(innerText, "to\s?coda") ||
+      if (StringUtil.StringContainsSeparatedWord(innerText, "to\\s?coda") ||
         StringUtil.StringContainsSeparatedWord(innerText, "a (la )?coda")) {
         let measureIndex: number = this.currentMeasureIndex;
         if (relativeMeasurePosition < 0.5) {


### PR DESCRIPTION
Fixes #370

Our StringUtil.StringContainsSeparatedWord function was implemented as if it used plain strings instead of RegExes with String.search(). The function should work as designed now, with proper RegExes.

Also fixes a crash in RepetitionCalculator when currentMeasure was not set.