### PR TITLE
fix crescendo spacing

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -89,6 +89,7 @@
             <option value="VexFlowStaffLine">StaffLines</option>
             <option value="SystemLine">SystemLines</option>
             <option value="StaffLineActivitySymbol">ActivitySymbols</option>
+            <option value="GraphicalContinuousDynamicExpression">DynamicExpressions</option>
         </select>
     </div>
     <div class="column">

--- a/demo/index.html
+++ b/demo/index.html
@@ -89,7 +89,7 @@
             <option value="VexFlowStaffLine">StaffLines</option>
             <option value="SystemLine">SystemLines</option>
             <option value="StaffLineActivitySymbol">ActivitySymbols</option>
-            <option value="GraphicalContinuousDynamicExpression">DynamicExpressions</option>
+            <option value="VexFlowContinuousDynamicExpression">DynamicExpressions</option>
         </select>
     </div>
     <div class="column">

--- a/src/MusicalScore/Graphical/AlignmentManager.ts
+++ b/src/MusicalScore/Graphical/AlignmentManager.ts
@@ -54,13 +54,17 @@ export class AlignmentManager {
                     }
                     expr.PositionAndShape.calculateBoundingBox();
                     // Squeeze wedges
-                    if (exprIdx < aes.length - 1 && exprIdx > 0 && (expr as VexFlowContinuousDynamicExpression).squeeze) {
-                        const nextExpression: AbstractGraphicalExpression = aes[exprIdx + 1];
-                        const prevExpression: AbstractGraphicalExpression = aes[exprIdx - 1];
-                        const overlapRight: PointF2D = this.getOverlap(expr.PositionAndShape, nextExpression.PositionAndShape);
-                        const overlapLeft: PointF2D = this.getOverlap(prevExpression.PositionAndShape, expr.PositionAndShape);
-                        (expr as VexFlowContinuousDynamicExpression).squeeze(-(overlapRight.x + this.rules.DynamicExpressionSpacer));
-                        (expr as VexFlowContinuousDynamicExpression).squeeze(overlapLeft.x + this.rules.DynamicExpressionSpacer);
+                    if ((expr as VexFlowContinuousDynamicExpression).squeeze) {
+                        const nextExpression: AbstractGraphicalExpression = exprIdx < aes.length - 1 ? aes[exprIdx + 1] : undefined;
+                        const prevExpression: AbstractGraphicalExpression = exprIdx > 0 ? aes[exprIdx - 1] : undefined;
+                        if (nextExpression) {
+                            const overlapRight: PointF2D = this.getOverlap(expr.PositionAndShape, nextExpression.PositionAndShape);
+                            (expr as VexFlowContinuousDynamicExpression).squeeze(-(overlapRight.x + this.rules.DynamicExpressionSpacer));
+                        }
+                        if (prevExpression) {
+                            const overlapLeft: PointF2D = this.getOverlap(prevExpression.PositionAndShape, expr.PositionAndShape);
+                            (expr as VexFlowContinuousDynamicExpression).squeeze(overlapLeft.x + this.rules.DynamicExpressionSpacer);
+                        }
                     }
                 }
             }

--- a/src/MusicalScore/Graphical/AlignmentManager.ts
+++ b/src/MusicalScore/Graphical/AlignmentManager.ts
@@ -68,7 +68,7 @@ export class AlignmentManager {
     }
 
     /**
-     * Get distance between to bounding boxes
+     * Get distance between two bounding boxes
      * @param a First bounding box
      * @param b Second bounding box
      */

--- a/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
@@ -290,13 +290,6 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
                 this.lines[0].End.x += value;
                 this.lines[1].End.x += value;
             }
-        } else {
-            if (value < 0) {
-                this.lines[0].Start.x += value;
-            } else {
-                this.lines[0].End.x += value;
-                this.lines[1].End.x += value;
-            }
         }
         this.calcPsi();
     }

--- a/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
@@ -135,10 +135,10 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
      * @param wedgeOpeningLength length of the opening
      * @param wedgeLineWidth line width of the wedge
      */
-    public createSecondHalfCresendoLines(startX: number, endX: number, y: number,
-                                         wedgeMeasureBeginOpeningLength: number = this.rules.WedgeMeasureBeginOpeningLength,
-                                         wedgeOpeningLength: number = this.rules.WedgeOpeningLength,
-                                         wedgeLineWidth: number = this.rules.WedgeLineWidth): void {
+    public createSecondHalfCrescendoLines(startX: number, endX: number, y: number,
+                                          wedgeMeasureBeginOpeningLength: number = this.rules.WedgeMeasureBeginOpeningLength,
+                                          wedgeOpeningLength: number = this.rules.WedgeOpeningLength,
+                                          wedgeLineWidth: number = this.rules.WedgeLineWidth): void {
         const upperLineStart: PointF2D = new PointF2D(startX, y - wedgeMeasureBeginOpeningLength / 2);
         const lowerLineStart: PointF2D = new PointF2D(startX, y + wedgeMeasureBeginOpeningLength / 2);
         const upperLineEnd: PointF2D = new PointF2D(endX, y - wedgeOpeningLength / 2);
@@ -157,7 +157,7 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
         this.lines.clear();
 
         if (isSecondHalfSplit) {
-            this.createSecondHalfCresendoLines(startX, endX, y);
+            this.createSecondHalfCrescendoLines(startX, endX, y);
         } else if (this.isSplittedPart) {
             this.createFirstHalfCrescendoLines(startX, endX, y);
         } else {

--- a/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
@@ -198,7 +198,7 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
         const lowerLineStart: PointF2D = new PointF2D(startX, y + wedgeOpeningLength / 2);
         const upperLineEnd: PointF2D = new PointF2D(endX, y - wedgeMeasureEndOpeningLength / 2);
         const lowerLineEnd: PointF2D = new PointF2D(endX, y + wedgeMeasureEndOpeningLength / 2);
-        this.addDoubleLines(upperLineStart, lowerLineStart, upperLineEnd, lowerLineEnd, wedgeLineWidth);
+        this.addDoubleLines(upperLineStart, upperLineEnd, lowerLineStart, lowerLineEnd, wedgeLineWidth);
     }
 
     /**

--- a/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
@@ -290,6 +290,13 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
                 this.lines[0].End.x += value;
                 this.lines[1].End.x += value;
             }
+        } else {
+            if (value < 0) {
+                this.lines[0].Start.x += value;
+            } else {
+                this.lines[0].End.x += value;
+                this.lines[1].End.x += value;
+            }
         }
         this.calcPsi();
     }

--- a/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
@@ -143,7 +143,7 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
         const lowerLineStart: PointF2D = new PointF2D(startX, y + wedgeMeasureBeginOpeningLength / 2);
         const upperLineEnd: PointF2D = new PointF2D(endX, y - wedgeOpeningLength / 2);
         const lowerLineEnd: PointF2D = new PointF2D(endX, y + wedgeOpeningLength / 2);
-        this.addDoubleLines(upperLineStart, lowerLineStart, upperLineEnd, lowerLineEnd, wedgeLineWidth);
+        this.addDoubleLines(upperLineStart, upperLineEnd, lowerLineStart, lowerLineEnd, wedgeLineWidth);
     }
 
     /**
@@ -280,7 +280,9 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
     }
 
     public squeeze(value: number): void {
-        if (this.IsVerbal) {
+        // Verbal expressions are not squeezable and squeezing below the width is also not possible
+        const width: number = Math.abs(this.lines[0].End.x - this.lines[0].Start.x);
+        if (this.IsVerbal || width < Math.abs(value)) {
             return;
         }
         if (this.ContinuousDynamic.DynamicType === ContDynamicEnum.crescendo) {

--- a/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalContinuousDynamicExpression.ts
@@ -281,8 +281,11 @@ export class GraphicalContinuousDynamicExpression extends AbstractGraphicalExpre
 
     public squeeze(value: number): void {
         // Verbal expressions are not squeezable and squeezing below the width is also not possible
+        if (this.IsVerbal) {
+            return;
+        }
         const width: number = Math.abs(this.lines[0].End.x - this.lines[0].Start.x);
-        if (this.IsVerbal || width < Math.abs(value)) {
+        if (width < Math.abs(value)) {
             return;
         }
         if (this.ContinuousDynamic.DynamicType === ContDynamicEnum.crescendo) {

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1163,9 +1163,7 @@ export abstract class MusicSheetCalculator {
         graphicalContinuousDynamic.Lines.clear();
         if (graphicalContinuousDynamic.ContinuousDynamic.DynamicType === ContDynamicEnum.crescendo) {
             if (sameStaffLine) {
-                graphicalContinuousDynamic.createCrescendoLines(
-                    upperStartX + this.rules.WedgeHorizontalMargin,
-                    upperEndX - this.rules.WedgeHorizontalMargin, idealY);
+                graphicalContinuousDynamic.createCrescendoLines(upperStartX, upperEndX, idealY);
                 graphicalContinuousDynamic.calcPsi();
             } else {
                 // two different Wedges

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1170,7 +1170,7 @@ export abstract class MusicSheetCalculator {
                 graphicalContinuousDynamic.createFirstHalfCrescendoLines(upperStartX, upperEndX, idealY);
                 graphicalContinuousDynamic.calcPsi();
 
-                secondGraphicalContinuousDynamic.createSecondHalfCresendoLines(lowerStartX, lowerEndX, secondIdealY);
+                secondGraphicalContinuousDynamic.createSecondHalfCrescendoLines(lowerStartX, lowerEndX, secondIdealY);
                 secondGraphicalContinuousDynamic.calcPsi();
             }
         } else if (graphicalContinuousDynamic.ContinuousDynamic.DynamicType === ContDynamicEnum.diminuendo) {

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -959,7 +959,7 @@ export abstract class MusicSheetCalculator {
 
         // Upper staff wedge always starts at the given position and the lower staff wedge always starts at the begin of measure
         const upperStartX: number = startPosInStaffline.x;
-        const lowerStartX: number = endStaffLine.Measures[0].beginInstructionsWidth + this.rules.WedgeHorizontalMargin;
+        const lowerStartX: number = endStaffLine.Measures[0].beginInstructionsWidth - this.rules.WedgeHorizontalMargin - 2;
         let upperEndX: number = 0;
         let lowerEndX: number = 0;
 
@@ -1181,7 +1181,7 @@ export abstract class MusicSheetCalculator {
                 graphicalContinuousDynamic.createFirstHalfDiminuendoLines(upperStartX, upperEndX, idealY);
                 graphicalContinuousDynamic.calcPsi();
 
-                secondGraphicalContinuousDynamic.createSecondHalfCresendoLines(lowerStartX, lowerEndX, secondIdealY);
+                secondGraphicalContinuousDynamic.createSecondHalfDiminuendoLines(lowerStartX, lowerEndX, secondIdealY);
                 secondGraphicalContinuousDynamic.calcPsi();
             }
         } //End Diminuendo

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1163,7 +1163,9 @@ export abstract class MusicSheetCalculator {
         graphicalContinuousDynamic.Lines.clear();
         if (graphicalContinuousDynamic.ContinuousDynamic.DynamicType === ContDynamicEnum.crescendo) {
             if (sameStaffLine) {
-                graphicalContinuousDynamic.createCrescendoLines(upperStartX, upperEndX, idealY);
+                graphicalContinuousDynamic.createCrescendoLines(
+                    upperStartX + this.rules.WedgeHorizontalMargin,
+                    upperEndX - this.rules.WedgeHorizontalMargin, idealY);
                 graphicalContinuousDynamic.calcPsi();
             } else {
                 // two different Wedges

--- a/src/MusicalScore/Graphical/StaffLine.ts
+++ b/src/MusicalScore/Graphical/StaffLine.ts
@@ -12,7 +12,7 @@ import {GraphicalLabel} from "./GraphicalLabel";
 import { SkyBottomLineCalculator } from "./SkyBottomLineCalculator";
 import { GraphicalOctaveShift } from "./GraphicalOctaveShift";
 import { GraphicalSlur } from "./GraphicalSlur";
-import { AlignmentManager } from "./AlignementManager";
+import { AlignmentManager } from "./AlignmentManager";
 import { AbstractGraphicalExpression } from "./AbstractGraphicalExpression";
 
 /**

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -233,7 +233,7 @@ export class OpenSheetMusicDisplay {
                 //    document.documentElement.offsetWidth
                 //);
                 //self.container.style.width = width + "px";
-                if (this.graphic !== undefined) {
+                if (self.graphic !== undefined) {
                     self.render();
                 }
             }
@@ -246,9 +246,6 @@ export class OpenSheetMusicDisplay {
      * @param endCallback is the function called when resizing (kind-of) ends
      */
     private handleResize(startCallback: () => void, endCallback: () => void): void {
-        if (this.graphic === undefined) {
-            return;
-        }
         let rtime: number;
         let timeout: number = undefined;
         const delta: number = 200;

--- a/test/data/OSMD_function_test_expressions_overlap.musicxml
+++ b/test/data/OSMD_function_test_expressions_overlap.musicxml
@@ -1,310 +1,365 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
-  <identification>
-    <encoding>
-      <software>MuseScore 2.3.2</software>
-      <encoding-date>2018-09-30</encoding-date>
-      <supports element="accidental" type="yes"/>
-      <supports element="beam" type="yes"/>
-      <supports element="print" attribute="new-page" type="yes" value="yes"/>
-      <supports element="print" attribute="new-system" type="yes" value="yes"/>
-      <supports element="stem" type="yes"/>
-      </encoding>
+    <work>
+        <work-title>Dynamic Expressions Overlap</work-title>
+    </work>
+    <identification>
+        <encoding>
+            <software>MuseScore 2.3.2</software>
+            <encoding-date>2018-10-13</encoding-date>
+            <supports element="accidental" type="yes"/>
+            <supports element="beam" type="yes"/>
+            <supports element="print" attribute="new-page" type="yes" value="yes"/>
+            <supports element="print" attribute="new-system" type="yes" value="yes"/>
+            <supports element="stem" type="yes"/>
+        </encoding>
     </identification>
-  <defaults>
-    <scaling>
-      <millimeters>7.05556</millimeters>
-      <tenths>40</tenths>
-      </scaling>
-    <page-layout>
-      <page-height>1683.36</page-height>
-      <page-width>1190.88</page-width>
-      <page-margins type="even">
-        <left-margin>56.6929</left-margin>
-        <right-margin>56.6929</right-margin>
-        <top-margin>56.6929</top-margin>
-        <bottom-margin>113.386</bottom-margin>
-        </page-margins>
-      <page-margins type="odd">
-        <left-margin>56.6929</left-margin>
-        <right-margin>56.6929</right-margin>
-        <top-margin>56.6929</top-margin>
-        <bottom-margin>113.386</bottom-margin>
-        </page-margins>
-      </page-layout>
-    <word-font font-family="FreeSerif" font-size="10"/>
-    <lyric-font font-family="FreeSerif" font-size="11"/>
+    <defaults>
+        <scaling>
+            <millimeters>7.05556</millimeters>
+            <tenths>40</tenths>
+        </scaling>
+        <page-layout>
+            <page-height>1683.36</page-height>
+            <page-width>1190.88</page-width>
+            <page-margins type="even">
+                <left-margin>56.6929</left-margin>
+                <right-margin>56.6929</right-margin>
+                <top-margin>56.6929</top-margin>
+                <bottom-margin>113.386</bottom-margin>
+            </page-margins>
+            <page-margins type="odd">
+                <left-margin>56.6929</left-margin>
+                <right-margin>56.6929</right-margin>
+                <top-margin>56.6929</top-margin>
+                <bottom-margin>113.386</bottom-margin>
+            </page-margins>
+        </page-layout>
+        <word-font font-family="FreeSerif" font-size="10"/>
+        <lyric-font font-family="FreeSerif" font-size="11"/>
     </defaults>
-  <part-list>
-    <score-part id="P1">
-      <part-name>Piano</part-name>
-      <part-abbreviation>Pno.</part-abbreviation>
-      <score-instrument id="P1-I1">
-        <instrument-name>Piano</instrument-name>
-        </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
-      <midi-instrument id="P1-I1">
-        <midi-channel>1</midi-channel>
-        <midi-program>1</midi-program>
-        <volume>78.7402</volume>
-        <pan>0</pan>
-        </midi-instrument>
-      </score-part>
+    <part-list>
+        <score-part id="P1">
+            <part-name>Piano</part-name>
+            <part-abbreviation>Pno.</part-abbreviation>
+            <score-instrument id="P1-I1">
+                <instrument-name>Piano</instrument-name>
+            </score-instrument>
+            <midi-device id="P1-I1" port="1"></midi-device>
+            <midi-instrument id="P1-I1">
+                <midi-channel>1</midi-channel>
+                <midi-program>1</midi-program>
+                <volume>78.7402</volume>
+                <pan>0</pan>
+            </midi-instrument>
+        </score-part>
     </part-list>
-  <part id="P1">
-    <measure number="1" width="614.02">
-      <print>
-        <system-layout>
-          <system-margins>
-            <left-margin>0.00</left-margin>
-            <right-margin>0.00</right-margin>
-            </system-margins>
-          <top-system-distance>70.00</top-system-distance>
-          </system-layout>
-        </print>
-      <attributes>
-        <divisions>2</divisions>
-        <key>
-          <fifths>0</fifths>
-          </key>
-        <time>
-          <beats>4</beats>
-          <beat-type>4</beat-type>
-          </time>
-        <clef>
-          <sign>G</sign>
-          <line>2</line>
-          </clef>
-        </attributes>
-      <direction placement="below">
-        <direction-type>
-          <dynamics default-x="6.58" default-y="-80.00">
-            <ppp/>
-            </dynamics>
-          </direction-type>
-        <sound dynamics="17.78"/>
-        </direction>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="crescendo" number="1" default-y="-75.00"/>
-          </direction-type>
-        </direction>
-      <note default-x="75.17" default-y="-40.00">
-        <pitch>
-          <step>E</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">begin</beam>
-        </note>
-      <note default-x="75.17" default-y="-25.00">
-        <chord/>
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="142.33" default-y="-20.00">
-        <pitch>
-          <step>B</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="stop" number="1"/>
-          </direction-type>
-        </direction>
-      <direction placement="below">
-        <direction-type>
-          <dynamics default-x="6.58" default-y="-80.00" relative-x="-1.37" relative-y="-0.38">
-            <ff/>
-            </dynamics>
-          </direction-type>
-        <sound dynamics="124.44"/>
-        </direction>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="crescendo" number="1" default-y="-75.00"/>
-          </direction-type>
-        </direction>
-      <note default-x="209.49" default-y="-20.00">
-        <pitch>
-          <step>B</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <note default-x="276.64" default-y="-15.00">
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <beam number="1">end</beam>
-        </note>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="stop" number="1"/>
-          </direction-type>
-        </direction>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="diminuendo" number="1" default-y="-75.00"/>
-          </direction-type>
-        </direction>
-      <note default-x="343.80" default-y="-15.00">
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        <beam number="1">begin</beam>
-        </note>
-      <note default-x="410.95" default-y="-25.00">
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="stop" number="1"/>
-          </direction-type>
-        </direction>
-      <note default-x="478.11" default-y="-40.00">
-        <pitch>
-          <step>E</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        </note>
-      <note default-x="478.11" default-y="5.00">
-        <chord/>
-        <pitch>
-          <step>G</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        </note>
-      <note default-x="545.27" default-y="-20.00">
-        <pitch>
-          <step>B</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        <beam number="1">end</beam>
-        </note>
-      <note default-x="533.40" default-y="0.00">
-        <chord/>
-        <pitch>
-          <step>F</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        </note>
-      <note default-x="545.27" default-y="5.00">
-        <chord/>
-        <pitch>
-          <step>G</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>down</stem>
-        </note>
-      </measure>
-    <measure number="2" width="463.47">
-      <direction placement="below">
-        <direction-type>
-          <dynamics default-x="6.58" default-y="-80.00" relative-x="-3.14" relative-y="-1.57">
-            <pp/>
-            </dynamics>
-          </direction-type>
-        <sound dynamics="36.67"/>
-        </direction>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="crescendo" number="1" default-y="-78.14" relative-x="5.81"/>
-          </direction-type>
-        </direction>
-      <note default-x="12.00" default-y="-30.00">
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <stem>up</stem>
-        </note>
-      <direction placement="below">
-        <direction-type>
-          <wedge type="stop" number="1" relative-x="1.57"/>
-          </direction-type>
-        </direction>
-      <direction placement="below">
-        <direction-type>
-          <dynamics default-x="3.29" default-y="-80.00" relative-x="-3.14" relative-y="-1.57">
-            <other-dynamics>sff</other-dynamics>
-            </dynamics>
-          </direction-type>
-        </direction>
-      <note default-x="232.26" default-y="-5.00">
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <stem>down</stem>
-        </note>
-      <barline location="right">
-        <bar-style>light-heavy</bar-style>
-        </barline>
-      </measure>
+    <part id="P1">
+        <measure number="1" width="457.55">
+            <print>
+                <system-layout>
+                    <system-margins>
+                        <left-margin>0.00</left-margin>
+                        <right-margin>-0.00</right-margin>
+                    </system-margins>
+                    <top-system-distance>70.00</top-system-distance>
+                </system-layout>
+            </print>
+            <attributes>
+                <divisions>2</divisions>
+                <key>
+                    <fifths>0</fifths>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+            </attributes>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="6.58" default-y="-80.00">
+                        <ppp/>
+                    </dynamics>
+                </direction-type>
+                <sound dynamics="17.78"/>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="crescendo" number="1" default-y="-75.00"/>
+                </direction-type>
+            </direction>
+            <note default-x="75.17" default-y="-40.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <beam number="1">begin</beam>
+            </note>
+            <note default-x="75.17" default-y="-25.00">
+                <chord/>
+                <pitch>
+                    <step>A</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+            </note>
+            <note default-x="122.77" default-y="-20.00">
+                <pitch>
+                    <step>B</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <beam number="1">continue</beam>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="stop" number="1"/>
+                </direction-type>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="6.58" default-y="-80.00" relative-x="-1.37" relative-y="-0.38">
+                        <ff/>
+                    </dynamics>
+                </direction-type>
+                <sound dynamics="124.44"/>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="crescendo" number="1" default-y="-75.00"/>
+                </direction-type>
+            </direction>
+            <note default-x="170.37" default-y="-20.00">
+                <pitch>
+                    <step>B</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <beam number="1">continue</beam>
+            </note>
+            <note default-x="217.97" default-y="-15.00">
+                <pitch>
+                    <step>C</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <beam number="1">end</beam>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="stop" number="1"/>
+                </direction-type>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="diminuendo" number="1" default-y="-75.00"/>
+                </direction-type>
+            </direction>
+            <note default-x="265.56" default-y="-15.00">
+                <pitch>
+                    <step>C</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+                <beam number="1">begin</beam>
+            </note>
+            <note default-x="313.16" default-y="-25.00">
+                <pitch>
+                    <step>A</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+                <beam number="1">continue</beam>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="stop" number="1"/>
+                </direction-type>
+            </direction>
+            <note default-x="360.76" default-y="-40.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+                <beam number="1">continue</beam>
+            </note>
+            <note default-x="360.76" default-y="5.00">
+                <chord/>
+                <pitch>
+                    <step>G</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+            </note>
+            <note default-x="408.35" default-y="-20.00">
+                <pitch>
+                    <step>B</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+                <beam number="1">end</beam>
+            </note>
+            <note default-x="396.49" default-y="0.00">
+                <chord/>
+                <pitch>
+                    <step>F</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+            </note>
+            <note default-x="408.35" default-y="5.00">
+                <chord/>
+                <pitch>
+                    <step>G</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+            </note>
+        </measure>
+        <measure number="2" width="298.00">
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="6.58" default-y="-80.00" relative-x="-3.14" relative-y="-1.57">
+                        <pp/>
+                    </dynamics>
+                </direction-type>
+                <sound dynamics="36.67"/>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="crescendo" number="1" default-y="-78.14" relative-x="5.81"/>
+                </direction-type>
+            </direction>
+            <note default-x="12.00" default-y="-30.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>1</voice>
+                <type>half</type>
+                <stem>up</stem>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="stop" number="1" relative-x="1.57"/>
+                </direction-type>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="3.29" default-y="-80.00" relative-x="-3.14" relative-y="-1.57">
+                        <other-dynamics>sff</other-dynamics>
+                    </dynamics>
+                </direction-type>
+            </direction>
+            <note default-x="154.02" default-y="-5.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>1</voice>
+                <type>half</type>
+                <stem>down</stem>
+            </note>
+        </measure>
+        <measure number="3" width="321.94">
+            <direction placement="below">
+                <direction-type>
+                    <words default-y="-80.00" relative-x="64.32" font-style="italic" font-size="12">crescendo</words>
+                </direction-type>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="6.58" default-y="-80.00">
+                        <pp/>
+                    </dynamics>
+                </direction-type>
+                <sound dynamics="36.67"/>
+            </direction>
+            <note default-x="12.00" default-y="-35.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>1</voice>
+                <type>half</type>
+                <stem>up</stem>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="6.58" default-y="-80.00" relative-x="-10.28" relative-y="-0.38">
+                        <sffz/>
+                    </dynamics>
+                </direction-type>
+            </direction>
+            <note default-x="145.24" default-y="-35.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+            </note>
+            <note default-x="228.29" default-y="-15.00">
+                <pitch>
+                    <step>C</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+            </note>
+            <barline location="right">
+                <bar-style>light-heavy</bar-style>
+            </barline>
+        </measure>
     </part>
-  </score-partwise>
+</score-partwise>


### PR DESCRIPTION
Spacing between two crescendos is already fixed here:
![image](https://user-images.githubusercontent.com/33069673/46895496-f238b480-ce78-11e8-9fd2-1a63145c1c8a.png)

I couldn't figure out how to fix the spacing between crescendo and e.g. a forte though, like in the Entertainer:
![image](https://user-images.githubusercontent.com/33069673/46895558-3926aa00-ce79-11e8-8428-0a1de4699d76.png)

It's strange because it works well in the function test Expressions Overlap.
![image](https://user-images.githubusercontent.com/33069673/46895567-4a6fb680-ce79-11e8-85f6-5782ca38d044.png)
The problem may be that in the Entertainer, the crescendo ends at the first note of the next bar.
This is a pretty common setup though, also found in Schubert - An die Musik.

I also added an option to [show wedges bounding boxes](https://user-images.githubusercontent.com/33069673/46909121-b57ac500-cf2d-11e8-8300-55704c98f436.png) to the demo.
