### PR TITLE
Add new render options (place ghost whole rest not or visible whole rest note)

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -213,6 +213,7 @@ export class EngravingRules {
     /** Position of fingering label in relation to corresponding note (left, right supported, above, below experimental) */
     private fingeringPosition: PlacementEnum;
     private fingeringInsideStafflines: boolean;
+    private showAutoPlaceWholeRestNote: boolean;
 
     constructor() {
         // global variables
@@ -435,6 +436,7 @@ export class EngravingRules {
         this.renderLyrics = true;
         this.fingeringPosition = PlacementEnum.Left; // easier to get bounding box, and safer for vertical layout
         this.fingeringInsideStafflines = false;
+        this.showAutoPlaceWholeRestNote = true;
 
         this.populateDictionaries();
         try {
@@ -1538,6 +1540,12 @@ export class EngravingRules {
     }
     public set FingeringInsideStafflines(value: boolean) {
         this.fingeringInsideStafflines = value;
+    }
+    public get ShowAutoPlaceWholeRestNote(): boolean {
+        return this.showAutoPlaceWholeRestNote;
+    }
+    public set ShowAutoPlaceWholeRestNote(value: boolean) {
+        this.showAutoPlaceWholeRestNote = value;
     }
 
     /**

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -2091,6 +2091,10 @@ export abstract class MusicSheetCalculator {
                 staff);
             const voiceEntry: VoiceEntry = new VoiceEntry(new Fraction(0, 1), staff.Voices[0], sourceStaffEntry);
             const note: Note = new Note(voiceEntry, sourceStaffEntry, Fraction.createFromFraction(sourceMeasure.Duration), undefined);
+            //if osmd option showAutoPlaceWholeRestNote is false, will draw invisible whole rest note
+            if (this.rules.ShowAutoPlaceWholeRestNote === false) {
+                note.PrintObject = false;
+            }
             voiceEntry.Notes.push(note);
             const graphicalStaffEntry: GraphicalStaffEntry = MusicSheetCalculator.symbolFactory.createStaffEntry(sourceStaffEntry, measure);
             measure.addGraphicalStaffEntry(graphicalStaffEntry);

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -108,6 +108,11 @@ export interface IOSMDOptions {
     tripletsBracketed?: boolean;
     /** Whether to draw hidden/invisible notes (print-object="no" in XML). Default false. Not yet supported. */ // TODO
     drawHiddenNotes?: boolean;
+    /** osmd will auto place whole rest note, if there are no notes information on specific staff, and will render it out.
+     * Default is true. which is will print the whole rest note out
+     * false, will print the ghost whole rest note, which is print-object = no
+     */
+    showAutoPlaceWholeRestNote?: boolean;
 }
 
 export enum AlignRestOption {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -383,6 +383,9 @@ export class OpenSheetMusicDisplay {
             this.autoResizeEnabled = false;
             // we could remove the window EventListener here, but not necessary.
         }
+        if (options.showAutoPlaceWholeRestNote !== undefined) {
+            EngravingRules.Rules.ShowAutoPlaceWholeRestNote = options.showAutoPlaceWholeRestNote;
+        }
     }
 
     public setColoringMode(options: IOSMDOptions): void {


### PR DESCRIPTION
Hi @sschmidTU  According to your suggestion on  #625 
I have added osmd render option, which could choose to print visible auto place whole rest note, or invisible