### PR TITLE
Add fix for cursor.next() when an instrument or voice is hidden

### DIFF
--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -64,7 +64,11 @@ export class Cursor {
     let x: number = 0, y: number = 0, height: number = 0;
 
     // get all staff entries inside the current voice entry
-    const gseArr: VexFlowStaffEntry[] = iterator.CurrentVoiceEntries.map(ve => this.getStaffEntriesFromVoiceEntry(ve));
+    const gseArr: VexFlowStaffEntry[] = iterator.CurrentVisibleVoiceEntries().map(ve => this.getStaffEntriesFromVoiceEntry(ve));
+    if (!gseArr.length) {
+      // there are currently no visible voices that have notes because some instruments/voices are hidden
+      return;
+    }
     // sort them by x position and take the leftmost entry
     const gse: VexFlowStaffEntry =
           gseArr.sort((a, b) => a.PositionAndShape.AbsolutePosition.x <= b.PositionAndShape.AbsolutePosition.x ? -1 : 1 )[0];

--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -58,17 +58,14 @@ export class Cursor {
     }
     this.graphic.Cursors.length = 0;
     const iterator: MusicPartManagerIterator = this.iterator;
-    if (iterator.EndReached || iterator.CurrentVoiceEntries === undefined || iterator.CurrentVoiceEntries.length === 0) {
+    const voiceEntries: VoiceEntry[] = iterator.CurrentVisibleVoiceEntries();
+    if (iterator.EndReached || iterator.CurrentVoiceEntries === undefined || voiceEntries.length === 0) {
       return;
     }
     let x: number = 0, y: number = 0, height: number = 0;
 
     // get all staff entries inside the current voice entry
-    const gseArr: VexFlowStaffEntry[] = iterator.CurrentVisibleVoiceEntries().map(ve => this.getStaffEntriesFromVoiceEntry(ve));
-    if (!gseArr.length) {
-      // there are currently no visible voices that have notes because some instruments/voices are hidden
-      return;
-    }
+    const gseArr: VexFlowStaffEntry[] = voiceEntries.map(ve => this.getStaffEntriesFromVoiceEntry(ve));
     // sort them by x position and take the leftmost entry
     const gse: VexFlowStaffEntry =
           gseArr.sort((a, b) => a.PositionAndShape.AbsolutePosition.x <= b.PositionAndShape.AbsolutePosition.x ? -1 : 1 )[0];

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -192,4 +192,25 @@ describe("OpenSheetMusicDisplay Main Export", () => {
             done
         ).catch(done);
     });
+
+    describe("show and hide instruments", () => {
+        let osmd: OpenSheetMusicDisplay;
+        beforeEach(() => {
+            const div: HTMLElement = TestUtils.getDivElement(document);
+            osmd = TestUtils.createOpenSheetMusicDisplay(div);
+            const score: Document =
+                TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
+            return osmd.load(score)
+            .then(() => {
+                osmd.render();
+            });
+        });
+
+        it("should move cursor after instrument is hidden", () => {
+            osmd.Sheet.Instruments[0].Visible = false;
+            osmd.render();
+            osmd.cursor.show();
+            osmd.cursor.next();
+        });
+    });
 });

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -193,7 +193,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
         ).catch(done);
     });
 
-    describe("show and hide instruments", () => {
+    describe("cursor with hidden instrument", () => {
         let osmd: OpenSheetMusicDisplay;
         beforeEach(() => {
             const div: HTMLElement = TestUtils.getDivElement(document);
@@ -207,10 +207,12 @@ describe("OpenSheetMusicDisplay Main Export", () => {
         });
 
         it("should move cursor after instrument is hidden", () => {
-            osmd.Sheet.Instruments[0].Visible = false;
+            osmd.Sheet.Instruments[1].Visible = false;
             osmd.render();
             osmd.cursor.show();
-            osmd.cursor.next();
+            for (let i: number = 0; i < 100; i++) {
+                osmd.cursor.next();
+            }
         });
     });
 });


### PR DESCRIPTION
Calling `cursor.next()` might throw an error when an instrument is invisible (i.e. `osmd.Sheet.Instruments[0].Visible = false` is set and `osmd.render()` is called):

```
TypeError: Cannot read property 'PositionAndShape' of undefined
    at Cursor../src/OpenSheetMusicDisplay/Cursor.ts.Cursor.update:73
```

This happens if all of the voice entries under cursor are hidden. In other words, when the currently visible voices under cursor have no notes, but the hidden ones do.

I solved this problem by modifying the `Cursor#update()` method to use `iterator.CurrentVisibleVoiceEntries()` instead of `iterator.CurrentVoiceEntries`.

Also added a test which will fail if changes in `Cursor.ts` are reverted.