### PR TITLE
feat(ChordSymbols): Chord symbols are now updating their bounding box…

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -847,7 +847,25 @@ export abstract class MusicSheetCalculator {
     }
 
     protected calculateChordSymbols(): void {
-        return;
+        for (const musicPage of this.graphicalMusicSheet.MusicPages) {
+            for (const musicSystem of musicPage.MusicSystems) {
+                for (const staffLine of musicSystem.StaffLines) {
+                    const sbc: SkyBottomLineCalculator = staffLine.SkyBottomLineCalculator;
+                    for (const measure of staffLine.Measures) {
+                        for (const staffEntry of measure.staffEntries) {
+                            if (!staffEntry.graphicalChordContainer) {
+                                continue;
+                            }
+                            const sps: BoundingBox = staffEntry.PositionAndShape;
+                            const gps: BoundingBox = staffEntry.graphicalChordContainer.PositionAndShape;
+                            const start: number = gps.BorderMarginLeft + sps.AbsolutePosition.x;
+                            const end: number = gps.BorderMarginRight + sps.AbsolutePosition.x;
+                            sbc.updateSkyLineInRange(start, end, sps.BorderMarginTop);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
… in the skyline.
#464 

This should at least remedy most collisions. What I didn't include is the dynamic positioning of the chord labels. As @sschmidTU said they are only place at a fixed distance above the staffline. I downloaded some examples from musescore which looked quite OK with it. 
@bukaznik: Can you send me your files for further testing?

