### PR TITLE
Added feature `MinMeasureToDrawIndex`

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -190,6 +190,7 @@ export class EngravingRules {
     private defaultColorLabel: string;
     private defaultColorTitle: string;
     private maxMeasureToDrawIndex: number;
+    private minMeasureToDrawIndex: number;
     /** Whether to render a label for the composer of the piece at the top of the sheet. */
     private renderComposer: boolean;
     private renderTitle: boolean;
@@ -406,6 +407,7 @@ export class EngravingRules {
         this.defaultColorLabel = this.defaultColorNotehead;
         this.defaultColorTitle = this.defaultColorNotehead;
         this.maxMeasureToDrawIndex = Number.MAX_VALUE;
+        this.minMeasureToDrawIndex = 0;
         this.renderComposer = true;
         this.renderTitle = true;
         this.renderSubtitle = true;
@@ -1403,6 +1405,12 @@ export class EngravingRules {
     }
     public set MaxMeasureToDrawIndex(value: number) {
         this.maxMeasureToDrawIndex = value;
+    }
+    public get MinMeasureToDrawIndex(): number {
+        return this.minMeasureToDrawIndex;
+    }
+    public set MinMeasureToDrawIndex(value: number) {
+        this.minMeasureToDrawIndex = value;
     }
     public get RenderComposer(): boolean {
         return this.renderComposer;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -2601,7 +2601,8 @@ export abstract class MusicSheetCalculator {
 
     private calculateDynamicExpressions(): void {
         const maxIndex: number = Math.min(this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length, EngravingRules.Rules.MaxMeasureToDrawIndex);
-        for (let i: number = 0; i < maxIndex; i++) {
+        const minIndex: number = EngravingRules.Rules.MinMeasureToDrawIndex;
+        for (let i: number = minIndex; i < maxIndex; i++) {
             const sourceMeasure: SourceMeasure = this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures[i];
             for (let j: number = 0; j < sourceMeasure.StaffLinkedExpressions.length; j++) {
                 if (this.graphicalMusicSheet.MeasureList[i][j].ParentStaff.ParentInstrument.Visible) {
@@ -2682,7 +2683,8 @@ export abstract class MusicSheetCalculator {
 
     private calculateTempoExpressions(): void {
         const maxIndex: number = Math.min(this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length, EngravingRules.Rules.MaxMeasureToDrawIndex);
-        for (let i: number = 0; i < maxIndex; i++) {
+        const minIndex: number = EngravingRules.Rules.MinMeasureToDrawIndex;
+        for (let i: number = minIndex; i < maxIndex; i++) {
             const sourceMeasure: SourceMeasure = this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures[i];
             for (let j: number = 0; j < sourceMeasure.TempoExpressions.length; j++) {
                 this.calculateTempoExpressionsForMultiTempoExpression(sourceMeasure, sourceMeasure.TempoExpressions[j], i);

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -671,7 +671,8 @@ export abstract class MusicSheetCalculator {
 
         // visible 2D-MeasureList
         const visibleMeasureList: GraphicalMeasure[][] = [];
-        for (let idx: number = 0, len: number = allMeasures.length; idx < len && idx < EngravingRules.Rules.MaxMeasureToDrawIndex; ++idx) {
+        for (let idx: number = EngravingRules.Rules.MinMeasureToDrawIndex, len: number = allMeasures.length;
+            idx < len && idx < EngravingRules.Rules.MaxMeasureToDrawIndex; ++idx) {
             const graphicalMeasures: GraphicalMeasure[] = allMeasures[idx];
             const visiblegraphicalMeasures: GraphicalMeasure[] = [];
             for (let idx2: number = 0, len2: number = graphicalMeasures.length; idx2 < len2; ++idx2) {

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -57,8 +57,10 @@ export interface IOSMDOptions {
     fingeringPosition?: string;
     /** For above/below fingerings, whether to draw them directly above/below notes (default), or above/below staffline. */
     fingeringInsideStafflines?: boolean;
-    /** Only draw measure 1 to n, where n is the number you specify. */
+    /** Only draw measure n to m, where m is the number you specify. */
     drawUpToMeasureNumber?: number;
+    /** Only draw measure n to m, where n is the number you specify. */
+    drawFromMeasureNumber?: number;
     /** Whether to set the wanted stem direction by xml (default) or automatically. */
     setWantedStemDirectionByXml?: boolean;
     /** Whether tuplets are labeled with ratio (e.g. 5:2 instead of 5 for quintuplets). Default false. */

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -312,6 +312,9 @@ export class OpenSheetMusicDisplay {
         if (options.drawUpToMeasureNumber) {
             EngravingRules.Rules.MaxMeasureToDrawIndex = options.drawUpToMeasureNumber;
         }
+        if (options.drawFromMeasureNumber) {
+            EngravingRules.Rules.MinMeasureToDrawIndex = options.drawFromMeasureNumber;
+        }
         if (options.tupletsRatioed) {
             EngravingRules.Rules.TupletsRatioed = true;
         }


### PR DESCRIPTION
Hello,

I have added a new feature I personally wanted, allowing to render a particular interval of measures. Now,  `MaxMeasureToDrawIndex` is already implemented. I simply wanted to add its opposite `MinMeasureToDrawIndex`.

There is one thing that I want to ask you, how should I handle the case where `MinMeasureToDrawIndex > MaxMeasureToDrawIndex` ? Currently, an exception `TypeError: this.graphicalMusicSheet.MusicPages[0] is undefined` is thrown automatically. Other than that, here is a screenshot of the feature in action.

<img width="1268" alt="Screenshot 2019-05-30 at 03 35 25" src="https://user-images.githubusercontent.com/22145460/58604686-30120e00-828d-11e9-8fe2-d753df7744a7.png">
