### PR TITLE
Fix Whole Rest Bbox/Cursor

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -84,11 +84,11 @@
             <option value="VexFlowMeasure">Measures</option>
             <option value="VexFlowGraphicalNote">GraphicalNotes</option>
             <option value="VexFlowVoiceEntry">VoiceEntries</option>
-            <option value="VexFlowStaffEntry">Staff entries</option>
+            <option value="VexFlowStaffEntry">StaffEntries</option>
             <option value="GraphicalLabel">Labels</option>
-            <option value="VexFlowStaffLine">Staff lines</option>
-            <option value="SystemLine">System lines</option>
-            <option value="StaffLineActivitySymbol">Activity symbols</option>
+            <option value="VexFlowStaffLine">StaffLines</option>
+            <option value="SystemLine">SystemLines</option>
+            <option value="StaffLineActivitySymbol">ActivitySymbols</option>
         </select>
     </div>
     <div class="column">

--- a/demo/index.html
+++ b/demo/index.html
@@ -82,6 +82,8 @@
             <option value="none">None</option>
             <option value="all">All</option>
             <option value="VexFlowMeasure">Measures</option>
+            <option value="VexFlowGraphicalNote">GraphicalNotes</option>
+            <option value="VexFlowVoiceEntry">VoiceEntries</option>
             <option value="VexFlowStaffEntry">Staff entries</option>
             <option value="GraphicalLabel">Labels</option>
             <option value="VexFlowStaffLine">Staff lines</option>

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -69,7 +69,7 @@ export class EngravingRules {
     private distanceOffsetBetweenTwoHorizontallyCrossedWedges: number;
     private wedgeMinLength: number;
     private distanceBetweenAdjacentDynamics: number;
-    private tempoChangeMeasureValitidy: number;
+    private tempoChangeMeasureValidity: number;
     private tempoContinousFactor: number;
     private staccatoScalingFactor: number;
     private betweenDotsDistance: number;
@@ -140,6 +140,7 @@ export class EngravingRules {
     private minNoteDistance: number;
     private subMeasureXSpacingThreshold: number;
     private measureDynamicsMaxScalingFactor: number;
+    private wholeRestXShiftVexflow: number;
     private maxInstructionsConstValue: number;
     private noteDistances: number[] = [1.0, 1.0, 1.3, 1.6, 2.0, 2.5, 3.0, 4.0];
     private noteDistancesScalingFactors: number[] = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0];
@@ -218,7 +219,7 @@ export class EngravingRules {
         this.graceNoteScalingFactor = 0.6;
         this.graceNoteXOffset = 0.2;
 
-        // GraceNote Variables
+        // Wedge Variables
         this.wedgeOpeningLength = 1.2;
         this.wedgeMeasureEndOpeningLength = 0.75;
         this.wedgeMeasureBeginOpeningLength = 0.75;
@@ -230,8 +231,8 @@ export class EngravingRules {
         this.wedgeMinLength = 2.0;
         this.distanceBetweenAdjacentDynamics = 0.75;
 
-        // GraceNote Variables
-        this.tempoChangeMeasureValitidy = 4;
+        // Tempo Variables
+        this.tempoChangeMeasureValidity = 4;
         this.tempoContinousFactor = 0.7;
 
         // various
@@ -316,6 +317,7 @@ export class EngravingRules {
         this.minNoteDistance = 2.0;
         this.subMeasureXSpacingThreshold = 35;
         this.measureDynamicsMaxScalingFactor = 2.5;
+        this.wholeRestXShiftVexflow = -2.5; // VexFlow draws rest notes too far to the right
 
         this.populateDictionaries();
         try {
@@ -708,11 +710,11 @@ export class EngravingRules {
     public set DistanceBetweenAdjacentDynamics(value: number) {
         this.distanceBetweenAdjacentDynamics = value;
     }
-    public get TempoChangeMeasureValitidy(): number {
-        return this.tempoChangeMeasureValitidy;
+    public get TempoChangeMeasureValidity(): number {
+        return this.tempoChangeMeasureValidity;
     }
-    public set TempoChangeMeasureValitidy(value: number) {
-        this.tempoChangeMeasureValitidy = value;
+    public set TempoChangeMeasureValidity(value: number) {
+        this.tempoChangeMeasureValidity = value;
     }
     public get TempoContinousFactor(): number {
         return this.tempoContinousFactor;
@@ -1127,6 +1129,12 @@ export class EngravingRules {
     }
     public set MeasureDynamicsMaxScalingFactor(value: number) {
         this.measureDynamicsMaxScalingFactor = value;
+    }
+    public get WholeRestXShiftVexflow(): number {
+        return this.wholeRestXShiftVexflow;
+    }
+    public set WholeRestXShiftVexflow(value: number) {
+        this.wholeRestXShiftVexflow = value;
     }
     public get MaxInstructionsConstValue(): number {
         return this.maxInstructionsConstValue;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -161,7 +161,7 @@ export abstract class MusicSheetCalculator {
         }
         this.handleStaffEntries();
         this.calculateVerticalContainersList();
-        this.setIndecesToVerticalGraphicalContainers();
+        this.setIndicesToVerticalGraphicalContainers();
     }
 
     /**
@@ -1454,7 +1454,7 @@ export abstract class MusicSheetCalculator {
         }
     }
 
-    private setIndecesToVerticalGraphicalContainers(): void {
+    private setIndicesToVerticalGraphicalContainers(): void {
         for (let i: number = 0; i < this.graphicalMusicSheet.VerticalGraphicalStaffEntryContainers.length; i++) {
             this.graphicalMusicSheet.VerticalGraphicalStaffEntryContainers[i].Index = i;
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -21,6 +21,7 @@ import { SystemLinePosition } from "../SystemLinePosition";
 import { GraphicalVoiceEntry } from "../GraphicalVoiceEntry";
 import { OrnamentEnum, OrnamentContainer } from "../../VoiceData/OrnamentContainer";
 import { NoteHead, NoteHeadShape } from "../../VoiceData/NoteHead";
+import { unitInPixels } from "./VexFlowMusicSheetDrawer";
 
 /**
  * Helper class, which contains static methods which actually convert
@@ -228,7 +229,8 @@ export class VexFlowConverter {
                     // https://github.com/0xfe/vexflow/issues/579 The author reports that he needs to add some negative x shift
                     // if the measure has no modifiers.
                     alignCenter = true;
-                    xShift = -25; // TODO: Either replace by EngravingRules entry or find a way to make it dependent on the modifiers
+                    xShift = -2.5 * unitInPixels; // TODO: Either replace by EngravingRules entry or find a way to make it dependent on the modifiers
+                    // affects VexFlowStaffEntry.calculateXPosition()
                 }
                 duration += "r";
                 break;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -22,6 +22,7 @@ import { GraphicalVoiceEntry } from "../GraphicalVoiceEntry";
 import { OrnamentEnum, OrnamentContainer } from "../../VoiceData/OrnamentContainer";
 import { NoteHead, NoteHeadShape } from "../../VoiceData/NoteHead";
 import { unitInPixels } from "./VexFlowMusicSheetDrawer";
+import { EngravingRules } from "../EngravingRules";
 
 /**
  * Helper class, which contains static methods which actually convert
@@ -229,7 +230,7 @@ export class VexFlowConverter {
                     // https://github.com/0xfe/vexflow/issues/579 The author reports that he needs to add some negative x shift
                     // if the measure has no modifiers.
                     alignCenter = true;
-                    xShift = -2.5 * unitInPixels; // TODO: Either replace by EngravingRules entry or find a way to make it dependent on the modifiers
+                    xShift = EngravingRules.Rules.WholeRestXShiftVexflow * unitInPixels; // TODO find way to make dependent on the modifiers
                     // affects VexFlowStaffEntry.calculateXPosition()
                 }
                 duration += "r";

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -4,6 +4,7 @@ import {SourceStaffEntry} from "../../VoiceData/SourceStaffEntry";
 import {unitInPixels} from "./VexFlowMusicSheetDrawer";
 import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
 import { Note } from "../../VoiceData/Note";
+import { EngravingRules } from "../EngravingRules";
 
 export class VexFlowStaffEntry extends GraphicalStaffEntry {
     constructor(measure: VexFlowMeasure, sourceStaffEntry: SourceStaffEntry, staffEntryParent: VexFlowStaffEntry) {
@@ -32,7 +33,8 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                 this.PositionAndShape.RelativePosition.x = gve.vfStaveNote.getBoundingBox().x / unitInPixels;
                 const sourceNote: Note = gve.notes[0].sourceNote;
                 if (sourceNote.isRest() && sourceNote.Length.WholeValue === 1) { // whole rest
-                    this.PositionAndShape.RelativePosition.x -= 2.6; // xShift from VexFlowConverter
+                    this.PositionAndShape.RelativePosition.x +=
+                        EngravingRules.Rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
                     gve.PositionAndShape.BorderLeft = -0.7;
                     gve.PositionAndShape.BorderRight = 0.7;
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -3,6 +3,7 @@ import {VexFlowMeasure} from "./VexFlowMeasure";
 import {SourceStaffEntry} from "../../VoiceData/SourceStaffEntry";
 import {unitInPixels} from "./VexFlowMusicSheetDrawer";
 import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
+import { Note } from "../../VoiceData/Note";
 
 export class VexFlowStaffEntry extends GraphicalStaffEntry {
     constructor(measure: VexFlowMeasure, sourceStaffEntry: SourceStaffEntry, staffEntryParent: VexFlowStaffEntry) {
@@ -29,6 +30,12 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                 gve.vfStaveNote.setStave(stave);
                 gve.applyBordersFromVexflow();
                 this.PositionAndShape.RelativePosition.x = gve.vfStaveNote.getBoundingBox().x / unitInPixels;
+                const sourceNote: Note = gve.notes[0].sourceNote;
+                if (sourceNote.isRest() && sourceNote.Length.WholeValue === 1) { // whole rest
+                    this.PositionAndShape.RelativePosition.x -= 2.6; // xShift from VexFlowConverter
+                    gve.PositionAndShape.BorderLeft = -0.7;
+                    gve.PositionAndShape.BorderRight = 0.7;
+                }
                 if (gve.PositionAndShape.BorderLeft < lastBorderLeft) {
                     lastBorderLeft = gve.PositionAndShape.BorderLeft;
                 }


### PR DESCRIPTION
Fix #380

* Fix whole rest Bounding Box (for StaffEntry, VoiceEntry, GraphicalNote), fixing Cursor position
![image](https://user-images.githubusercontent.com/33069673/45445393-64777700-b6ca-11e8-90bb-63123d7e0b45.png)

* Add GraphicalNotes and VoiceEntries options to show bbox
* Demo: Rename "Show bounding box" options to be more similar to class names
![image](https://user-images.githubusercontent.com/33069673/45445313-2da16100-b6ca-11e8-9892-92b702c0dbed.png)

The bbox fix isn't pretty, but that's because the bounding box given by Vexflow is completely wrong.

Test Xml with some rest variations:
[Whole_Rest_Bbox_test.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/2376420/Whole_Rest_Bbox_test.zip)
