### PR TITLE
Fix Demo: null checks for release builds

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -95,33 +95,47 @@ import { OpenSheetMusicDisplay } from '../src/OpenSheetMusicDisplay/OpenSheetMus
             }
             selectSample.appendChild(option);
         }
-        selectSample.onchange = selectSampleOnChange;
-        selectBounding.onchange = selectBoundingOnChange;
+        if (selectSample) {
+            selectSample.onchange = selectSampleOnChange;
+        }
+        if (selectBounding) {
+            selectBounding.onchange = selectBoundingOnChange;
+        }
 
         // Pre-select default music piece
 
         custom.appendChild(document.createTextNode("Custom"));
 
         // Create zoom controls
-        zoomIn.onclick = function () {
-            zoom *= 1.2;
-            scale();
-        };
-        zoomOut.onclick = function () {
-            zoom /= 1.2;
-            scale();
-        };
-
-        skylineDebug.onclick = function() {
-            openSheetMusicDisplay.DrawSkyLine = !openSheetMusicDisplay.DrawSkyLine;
+        if (zoomIn) {
+            zoomIn.onclick = function () {
+                zoom *= 1.2;
+                scale();
+            };
+        }
+        if (zoomOut) {
+            zoomOut.onclick = function () {
+                zoom /= 1.2;
+                scale();
+            };
         }
 
-        bottomlineDebug.onclick = function() {
-            openSheetMusicDisplay.DrawBottomLine = !openSheetMusicDisplay.DrawBottomLine;
+        if (skylineDebug) {
+            skylineDebug.onclick = function() {
+                openSheetMusicDisplay.DrawSkyLine = !openSheetMusicDisplay.DrawSkyLine;
+            }
         }
 
-        debugReRenderBtn.onclick = function() {
-            rerender();
+        if (bottomlineDebug) {
+            bottomlineDebug.onclick = function() {
+                openSheetMusicDisplay.DrawBottomLine = !openSheetMusicDisplay.DrawBottomLine;
+            }
+        }
+
+        if (debugReRenderBtn) {
+            debugReRenderBtn.onclick = function() {
+                rerender();
+            }
         }
 
         // Create OSMD object and canvas


### PR DESCRIPTION
Adds some null checks to the demo, so that our [Official Demo](https://opensheetmusicdisplay.github.io/demo/) isn't broken when we push a new release. This happens because our official demo has less buttons than the local demo (e.g. Show Skyline), but uses the same index.js, so it accesses undefined buttons.

I just had to push this build to the github.io repo manually again to make the demo work again.

Of course we want to redesign the demo at some point, but i think we should still keep it solid until we've built a new demo.