### PR TITLE
Allow updating the graphical sheet from the music sheet

### DIFF
--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -150,7 +150,7 @@ export class OpenSheetMusicDisplay {
         }
         log.info(`[OSMD] Loaded sheet ${this.sheet.TitleString} successfully.`);
 
-        this.updateGraphicSheet();
+        this.updateGraphic();
 
         return Promise.resolve({});
     }
@@ -158,7 +158,7 @@ export class OpenSheetMusicDisplay {
     /**
      * (Re-)creates the graphic sheet from the music sheet
      */
-    public updateGraphicSheet(): void {
+    public updateGraphic(): void {
         const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();
         this.graphic = new GraphicalMusicSheet(this.sheet, calc);
         if (this.drawingParameters.drawCursors && this.cursor) {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -142,19 +142,28 @@ export class OpenSheetMusicDisplay {
             return Promise.reject(new Error("OpenSheetMusicDisplay: Document is not a valid 'partwise' MusicXML"));
         }
         const score: IXmlElement = new IXmlElement(scorePartwiseElement);
-        const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();
         const reader: MusicSheetReader = new MusicSheetReader();
         this.sheet = reader.createMusicSheet(score, "Untitled Score");
         if (this.sheet === undefined) {
             // error loading sheet, probably already logged, do nothing
             return Promise.reject(new Error("given music sheet was incomplete or could not be loaded."));
         }
+        log.info(`[OSMD] Loaded sheet ${this.sheet.TitleString} successfully.`);
+
+        this.updateGraphicSheet();
+
+        return Promise.resolve({});
+    }
+
+    /**
+     * (Re-)creates the graphic sheet from the music sheet
+     */
+    public updateGraphicSheet(): void {
+        const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();
         this.graphic = new GraphicalMusicSheet(this.sheet, calc);
         if (this.drawingParameters.drawCursors && this.cursor) {
             this.cursor.init(this.sheet.MusicPartManager, this.graphic);
         }
-        log.info(`[OSMD] Loaded sheet ${this.sheet.TitleString} successfully.`);
-        return Promise.resolve({});
     }
 
     /**

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -1,7 +1,7 @@
 import chai = require("chai");
 import { OpenSheetMusicDisplay } from "../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
 import { TestUtils } from "../../Util/TestUtils";
-import { VoiceEntry, Instrument, Note } from "../../../src";
+import { VoiceEntry, Instrument, Note, Staff, Voice, GraphicalStaffEntry, GraphicalNote, Fraction, Pitch, AccidentalEnum } from "../../../src";
 
 describe("OpenSheetMusicDisplay Main Export", () => {
     let container1: HTMLElement;
@@ -275,6 +275,39 @@ describe("OpenSheetMusicDisplay Main Export", () => {
             it("gets all notes under cursor when instrument unspecified", () => {
                 const notes: Note[] = opensheetmusicdisplay.cursor.NotesUnderCursor();
                 chai.expect(notes.length).to.equal(2);
+            });
+        });
+
+        describe("updateGraphic", () => {
+            it("updates the graphical sheet with mutations on the music sheet", () => {
+                const staff: Staff = opensheetmusicdisplay.Sheet.Staves[0];
+                const voice: Voice = staff.Voices[0];
+                const voiceEntry: VoiceEntry = voice.VoiceEntries[0];
+                const numNotesBefore: number = voiceEntry.Notes.length;
+
+                // Validate current state
+                {
+                    const graphicalStaffEntry: GraphicalStaffEntry = opensheetmusicdisplay.GraphicSheet.getStaffEntry(0);
+                    const graphicalNotes: GraphicalNote[] = graphicalStaffEntry.findVoiceEntryGraphicalNotes(voiceEntry);
+
+                    chai.expect(graphicalNotes.length).to.equal(numNotesBefore);
+                }
+
+                const newNote: Note = new Note(
+                    voiceEntry,
+                    voiceEntry.ParentSourceStaffEntry,
+                    new Fraction(1),
+                    new Pitch(11, 1, AccidentalEnum.NATURAL));
+                voiceEntry.Notes.push(newNote);
+
+                opensheetmusicdisplay.updateGraphicSheet();
+
+                {
+                    const graphicalStaffEntry: GraphicalStaffEntry = opensheetmusicdisplay.GraphicSheet.getStaffEntry(0);
+                    const graphicalNotes: GraphicalNote[] = graphicalStaffEntry.findVoiceEntryGraphicalNotes(voiceEntry);
+
+                    chai.expect(graphicalNotes.length).to.equal(numNotesBefore + 1);
+                }
             });
         });
     });

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -300,7 +300,7 @@ describe("OpenSheetMusicDisplay Main Export", () => {
                     new Pitch(11, 1, AccidentalEnum.NATURAL));
                 voiceEntry.Notes.push(newNote);
 
-                opensheetmusicdisplay.updateGraphicSheet();
+                opensheetmusicdisplay.updateGraphic();
 
                 {
                     const graphicalStaffEntry: GraphicalStaffEntry = opensheetmusicdisplay.GraphicSheet.getStaffEntry(0);


### PR DESCRIPTION
This would allow updating the model in the sheet and rerendering the graphical sheet thereof, thus allowing mutations on the OSMD model instead of the graphical model directly. However, this still requires a full rerender.