### PR TITLE
Saving measures' BPM and fix #557

### DIFF
--- a/src/MusicalScore/MusicSheet.ts
+++ b/src/MusicalScore/MusicSheet.ts
@@ -41,6 +41,7 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
         this.pageWidth = 120;
         // create MusicPartManager
         this.MusicPartManager = new MusicPartManager(this);
+        this.hasBPMInfo = false;
     }
     public static defaultTitle: string = "[kein Titel]";
 
@@ -77,6 +78,11 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
     // (*) private musicSheetParameterObject: MusicSheetParameterObject = undefined;
     private engravingRules: EngravingRules;
     // (*) private musicSheetParameterChangedDelegate: MusicSheetParameterChangedDelegate;
+    /*
+     * The BPM info is present in the sheet, if it is set to false, means each measure's
+     * BPM was set to its value, 120
+     */
+    private hasBPMInfo: boolean;
 
     /**
      * Get the global index within the music sheet for this staff.
@@ -225,6 +231,15 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
     public set SelectionEnd(value: Fraction) {
         this.selectionEnd = value;
     }
+
+    public set HasBPMInfo(value: boolean) {
+        this.hasBPMInfo = value;
+    }
+
+    public get HasBPMInfo(): boolean {
+        return this.hasBPMInfo;
+    }
+
     // (*) public get MusicSheetParameterObject(): MusicSheetParameterObject {
     //    return this.musicSheetParameterObject;
     //}

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -502,11 +502,15 @@ export class InstrumentReader {
          const reader: ExpressionReader = this.expressionReaders[i];
          if (reader !== undefined) {
            reader.checkForOpenExpressions(this.currentMeasure, currentFraction);
-      }
+          }
         }
       }
 
-      if (currentMeasure.TempoInBPM === 0) {
+      // if this is the first measure and no BPM info found, we set it to 120
+      // next measures will automatically inherit that value
+      if (!this.musicSheet.HasBPMInfo) {
+        this.currentMeasure.TempoInBPM = 120;
+      } else if (currentMeasure.TempoInBPM === 0) {
         this.currentMeasure.TempoInBPM = this.previousMeasure.TempoInBPM;
       }
     } catch (e) {

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -505,6 +505,10 @@ export class InstrumentReader {
       }
         }
       }
+
+      if (currentMeasure.TempoInBPM === 0) {
+        this.currentMeasure.TempoInBPM = this.previousMeasure.TempoInBPM;
+      }
     } catch (e) {
       if (divisionsException) {
         throw new MusicSheetReadingException(e.Message);

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -183,7 +183,8 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
          afterSheetReadingModule.calculate(this.musicSheet);
         }
 
-        this.musicSheet.userStartTempoInBPM = this.musicSheet.SourceMeasures[0].TempoInBPM;
+        this.musicSheet.DefaultStartTempoInBpm = this.musicSheet.SourceMeasures[0].TempoInBPM;
+        this.musicSheet.userStartTempoInBPM = this.musicSheet.userStartTempoInBPM || this.musicSheet.DefaultStartTempoInBpm;
 
         return this.musicSheet;
     }

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -183,6 +183,8 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
          afterSheetReadingModule.calculate(this.musicSheet);
         }
 
+        this.musicSheet.userStartTempoInBPM = this.musicSheet.SourceMeasures[0].TempoInBPM;
+
         return this.musicSheet;
     }
 

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -142,6 +142,7 @@ export class ExpressionReader {
             if (tempoAttr) {
                 const match: string[] = tempoAttr.value.match(/\d+/);
                 this.soundTempo = match !== undefined ? parseInt(match[0], 10) : 100;
+                currentMeasure.TempoInBPM = this.soundTempo;
                 isTempoInstruction = true;
             }
             if (dynAttr) {

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -176,6 +176,9 @@ export class ExpressionReader {
                                                      bpmNumber,
                                                      this.currentMultiTempoExpression,
                                                      true);
+                this.soundTempo = bpmNumber;
+                currentMeasure.TempoInBPM = this.soundTempo;
+                this.musicSheet.HasBPMInfo = true;
                 instantaneousTempoExpression.dotted = dotted;
                 instantaneousTempoExpression.beatUnit = beatUnit.value;
                 this.currentMultiTempoExpression.addExpression(instantaneousTempoExpression, "");

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -143,6 +143,7 @@ export class ExpressionReader {
                 const match: string[] = tempoAttr.value.match(/\d+/);
                 this.soundTempo = match !== undefined ? parseInt(match[0], 10) : 100;
                 currentMeasure.TempoInBPM = this.soundTempo;
+                this.musicSheet.HasBPMInfo = true;
                 isTempoInstruction = true;
             }
             if (dynAttr) {

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -32,6 +32,7 @@ export class SourceMeasure {
         this.endingBarStyle = "";
         this.firstInstructionsStaffEntries = new Array(completeNumberOfStaves);
         this.lastInstructionsStaffEntries = new Array(completeNumberOfStaves);
+        this.TempoInBPM = 0;
         for (let i: number = 0; i < completeNumberOfStaves; i++) {
             this.graphicalMeasureErrors.push(false);
             this.staffLinkedExpressions.push([]);
@@ -65,7 +66,7 @@ export class SourceMeasure {
     private lastInstructionsStaffEntries: SourceStaffEntry[];
     private firstRepetitionInstructions: RepetitionInstruction[] = [];
     private lastRepetitionInstructions: RepetitionInstruction[] = [];
-
+    private tempoInBPM: number;
     private verticalMeasureList: GraphicalMeasure[]; // useful, see GraphicalMusicSheet.GetGraphicalFromSourceStaffEntry
 
     public get MeasureNumber(): number {
@@ -167,6 +168,13 @@ export class SourceMeasure {
         this.verticalMeasureList = value;
     }
 
+    public get TempoInBPM(): number {
+        return this.tempoInBPM;
+    }
+
+    public set TempoInBPM(value: number) {
+        this.tempoInBPM = value;
+    }
     /**
      * Check at the given timestamp if a VerticalContainer exists, if not creates a new, timestamp-ordered one,
      * and at the given index, if a [[SourceStaffEntry]] exists, and if not, creates a new one.


### PR DESCRIPTION
praisethemoon strikes once again with another PR. I personally needed such API to capture measure's tempo. 

Does this deprecate `this.osmd.sheet.userStartTempoInBPM`? Right now it has a different value (100) and I think it either must be deprecated, or inherits its value from BPM of the first measure. 

Any thoughts? 🎵 