### PR TITLE
set autoResize at runtime, fix autoResize handling, demo null checks

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -12,6 +12,10 @@ select {
   width: 320px;
 }
 
+#selectBounding {
+  width: 80%;
+}
+
 .bignum {
   width: 1em;
   text-align: center;

--- a/demo/index.html
+++ b/demo/index.html
@@ -78,7 +78,7 @@
     </div>
     <div class="column">
         <h3 class="ui header">Show bounding box for:</h3>
-        <select class="ui selection dropdown" id="selectBounding">
+        <select class="ui selection dropdown" id="selectBounding" style="width: 80%">
             <option value="none">None</option>
             <option value="all">All</option>
             <option value="VexFlowMeasure">Measures</option>
@@ -111,8 +111,14 @@
     </div>
     <div class="column">
         <h3 class="ui header">Debug controls:</h3>
-        <div class="ui vertical buttons">
-            <div class="ui button" id="debug-re-render-btn">Re-render</div>
+        <div>
+            <div class="ui vertical buttons">
+                <div class="ui button" id="debug-re-render-btn" style="width: 100%">Re-render</div>
+                
+            </div>
+            <div class="ui vertical buttons">
+                <div class="ui button" id="debug-clear-btn" style="width: 100%">Clear</div>
+            </div>
         </div>
     </div>
 </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -78,7 +78,7 @@
     </div>
     <div class="column">
         <h3 class="ui header">Show bounding box for:</h3>
-        <select class="ui selection dropdown" id="selectBounding" style="width: 80%">
+        <select class="ui selection dropdown" id="selectBounding">
             <option value="none">None</option>
             <option value="all">All</option>
             <option value="VexFlowMeasure">Measures</option>
@@ -113,11 +113,11 @@
         <h3 class="ui header">Debug controls:</h3>
         <div>
             <div class="ui vertical buttons">
-                <div class="ui button" id="debug-re-render-btn" style="width: 100%">Re-render</div>
+                <div class="ui button" id="debug-re-render-btn">Re-render</div>
                 
             </div>
             <div class="ui vertical buttons">
-                <div class="ui button" id="debug-clear-btn" style="width: 100%">Clear</div>
+                <div class="ui button" id="debug-clear-btn"">Clear</div>
             </div>
         </div>
     </div>

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -6,9 +6,11 @@ import { PlacementEnum } from "../VoiceData/Expressions/AbstractExpression";
 
 export class EngravingRules {
     private static rules: EngravingRules;
+    /** A unit of distance. 1.0 is the distance between lines of a stave for OSMD, which is 10 pixels in Vexflow. */
     private static unit: number = 1.0;
     private samplingUnit: number;
     private staccatoShorteningFactor: number;
+    /** Height (size) of the sheet title. */
     private sheetTitleHeight: number;
     private sheetSubtitleHeight: number;
     private sheetMinimumDistanceBetweenTitleAndSubtitle: number;
@@ -104,6 +106,10 @@ export class EngravingRules {
     private repetitionEndingLabelYOffset: number;
     private repetitionEndingLineYLowerOffset: number;
     private repetitionEndingLineYUpperOffset: number;
+    /** Default alignment of lyrics.
+     * Left alignments will extend text to the right of the bounding box,
+     * which facilitates spacing by extending measure width.
+     */
     private lyricsAlignmentStandard: TextAlignmentEnum;
     private lyricsHeight: number;
     private lyricsYOffsetToStaffHeight: number;
@@ -162,6 +168,7 @@ export class EngravingRules {
     private noteDistancesScalingFactors: number[] = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0];
     private durationDistanceDict: {[_: number]: number; } = {};
     private durationScalingDistanceDict: {[_: number]: number; } = {};
+    /** Whether to render a label for the composer of the piece at the top of the sheet. */
     private renderComposer: boolean;
     private renderTitle: boolean;
     private renderSubtitle: boolean;
@@ -170,6 +177,7 @@ export class EngravingRules {
     private renderFingerings: boolean;
     private dynamicExpressionMaxDistance: number;
     private dynamicExpressionSpacer: number;
+    /** Position of fingering label in relation to corresponding note (left, right supported, above, below experimental) */
     private fingeringPosition: PlacementEnum;
     private fingeringInsideStafflines: boolean;
 

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -416,6 +416,7 @@ export class OpenSheetMusicDisplay {
             this.autoResizeEnabled = true;
         } else if (options.autoResize === false) { // not undefined
             this.autoResizeEnabled = false;
+            // we could remove the window EventListener here, but not necessary.
         }
     }
 


### PR DESCRIPTION
osmd: autoResize defaults to true, add clear(), isReadyToRender() methods
osmd: fix autoResize handling: don't attach listeners multiple times, don't set timeouts if autoResize disabled

previously, disabling autoResize at runtime didn't work.

index.html: add clear button, improve re-render button size/layout
index.js (demo): null-check buttons for public demo, remove resize code (handled by osmd)

In the demo, try combinations of clear, re-render and this in the console:
`osmd.setOptions({autoResize: false})` (or true)

closes #403 (null-checks for github.io demo which has less buttons. better solved here)
closes #387 (autoResize code in osmd and index.js isn't inconsistent and duplicate anymore)