### PR TITLE
* Bar Lines: Add support for ending bar line styles

### DIFF
--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -685,6 +685,31 @@ export class MusicSystemBuilder {
         if (this.nextMeasureHasKeyInstructionChange() || this.thisMeasureEndsWordRepetition() || this.nextMeasureBeginsWordRepetition()) {
             return SystemLinesEnum.DoubleThin;
         }
+        const sourceMeasure: SourceMeasure = this.measureList[this.measureListIndex][0].parentSourceMeasure;
+        if (sourceMeasure.endingBarStyle === "regular") {
+            return SystemLinesEnum.SingleThin;
+        } else if (sourceMeasure.endingBarStyle === "dotted") {
+            return SystemLinesEnum.Dotted;
+        } else if (sourceMeasure.endingBarStyle === "dashed") {
+            return SystemLinesEnum.Dashed;
+        } else if (sourceMeasure.endingBarStyle === "heavy") {
+            return SystemLinesEnum.Bold;
+        } else if (sourceMeasure.endingBarStyle === "light-light") {
+            return SystemLinesEnum.DoubleThin;
+        } else if (sourceMeasure.endingBarStyle === "light-heavy") {
+            return SystemLinesEnum.ThinBold;
+        } else if (sourceMeasure.endingBarStyle === "heavy-light") {
+            return SystemLinesEnum.BoldThin;
+        } else if (sourceMeasure.endingBarStyle === "heavy-heavy") {
+            return SystemLinesEnum.DoubleBold;
+        } else if (sourceMeasure.endingBarStyle === "tick") {
+            return SystemLinesEnum.Tick;
+        } else if (sourceMeasure.endingBarStyle === "short") {
+            return SystemLinesEnum.Short;
+        } else if (sourceMeasure.endingBarStyle === "none") {
+            return SystemLinesEnum.None;
+        }
+        // TODO: print an error message if the default fallback is used.
         return SystemLinesEnum.SingleThin;
     }
 

--- a/src/MusicalScore/Graphical/SystemLinesEnum.ts
+++ b/src/MusicalScore/Graphical/SystemLinesEnum.ts
@@ -1,9 +1,16 @@
 export enum SystemLinesEnum {
-    SingleThin = 0,
-    DoubleThin = 1,
-    ThinBold = 2,
-    BoldThinDots = 3,
-    DotsThinBold = 4,
-    DotsBoldBoldDots = 5,
-    None = 6
+    SingleThin = 0,       /*SINGLE,       [bar-style=regular]*/
+    DoubleThin = 1,       /*DOUBLE,       [bar-style=light-light]*/
+    ThinBold = 2,         /*END,          [bar-style=light-heavy]*/
+    BoldThinDots = 3,     /*REPEAT_BEGIN, repeat[direction=forward]*/
+    DotsThinBold = 4,     /*REPEAT_END,   repeat[direction=backward]*/
+    DotsBoldBoldDots = 5, /*REPEAT_BOTH*/
+    None = 6,             /*              [bar-style=none]*/
+    Dotted = 7,           /*              [bar-style=dotted]*/
+    Dashed = 8,           /*              [bar-style=dashed]*/
+    Bold = 9,             /*              [bar-style=heavy]*/
+    BoldThin = 10,        /*              [bar-style=heavy-light]*/
+    DoubleBold = 11,      /*              [bar-style=heavy-heavy]*/
+    Tick = 12,            /*              [bar-style=tick]*/
+    Short = 13            /*              [bar-style=short]*/
 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -199,6 +199,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
                     case SystemLinesEnum.ThinBold:
                         this.stave.setEndBarType(Vex.Flow.Barline.type.END);
                         break;
+                    // TODO: Add support for additional Barline types when VexFlow supports them
                     default:
                         break;
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -199,6 +199,9 @@ export class VexFlowMeasure extends GraphicalMeasure {
                     case SystemLinesEnum.ThinBold:
                         this.stave.setEndBarType(Vex.Flow.Barline.type.END);
                         break;
+                    case SystemLinesEnum.None:
+                        this.stave.setEndBarType(Vex.Flow.Barline.type.NONE);
+                        break;
                     // TODO: Add support for additional Barline types when VexFlow supports them
                     default:
                         break;

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -473,6 +473,9 @@ export class InstrumentReader {
              this.currentMeasure.endsPiece = true;
            }
           }
+          if (xmlNode.element("bar-style") !== undefined) {
+            this.currentMeasure.endingBarStyle = xmlNode.element("bar-style").value;
+          }
         } else if (xmlNode.name === "sound") {
           // (*) MetronomeReader.readTempoInstruction(xmlNode, this.musicSheet, this.currentXmlMeasureIndex);
         } else if (xmlNode.name === "harmony") {

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -29,6 +29,7 @@ export class SourceMeasure {
         this.implicitMeasure = false;
         this.breakSystemAfter = false;
         this.endsPiece = false;
+        this.endingBarStyle = "";
         this.firstInstructionsStaffEntries = new Array(completeNumberOfStaves);
         this.lastInstructionsStaffEntries = new Array(completeNumberOfStaves);
         for (let i: number = 0; i < completeNumberOfStaves; i++) {
@@ -45,6 +46,10 @@ export class SourceMeasure {
      * The measure number for showing on the music sheet. Typically starts with 1.
      */
     public endsPiece: boolean;
+    /**
+     * The style of the ending bar line.
+     */
+    public endingBarStyle: string;
 
     private measureNumber: number;
     private absoluteTimestamp: Fraction;


### PR DESCRIPTION
Starts to add support for bar-style

Note: changes need to be made to VexFlow for these to be complete.

Example: 46a-Barlines.xml from the [Unofficial MusicXML Test Suite](http://lilypond.org/doc/v2.18/input/regression/musicxml/collated-files#t_g46-_002e_002e_002e-barlines-measures).

Measure 6 has `[bar-style=light-light]`, measure 7 `[bar-style=light-heavy]`

![barlinesosmd](https://user-images.githubusercontent.com/12452738/56911519-1bb6d780-6a7b-11e9-9075-ee0674813fe6.png)
