### PR TITLE
Allow for multiple OSMD instances on the same page

### DIFF
--- a/src/MusicalScore/Graphical/AbstractGraphicalExpression.ts
+++ b/src/MusicalScore/Graphical/AbstractGraphicalExpression.ts
@@ -11,7 +11,7 @@ export abstract class AbstractGraphicalExpression extends GraphicalObject {
     /** Internal cache of read expression */
     protected expression: AbstractExpression;
     /** EngravingRules for positioning */
-    protected rules: EngravingRules = EngravingRules.Rules;
+    protected rules: EngravingRules;
 
     constructor(parentStaffline: StaffLine, expression: AbstractExpression) {
         super();
@@ -19,6 +19,7 @@ export abstract class AbstractGraphicalExpression extends GraphicalObject {
         this.boundingBox = new BoundingBox(this, parentStaffline.PositionAndShape);
         this.parentStaffLine = parentStaffline;
         this.parentStaffLine.AbstractExpressions.push(this);
+        this.rules = parentStaffline.ParentMusicSystem.rules;
     }
 
     /** Graphical label of the expression if available */

--- a/src/MusicalScore/Graphical/AlignmentManager.ts
+++ b/src/MusicalScore/Graphical/AlignmentManager.ts
@@ -7,10 +7,11 @@ import { EngravingRules } from "./EngravingRules";
 
 export class AlignmentManager {
     private parentStaffline: StaffLine;
-    private rules: EngravingRules = EngravingRules.Rules;
+    private rules: EngravingRules;
 
     constructor(staffline: StaffLine) {
         this.parentStaffline = staffline;
+        this.rules = this.parentStaffline.ParentMusicSystem.rules;
     }
 
     public alignDynamicExpressions(): void {

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -20,6 +20,7 @@ export enum DrawingParametersEnum {
 export class DrawingParameters {
     /** will set other settings if changed with set method */
     private drawingParametersEnum: DrawingParametersEnum;
+    private rules: EngravingRules = new EngravingRules();
     public drawHighlights: boolean;
     public drawErrors: boolean;
     public drawSelectionStartSymbol: boolean;
@@ -87,7 +88,7 @@ export class DrawingParameters {
         this.drawCredits = true;
         this.DrawPartNames = true;
         this.drawHiddenNotes = true;
-        EngravingRules.Rules.CompactMode = false;
+        this.rules.CompactMode = false;
     }
 
     public setForDefault(): void {
@@ -110,7 +111,7 @@ export class DrawingParameters {
 
     public setForCompactMode(): void {
         this.setForDefault();
-        EngravingRules.Rules.CompactMode = true;
+        this.rules.CompactMode = true;
         this.DrawCredits = false; // sets DrawComposer, DrawTitle, DrawLyricist to false
         // this.DrawPartNames = true; // unnecessary
         this.drawHiddenNotes = false;
@@ -152,7 +153,7 @@ export class DrawingParameters {
     /** Enable or disable drawing the Title of the piece. If disabled, will disable drawing Subtitle as well. */
     public set DrawTitle(value: boolean) {
         this.drawTitle = value;
-        EngravingRules.Rules.RenderTitle = value;
+        this.rules.RenderTitle = value;
         if (!value) { // don't draw subtitle if title isn't drawn
             this.DrawSubtitle = false;
         }
@@ -165,7 +166,7 @@ export class DrawingParameters {
     /** Enable or disable drawing the Subtitle of the piece. If enabled, will enable drawing Title as well. */
     public set DrawSubtitle(value: boolean) {
         this.drawSubtitle = value;
-        EngravingRules.Rules.RenderSubtitle = value;
+        this.rules.RenderSubtitle = value;
         if (value) {
             this.DrawTitle = true; // if subtitle is drawn, title needs to be drawn as well
         }
@@ -178,7 +179,7 @@ export class DrawingParameters {
     /** Enable or disable drawing a label for the Composer of the piece. */
     public set DrawComposer(value: boolean) {
         this.drawComposer = value;
-        EngravingRules.Rules.RenderComposer = value;
+        this.rules.RenderComposer = value;
     }
 
     public get DrawLyricist(): boolean {
@@ -187,7 +188,7 @@ export class DrawingParameters {
 
     public set DrawLyricist(value: boolean) {
         this.drawLyricist = value;
-        EngravingRules.Rules.RenderLyricist = value;
+        this.rules.RenderLyricist = value;
     }
 
     public get DrawPartNames(): boolean {
@@ -196,7 +197,7 @@ export class DrawingParameters {
 
     public set DrawPartNames(value: boolean) {
         this.drawPartNames = value;
-        EngravingRules.Rules.RenderPartNames = value;
+        this.rules.RenderPartNames = value;
     }
 
     public get FingeringPosition(): PlacementEnum {
@@ -205,6 +206,14 @@ export class DrawingParameters {
 
     public set FingeringPosition(value: PlacementEnum) {
         this.fingeringPosition = value;
-        EngravingRules.Rules.FingeringPosition = value;
+        this.rules.FingeringPosition = value;
+    }
+
+    public get Rules(): EngravingRules {
+        return this.rules;
+    }
+
+    public set Rules(value: EngravingRules) {
+        this.rules = value;
     }
 }

--- a/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
@@ -18,7 +18,7 @@ export class GraphicalLyricEntry {
     constructor(lyricsEntry: LyricsEntry, graphicalStaffEntry: GraphicalStaffEntry, lyricsHeight: number, staffHeight: number) {
         this.lyricsEntry = lyricsEntry;
         this.graphicalStaffEntry = graphicalStaffEntry;
-        const lyricsTextAlignment: TextAlignmentEnum = graphicalStaffEntry.parentMeasure.parentMusicSystem.rules.LyricsAlignmentStandard;
+        const lyricsTextAlignment: TextAlignmentEnum = graphicalStaffEntry.parentMeasure.parentSourceMeasure.Rules.LyricsAlignmentStandard;
         // for small notes with long text, use center alignment
         // TODO use this, fix center+left alignment combination spacing
         if (lyricsEntry.Text.length >= 4

--- a/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
@@ -4,7 +4,6 @@ import {GraphicalLabel} from "./GraphicalLabel";
 import {GraphicalStaffEntry} from "./GraphicalStaffEntry";
 import {Label} from "../Label";
 import {PointF2D} from "../../Common/DataObjects/PointF2D";
-import { EngravingRules } from "./EngravingRules";
 import { TextAlignmentEnum } from "../../Common/Enums/TextAlignment";
 
 /**
@@ -19,7 +18,7 @@ export class GraphicalLyricEntry {
     constructor(lyricsEntry: LyricsEntry, graphicalStaffEntry: GraphicalStaffEntry, lyricsHeight: number, staffHeight: number) {
         this.lyricsEntry = lyricsEntry;
         this.graphicalStaffEntry = graphicalStaffEntry;
-        const lyricsTextAlignment: TextAlignmentEnum = EngravingRules.Rules.LyricsAlignmentStandard;
+        const lyricsTextAlignment: TextAlignmentEnum = graphicalStaffEntry.parentMeasure.parentMusicSystem.rules.LyricsAlignmentStandard;
         // for small notes with long text, use center alignment
         // TODO use this, fix center+left alignment combination spacing
         if (lyricsEntry.Text.length >= 4

--- a/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
+++ b/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
@@ -23,7 +23,6 @@ import {CollectionUtil} from "../../Util/CollectionUtil";
 import {SelectionStartSymbol} from "./SelectionStartSymbol";
 import {SelectionEndSymbol} from "./SelectionEndSymbol";
 import {OutlineAndFillStyleEnum} from "./DrawingEnums";
-import {EngravingRules} from "./EngravingRules";
 
 /**
  * The graphical counterpart of a [[MusicSheet]]
@@ -165,7 +164,7 @@ export class GraphicalMusicSheet {
      */
     public static transformRelativeToAbsolutePosition(graphicalMusicSheet: GraphicalMusicSheet): void {
         for (let i: number = 0; i < graphicalMusicSheet.MusicPages.length; i++) {
-            const pageAbsolute: PointF2D = graphicalMusicSheet.MusicPages[i].setMusicPageAbsolutePosition(i, graphicalMusicSheet.ParentMusicSheet.rules);
+            const pageAbsolute: PointF2D = graphicalMusicSheet.MusicPages[i].setMusicPageAbsolutePosition(i, graphicalMusicSheet.ParentMusicSheet.Rules);
             const page: GraphicalMusicPage = graphicalMusicSheet.MusicPages[i];
             page.PositionAndShape.calculateAbsolutePositionsRecursive(pageAbsolute.x, pageAbsolute.y);
         }
@@ -463,7 +462,7 @@ export class GraphicalMusicSheet {
     public getLastGraphicalMeasureFromIndex(staffIndex: number, lastRendered: boolean = true): GraphicalMeasure {
         let measureIndex: number = this.measureList.length - 1;
         if (lastRendered) {
-            measureIndex = EngravingRules.Rules.MaxMeasureToDrawIndex;
+            measureIndex = this.musicSheet.Rules.MaxMeasureToDrawIndex;
         }
         return this.measureList[measureIndex][staffIndex];
     }

--- a/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts
@@ -20,6 +20,7 @@ export class GraphicalVoiceEntry extends GraphicalObject {
         this.parentStaffEntry = parentStaffEntry;
         this.PositionAndShape = new BoundingBox(this, parentStaffEntry ? parentStaffEntry.PositionAndShape : undefined, true);
         this.notes = [];
+        this.rules = parentStaffEntry.parentMeasure.parentMusicSystem.rules;
     }
 
     public parentVoiceEntry: VoiceEntry;
@@ -27,6 +28,7 @@ export class GraphicalVoiceEntry extends GraphicalObject {
     public notes: GraphicalNote[];
     /** Contains octave shifts affecting this voice entry, caused by octave brackets. */
     public octaveShiftValue: OctaveEnum;
+    private rules: EngravingRules;
 
     /** Sort this entry's notes by pitch.
      * Notes need to be sorted for Vexflow StaveNote creation.
@@ -43,9 +45,9 @@ export class GraphicalVoiceEntry extends GraphicalObject {
      * See VexFlowConverter.StaveNote()
      */
     public color(): void {
-        const defaultColorNotehead: string = EngravingRules.Rules.DefaultColorNotehead;
-        const defaultColorRest: string = EngravingRules.Rules.DefaultColorRest;
-        const defaultColorStem: string = EngravingRules.Rules.DefaultColorStem;
+        const defaultColorNotehead: string = this.rules.DefaultColorNotehead;
+        const defaultColorRest: string = this.rules.DefaultColorRest;
+        const defaultColorStem: string = this.rules.DefaultColorStem;
         const transparentColor: string = "#00000000"; // transparent color in vexflow
         let noteheadColor: string; // if null: no noteheadcolor to set (stays black)
 
@@ -55,13 +57,13 @@ export class GraphicalVoiceEntry extends GraphicalObject {
 
             noteheadColor = note.sourceNote.NoteheadColor;
             // Switch between XML colors and automatic coloring
-            if (EngravingRules.Rules.ColoringMode === ColoringModes.AutoColoring ||
-                EngravingRules.Rules.ColoringMode === ColoringModes.CustomColorSet) {
+            if (this.rules.ColoringMode === ColoringModes.AutoColoring ||
+                this.rules.ColoringMode === ColoringModes.CustomColorSet) {
                 if (note.sourceNote.isRest()) {
-                    noteheadColor = EngravingRules.Rules.ColoringSetCurrent.getValue(-1);
+                    noteheadColor = this.rules.ColoringSetCurrent.getValue(-1);
                 } else {
                     const fundamentalNote: NoteEnum = note.sourceNote.Pitch.FundamentalNote;
-                    noteheadColor = EngravingRules.Rules.ColoringSetCurrent.getValue(fundamentalNote);
+                    noteheadColor = this.rules.ColoringSetCurrent.getValue(fundamentalNote);
                 }
             }
             if (!note.sourceNote.PrintObject) {
@@ -70,7 +72,7 @@ export class GraphicalVoiceEntry extends GraphicalObject {
                 || noteheadColor === "#000000" // questionable, because you might want to set specific notes to black,
                                                // but unfortunately some programs export everything explicitly as black
                 ) {
-                noteheadColor = EngravingRules.Rules.DefaultColorNotehead;
+                noteheadColor = this.rules.DefaultColorNotehead;
             }
 
             // DEBUG runtime coloring test
@@ -96,7 +98,7 @@ export class GraphicalVoiceEntry extends GraphicalObject {
             }
 
             // color notebeam if all noteheads have same color and stem coloring enabled
-            if (EngravingRules.Rules.ColoringEnabled && note.sourceNote.NoteBeam && EngravingRules.Rules.ColorStemsLikeNoteheads) {
+            if (this.rules.ColoringEnabled && note.sourceNote.NoteBeam && this.rules.ColorStemsLikeNoteheads) {
                 const beamNotes: Note[] = note.sourceNote.NoteBeam.Notes;
                 let colorBeam: boolean = true;
                 for (let j: number = 0; j < beamNotes.length; j++) {
@@ -122,10 +124,10 @@ export class GraphicalVoiceEntry extends GraphicalObject {
         }
 
         // color stems
-        let stemColor: string = EngravingRules.Rules.DefaultColorStem; // reset to black/default when coloring was disabled. maybe needed elsewhere too
-        if (EngravingRules.Rules.ColoringEnabled) {
+        let stemColor: string = this.rules.DefaultColorStem; // reset to black/default when coloring was disabled. maybe needed elsewhere too
+        if (this.rules.ColoringEnabled) {
             stemColor = this.parentVoiceEntry.StemColor; // TODO: once coloringSetCustom gets stem color, respect it
-            if (!stemColor || EngravingRules.Rules.ColorStemsLikeNoteheads
+            if (!stemColor || this.rules.ColorStemsLikeNoteheads
                 || stemColor === "#000000") { // see above, noteheadColor === "#000000"
                 // condition could be even more fine-grained by only recoloring if there was no custom StemColor set. will be more complex though
                 if (noteheadColor) {
@@ -152,7 +154,7 @@ export class GraphicalVoiceEntry extends GraphicalObject {
                 this.parentVoiceEntry.StemColor = stemColor;
             }
             vfStaveNote.setStemStyle(stemStyle);
-            if (vfStaveNote.flag && vfStaveNote.setFlagStyle && EngravingRules.Rules.ColorFlags) {
+            if (vfStaveNote.flag && vfStaveNote.setFlagStyle && this.rules.ColorFlags) {
                 vfStaveNote.setFlagStyle(stemStyle);
             }
         }

--- a/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts
@@ -20,7 +20,7 @@ export class GraphicalVoiceEntry extends GraphicalObject {
         this.parentStaffEntry = parentStaffEntry;
         this.PositionAndShape = new BoundingBox(this, parentStaffEntry ? parentStaffEntry.PositionAndShape : undefined, true);
         this.notes = [];
-        this.rules = parentStaffEntry.parentMeasure.parentMusicSystem.rules;
+        this.rules = parentStaffEntry.parentMeasure.parentSourceMeasure.Rules;
     }
 
     public parentVoiceEntry: VoiceEntry;

--- a/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts
@@ -20,7 +20,8 @@ export class GraphicalVoiceEntry extends GraphicalObject {
         this.parentStaffEntry = parentStaffEntry;
         this.PositionAndShape = new BoundingBox(this, parentStaffEntry ? parentStaffEntry.PositionAndShape : undefined, true);
         this.notes = [];
-        this.rules = parentStaffEntry.parentMeasure.parentSourceMeasure.Rules;
+        this.rules = parentStaffEntry ?
+                        parentStaffEntry.parentMeasure.parentSourceMeasure.Rules : new EngravingRules();
     }
 
     public parentVoiceEntry: VoiceEntry;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -108,7 +108,7 @@ export abstract class MusicSheetCalculator {
 
     public initialize(graphicalMusicSheet: GraphicalMusicSheet): void {
         this.graphicalMusicSheet = graphicalMusicSheet;
-        this.rules = graphicalMusicSheet.ParentMusicSheet.rules;
+        this.rules = graphicalMusicSheet.ParentMusicSheet.Rules;
         this.prepareGraphicalMusicSheet();
         //this.calculate();
     }
@@ -235,21 +235,21 @@ export abstract class MusicSheetCalculator {
         // xPosition is always fixed
         let relativePosition: PointF2D = new PointF2D(this.rules.PageLeftMargin + this.rules.SystemLeftMargin, 0);
 
-        if (EngravingRules.Rules.CompactMode) {
-            relativePosition.y += EngravingRules.Rules.PageTopMarginNarrow;
+        if (this.rules.CompactMode) {
+            relativePosition.y += this.rules.PageTopMarginNarrow;
         } else {
-            relativePosition.y += EngravingRules.Rules.PageTopMargin;
+            relativePosition.y += this.rules.PageTopMargin;
         }
 
         // first System is handled extra
         const firstMusicSystem: MusicSystem = graphicalMusicPage.MusicSystems[0];
         if (graphicalMusicPage === graphicalMusicPage.Parent.MusicPages[0]) {
-            if (EngravingRules.Rules.RenderTitle) {
+            if (this.rules.RenderTitle) {
                 relativePosition.y += this.rules.TitleTopDistance + this.rules.SheetTitleHeight +
                     this.rules.TitleBottomDistance;
             }
         } else {
-            if (EngravingRules.Rules.RenderTitle) {
+            if (this.rules.RenderTitle) {
                 relativePosition.y += this.rules.PageTopMargin + this.rules.TitleTopDistance;
             } else {
                 relativePosition.y = this.rules.PageTopMargin;
@@ -669,15 +669,15 @@ export abstract class MusicSheetCalculator {
         if (allMeasures === undefined) {
             return;
         }
-        if (EngravingRules.Rules.MinMeasureToDrawIndex > allMeasures.length - 1) {
+        if (this.rules.MinMeasureToDrawIndex > allMeasures.length - 1) {
             log.debug("minimum measure to draw index out of range. resetting min measure index to limit.");
-            EngravingRules.Rules.MinMeasureToDrawIndex = allMeasures.length - 1;
+            this.rules.MinMeasureToDrawIndex = allMeasures.length - 1;
         }
 
         // visible 2D-MeasureList
         const visibleMeasureList: GraphicalMeasure[][] = [];
-        for (let idx: number = EngravingRules.Rules.MinMeasureToDrawIndex, len: number = allMeasures.length;
-            idx < len && idx <= EngravingRules.Rules.MaxMeasureToDrawIndex; ++idx) {
+        for (let idx: number = this.rules.MinMeasureToDrawIndex, len: number = allMeasures.length;
+            idx < len && idx <= this.rules.MaxMeasureToDrawIndex; ++idx) {
             const graphicalMeasures: GraphicalMeasure[] = allMeasures[idx];
             const visiblegraphicalMeasures: GraphicalMeasure[] = [];
             for (let idx2: number = 0, len2: number = graphicalMeasures.length; idx2 < len2; ++idx2) {
@@ -686,7 +686,7 @@ export abstract class MusicSheetCalculator {
                 if (graphicalMeasure.isVisible()) {
                     visiblegraphicalMeasures.push(graphicalMeasure);
 
-                    if (EngravingRules.Rules.ColoringEnabled) {
+                    if (this.rules.ColoringEnabled) {
                         // (re-)color notes
                         for (const staffEntry of graphicalMeasure.staffEntries) {
                             for (const gve of staffEntry.graphicalVoiceEntries) {
@@ -729,7 +729,7 @@ export abstract class MusicSheetCalculator {
             this.optimizeRestPlacement();
             // possible Displacement of RestNotes
             this.calculateStaffEntryArticulationMarks();
-            if (EngravingRules.Rules.RenderSlurs) { // technically we should separate slurs and ties, but shouldn't be relevant for now
+            if (this.rules.RenderSlurs) { // technically we should separate slurs and ties, but shouldn't be relevant for now
                 // calculate Ties
                 this.calculateTieCurves();
             }
@@ -741,7 +741,7 @@ export abstract class MusicSheetCalculator {
         this.calculateTupletNumbers();
 
         // calculate MeasureNumbers
-        if (EngravingRules.Rules.RenderMeasureNumbers) {
+        if (this.rules.RenderMeasureNumbers) {
             for (let idx: number = 0, len: number = this.graphicalMusicSheet.MusicPages.length; idx < len; ++idx) {
                 const graphicalMusicPage: GraphicalMusicPage = this.graphicalMusicSheet.MusicPages[idx];
                 for (let idx2: number = 0, len2: number = graphicalMusicPage.MusicSystems.length; idx2 < len2; ++idx2) {
@@ -751,7 +751,7 @@ export abstract class MusicSheetCalculator {
             }
         }
         // calculate Slurs
-        if (!this.leadSheet && EngravingRules.Rules.RenderSlurs) {
+        if (!this.leadSheet && this.rules.RenderSlurs) {
             this.calculateSlurs();
         }
         // calculate StaffEntry Ornaments
@@ -1377,7 +1377,7 @@ export abstract class MusicSheetCalculator {
 
         if (multiTempoExpression.ContinuousTempo || multiTempoExpression.InstantaneousTempo) {
             // TempoExpressions always on the first visible System's StaffLine // TODO is it though?
-            if (EngravingRules.Rules.MinMeasureToDrawIndex > 0) {
+            if (this.rules.MinMeasureToDrawIndex > 0) {
                 return; // assuming that the tempo is always in measure 1 (idx 0), adding the expression causes issues when we don't draw measure 1
             }
             let staffLine: StaffLine = measures[0].ParentStaffLine;
@@ -1418,7 +1418,7 @@ export abstract class MusicSheetCalculator {
                         const lastInstruction: AbstractGraphicalInstruction = firstInstructionEntry.GraphicalInstructions.last();
                         relative.x = lastInstruction.PositionAndShape.RelativePosition.x;
                     }
-                    if (EngravingRules.Rules.CompactMode) {
+                    if (this.rules.CompactMode) {
                         relative.x = staffLine.PositionAndShape.RelativePosition.x +
                             staffLine.Measures[0].PositionAndShape.RelativePosition.x;
                     }
@@ -1428,7 +1428,7 @@ export abstract class MusicSheetCalculator {
             // const addAtLastList: GraphicalObject[] = [];
             for (const entry of multiTempoExpression.EntriesList) {
                 let textAlignment: TextAlignmentEnum = TextAlignmentEnum.CenterBottom;
-                if (EngravingRules.Rules.CompactMode) {
+                if (this.rules.CompactMode) {
                     textAlignment = TextAlignmentEnum.LeftBottom;
                 }
                 const graphLabel: GraphicalLabel = this.calculateLabel(staffLine,
@@ -1436,7 +1436,7 @@ export abstract class MusicSheetCalculator {
                                                                        entry.label,
                                                                        multiTempoExpression.getFontstyleOfFirstEntry(),
                                                                        entry.Expression.Placement,
-                                                                       EngravingRules.Rules.UnknownTextHeight,
+                                                                       this.rules.UnknownTextHeight,
                                                                        textAlignment);
 
                 if (entry.Expression instanceof InstantaneousTempoExpression) {
@@ -1538,7 +1538,7 @@ export abstract class MusicSheetCalculator {
                                octaveShiftValue: OctaveEnum, linkedNotes: Note[] = undefined,
                                sourceStaffEntry: SourceStaffEntry = undefined): OctaveEnum {
         if (voiceEntry.StemDirectionXml !== StemDirectionType.Undefined &&
-            EngravingRules.Rules.SetWantedStemDirectionByXml &&
+            this.rules.SetWantedStemDirectionByXml &&
             voiceEntry.StemDirectionXml !== undefined) {
                 voiceEntry.WantedStemDirection = voiceEntry.StemDirectionXml;
         } else {
@@ -1616,7 +1616,7 @@ export abstract class MusicSheetCalculator {
         for (const instrument of this.graphicalMusicSheet.ParentMusicSheet.Instruments) {
             if (instrument.Voices.length > 0 && instrument.Voices[0].Visible) {
                 let renderedLabel: Label = instrument.NameLabel;
-                if (!EngravingRules.Rules.RenderPartNames) {
+                if (!this.rules.RenderPartNames) {
                     renderedLabel = new Label("", renderedLabel.textAlignment, renderedLabel.font);
                 }
                 const graphicalLabel: GraphicalLabel = new GraphicalLabel(
@@ -1625,7 +1625,7 @@ export abstract class MusicSheetCalculator {
                 maxLabelLength = Math.max(maxLabelLength, graphicalLabel.PositionAndShape.MarginSize.width);
             }
         }
-        if (!EngravingRules.Rules.RenderPartNames) {
+        if (!this.rules.RenderPartNames) {
             return 0;
         }
         return maxLabelLength;
@@ -1633,37 +1633,37 @@ export abstract class MusicSheetCalculator {
 
     protected calculateSheetLabelBoundingBoxes(): void {
         const musicSheet: MusicSheet = this.graphicalMusicSheet.ParentMusicSheet;
-        const defaultColorTitle: string = EngravingRules.Rules.DefaultColorTitle; // can be undefined => black
-        if (musicSheet.Title !== undefined && EngravingRules.Rules.RenderTitle) {
+        const defaultColorTitle: string = this.rules.DefaultColorTitle; // can be undefined => black
+        if (musicSheet.Title !== undefined && this.rules.RenderTitle) {
             const title: GraphicalLabel = new GraphicalLabel(musicSheet.Title, this.rules.SheetTitleHeight, TextAlignmentEnum.CenterBottom);
             title.Label.colorDefault = defaultColorTitle;
             this.graphicalMusicSheet.Title = title;
             title.setLabelPositionAndShapeBorders();
-        } else if (!EngravingRules.Rules.RenderTitle) {
+        } else if (!this.rules.RenderTitle) {
             this.graphicalMusicSheet.Title = undefined; // clear label if rendering it was disabled after last render
         }
-        if (musicSheet.Subtitle !== undefined && EngravingRules.Rules.RenderSubtitle) {
+        if (musicSheet.Subtitle !== undefined && this.rules.RenderSubtitle) {
             const subtitle: GraphicalLabel = new GraphicalLabel(musicSheet.Subtitle, this.rules.SheetSubtitleHeight, TextAlignmentEnum.CenterCenter);
             subtitle.Label.colorDefault = defaultColorTitle;
             this.graphicalMusicSheet.Subtitle = subtitle;
             subtitle.setLabelPositionAndShapeBorders();
-        } else if (!EngravingRules.Rules.RenderSubtitle) {
+        } else if (!this.rules.RenderSubtitle) {
             this.graphicalMusicSheet.Subtitle = undefined;
         }
-        if (musicSheet.Composer !== undefined && EngravingRules.Rules.RenderComposer) {
+        if (musicSheet.Composer !== undefined && this.rules.RenderComposer) {
             const composer: GraphicalLabel = new GraphicalLabel(musicSheet.Composer, this.rules.SheetComposerHeight, TextAlignmentEnum.RightCenter);
             composer.Label.colorDefault = defaultColorTitle;
             this.graphicalMusicSheet.Composer = composer;
             composer.setLabelPositionAndShapeBorders();
-        } else if (!EngravingRules.Rules.RenderComposer) {
+        } else if (!this.rules.RenderComposer) {
             this.graphicalMusicSheet.Composer = undefined;
         }
-        if (musicSheet.Lyricist !== undefined && EngravingRules.Rules.RenderLyricist) {
+        if (musicSheet.Lyricist !== undefined && this.rules.RenderLyricist) {
             const lyricist: GraphicalLabel = new GraphicalLabel(musicSheet.Lyricist, this.rules.SheetAuthorHeight, TextAlignmentEnum.LeftCenter);
             lyricist.Label.colorDefault = defaultColorTitle;
             this.graphicalMusicSheet.Lyricist = lyricist;
             lyricist.setLabelPositionAndShapeBorders();
-        } else if (!EngravingRules.Rules.RenderLyricist) {
+        } else if (!this.rules.RenderLyricist) {
             this.graphicalMusicSheet.Lyricist = undefined;
         }
     }
@@ -2085,7 +2085,7 @@ export abstract class MusicSheetCalculator {
         }
         // if there are no staffEntries in this measure, create a rest for the whole measure:
         // check OSMDOptions.fillEmptyMeasuresWithWholeRest
-        if (EngravingRules.Rules.FillEmptyMeasuresWithWholeRest >= 1) { // fill measures with no notes given with whole rests, visible (1) or invisible (2)
+        if (this.rules.FillEmptyMeasuresWithWholeRest >= 1) { // fill measures with no notes given with whole rests, visible (1) or invisible (2)
             if (measure.staffEntries.length === 0) {
                 const sourceStaffEntry: SourceStaffEntry = new SourceStaffEntry(
                     new VerticalSourceStaffEntryContainer(measure.parentSourceMeasure,
@@ -2094,7 +2094,7 @@ export abstract class MusicSheetCalculator {
                     staff);
                 const voiceEntry: VoiceEntry = new VoiceEntry(new Fraction(0, 1), staff.Voices[0], sourceStaffEntry);
                 const note: Note = new Note(voiceEntry, sourceStaffEntry, Fraction.createFromFraction(sourceMeasure.Duration), undefined);
-                note.PrintObject = EngravingRules.Rules.FillEmptyMeasuresWithWholeRest === FillEmptyMeasuresWithWholeRests.YesVisible;
+                note.PrintObject = this.rules.FillEmptyMeasuresWithWholeRest === FillEmptyMeasuresWithWholeRests.YesVisible;
                   // don't display whole rest that wasn't given in XML, only for layout/voice completion
                 voiceEntry.Notes.push(note);
                 const graphicalStaffEntry: GraphicalStaffEntry = MusicSheetCalculator.symbolFactory.createStaffEntry(sourceStaffEntry, measure);
@@ -2647,8 +2647,8 @@ export abstract class MusicSheetCalculator {
     }
 
     private calculateDynamicExpressions(): void {
-        const maxIndex: number = Math.min(this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length - 1, EngravingRules.Rules.MaxMeasureToDrawIndex);
-        const minIndex: number = Math.min(EngravingRules.Rules.MinMeasureToDrawIndex, this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length);
+        const maxIndex: number = Math.min(this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length - 1, this.rules.MaxMeasureToDrawIndex);
+        const minIndex: number = Math.min(this.rules.MinMeasureToDrawIndex, this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length);
         for (let i: number = minIndex; i <= maxIndex; i++) {
             const sourceMeasure: SourceMeasure = this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures[i];
             for (let j: number = 0; j < sourceMeasure.StaffLinkedExpressions.length; j++) {
@@ -2729,8 +2729,8 @@ export abstract class MusicSheetCalculator {
     }
 
     private calculateTempoExpressions(): void {
-        const maxIndex: number = Math.min(this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length - 1, EngravingRules.Rules.MaxMeasureToDrawIndex);
-        const minIndex: number = EngravingRules.Rules.MinMeasureToDrawIndex;
+        const maxIndex: number = Math.min(this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length - 1, this.rules.MaxMeasureToDrawIndex);
+        const minIndex: number = this.rules.MinMeasureToDrawIndex;
         for (let i: number = minIndex; i <= maxIndex; i++) {
             const sourceMeasure: SourceMeasure = this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures[i];
             for (let j: number = 0; j < sourceMeasure.TempoExpressions.length; j++) {

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -295,7 +295,7 @@ export abstract class MusicSheetDrawer {
         for (const staffLine of musicSystem.StaffLines) {
             this.drawStaffLine(staffLine);
 
-            if (EngravingRules.Rules.RenderLyrics) {
+            if (this.rules.RenderLyrics) {
                 // draw lyric dashes
                 if (staffLine.LyricsDashes.length > 0) {
                     this.drawDashes(staffLine.LyricsDashes);
@@ -351,7 +351,7 @@ export abstract class MusicSheetDrawer {
             this.drawMeasure(measure);
         }
 
-        if (EngravingRules.Rules.RenderLyrics) {
+        if (this.rules.RenderLyrics) {
             if (staffLine.LyricsDashes.length > 0) {
                 this.drawDashes(staffLine.LyricsDashes);
             }
@@ -379,7 +379,7 @@ export abstract class MusicSheetDrawer {
             lyricLine.End.y += staffLine.PositionAndShape.AbsolutePosition.y;
             lyricLine.Start.x += staffLine.PositionAndShape.AbsolutePosition.x;
             lyricLine.End.x += staffLine.PositionAndShape.AbsolutePosition.x;
-            this.drawGraphicalLine(lyricLine, EngravingRules.Rules.LyricUnderscoreLineWidth);
+            this.drawGraphicalLine(lyricLine, this.rules.LyricUnderscoreLineWidth);
         });
     }
 

--- a/src/MusicalScore/Graphical/MusicSystem.ts
+++ b/src/MusicalScore/Graphical/MusicSystem.ts
@@ -26,6 +26,7 @@ import { Label } from "../Label";
  */
 export abstract class MusicSystem extends GraphicalObject {
     public needsToBeRedrawn: boolean = true;
+    public rules: EngravingRules;
     protected parent: GraphicalMusicPage;
     protected id: number;
     protected staffLines: StaffLine[] = [];
@@ -43,7 +44,6 @@ export abstract class MusicSystem extends GraphicalObject {
     protected graphicalMarkedAreas: GraphicalMarkedArea[] = [];
     protected graphicalComments: GraphicalComment[] = [];
     protected systemLines: SystemLine[] = [];
-    protected rules: EngravingRules;
 
     constructor(parent: GraphicalMusicPage, id: number) {
         super();
@@ -286,7 +286,7 @@ export abstract class MusicSystem extends GraphicalObject {
                 const instrument: Instrument = instruments[idx];
                 let instrNameLabel: Label;
                 if (this !== this.parent.MusicSystems[0]) {
-                    if (!EngravingRules.Rules.RenderPartAbbreviations
+                    if (!this.rules.RenderPartAbbreviations
                         // don't render part abbreviations if there's only one instrument/part (could be an option in the future)
                         || this.Parent.Parent.ParentMusicSheet.Instruments.length === 1
                         || !instrument.PartAbbreviation
@@ -298,7 +298,7 @@ export abstract class MusicSystem extends GraphicalObject {
                     instrNameLabel = new Label(labelText, instrument.NameLabel.textAlignment, instrument.NameLabel.font);
                 } else {
                     instrNameLabel = instrument.NameLabel;
-                    if (!EngravingRules.Rules.RenderPartNames) {
+                    if (!this.rules.RenderPartNames) {
                         instrNameLabel = new Label("", instrument.NameLabel.textAlignment, instrument.NameLabel.font);
                         systemLabelsRightMargin = 0; // might affect lyricist/tempo placement. but without this there's still some extra x-spacing.
                     }

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -45,7 +45,7 @@ export class MusicSystemBuilder {
         graphicalMusicSheet: GraphicalMusicSheet, measureList: GraphicalMeasure[][], numberOfStaffLines: number): void {
         this.leadSheet = graphicalMusicSheet.LeadSheet;
         this.graphicalMusicSheet = graphicalMusicSheet;
-        this.rules = this.graphicalMusicSheet.ParentMusicSheet.rules;
+        this.rules = this.graphicalMusicSheet.ParentMusicSheet.Rules;
         this.measureList = measureList;
         this.currentMusicPage = this.createMusicPage();
         this.currentPageHeight = 0.0;
@@ -336,7 +336,7 @@ export class MusicSystemBuilder {
             const relativePosition: PointF2D = new PointF2D();
             if (musicSystem.Parent.MusicSystems[0] === musicSystem &&
                 musicSystem.Parent === musicSystem.Parent.Parent.MusicPages[0] &&
-                !EngravingRules.Rules.CompactMode) {
+                !this.rules.CompactMode) {
                 relativePosition.x = this.rules.FirstSystemMargin;
                 boundingBox.BorderRight = musicSystem.PositionAndShape.Size.width - this.rules.FirstSystemMargin;
             } else {

--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -30,7 +30,7 @@ export class SkyBottomLineCalculator {
      */
     constructor(staffLineParent: StaffLine) {
         this.mStaffLineParent = staffLineParent;
-        this.mRules = EngravingRules.Rules;
+        this.mRules = staffLineParent.ParentMusicSystem.rules;
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -11,6 +11,12 @@ import { EngravingRules } from "..";
 export class SvgVexFlowBackend extends VexFlowBackend {
 
     private ctx: Vex.Flow.SVGContext;
+    private rules: EngravingRules;
+
+    constructor(rules: EngravingRules) {
+        super();
+        this.rules = rules;
+    }
 
     public getBackendType(): number {
         return Vex.Flow.Renderer.Backends.SVG;
@@ -59,7 +65,7 @@ export class SvgVexFlowBackend extends VexFlowBackend {
             this.ctx.attributes.fill = color;
             this.ctx.attributes.stroke = color;
         }
-        this.ctx.setFont(EngravingRules.Rules.DefaultFontFamily, fontHeight, VexFlowConverter.fontStyle(fontStyle));
+        this.ctx.setFont(this.rules.DefaultFontFamily, fontHeight, VexFlowConverter.fontStyle(fontStyle));
         // font size is set by VexFlow in `pt`. This overwrites the font so it's set to px instead
         this.ctx.attributes["font-size"] = `${fontHeight}px`;
         this.ctx.state["font-size"] = `${fontHeight}px`;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -166,6 +166,7 @@ export class VexFlowConverter {
         } */
         // VexFlow needs the notes ordered vertically in the other direction:
         const notes: GraphicalNote[] = gve.notes.reverse();
+        const rules: EngravingRules = gve.parentStaffEntry.parentMeasure.parentMusicSystem.rules;
 
         const baseNote: GraphicalNote = notes[0];
         let keys: string[] = [];
@@ -201,7 +202,7 @@ export class VexFlowConverter {
                     // https://github.com/0xfe/vexflow/issues/579 The author reports that he needs to add some negative x shift
                     // if the measure has no modifiers.
                     alignCenter = true;
-                    xShift = EngravingRules.Rules.WholeRestXShiftVexflow * unitInPixels; // TODO find way to make dependent on the modifiers
+                    xShift = rules.WholeRestXShiftVexflow * unitInPixels; // TODO find way to make dependent on the modifiers
                     // affects VexFlowStaffEntry.calculateXPosition()
                 }
                 break;
@@ -258,8 +259,8 @@ export class VexFlowConverter {
             vfnote = new Vex.Flow.StaveNote(vfnoteStruct);
         }
 
-        if (EngravingRules.Rules.ColoringEnabled) {
-            const defaultColorStem: string = EngravingRules.Rules.DefaultColorStem;
+        if (rules.ColoringEnabled) {
+            const defaultColorStem: string = rules.DefaultColorStem;
             let stemColor: string = gve.parentVoiceEntry.StemColor;
             if (!stemColor && defaultColorStem) {
                 stemColor = defaultColorStem;
@@ -269,7 +270,7 @@ export class VexFlowConverter {
             if (stemColor) {
                 gve.parentVoiceEntry.StemColor = stemColor;
                 vfnote.setStemStyle(stemStyle);
-                if (vfnote.flag && EngravingRules.Rules.ColorFlags) {
+                if (vfnote.flag && rules.ColorFlags) {
                     vfnote.setFlagStyle(stemStyle);
                 }
             }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -166,7 +166,7 @@ export class VexFlowConverter {
         } */
         // VexFlow needs the notes ordered vertically in the other direction:
         const notes: GraphicalNote[] = gve.notes.reverse();
-        const rules: EngravingRules = gve.parentStaffEntry.parentMeasure.parentMusicSystem.rules;
+        const rules: EngravingRules = gve.parentStaffEntry.parentMeasure.parentSourceMeasure.Rules;
 
         const baseNote: GraphicalNote = notes[0];
         let keys: string[] = [];

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowGraphicalSymbolFactory.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowGraphicalSymbolFactory.ts
@@ -156,7 +156,7 @@ export class VexFlowGraphicalSymbolFactory implements IGraphicalSymbolFactory {
      * @param transposeHalftones
      */
     public createChordSymbols(sourceStaffEntry: SourceStaffEntry, graphicalStaffEntry: GraphicalStaffEntry, transposeHalftones: number): void {
-        const rules: EngravingRules = graphicalStaffEntry.parentMeasure.parentMusicSystem.rules;
+        const rules: EngravingRules = graphicalStaffEntry.parentMeasure.parentSourceMeasure.Rules;
         let xShift: number = 0;
         const chordSymbolSpacing: number = rules.ChordSymbolXSpacing;
         for (const chordSymbolContainer of sourceStaffEntry.ChordContainers) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowGraphicalSymbolFactory.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowGraphicalSymbolFactory.ts
@@ -156,16 +156,17 @@ export class VexFlowGraphicalSymbolFactory implements IGraphicalSymbolFactory {
      * @param transposeHalftones
      */
     public createChordSymbols(sourceStaffEntry: SourceStaffEntry, graphicalStaffEntry: GraphicalStaffEntry, transposeHalftones: number): void {
+        const rules: EngravingRules = graphicalStaffEntry.parentMeasure.parentMusicSystem.rules;
         let xShift: number = 0;
-        const chordSymbolSpacing: number = EngravingRules.Rules.ChordSymbolXSpacing;
+        const chordSymbolSpacing: number = rules.ChordSymbolXSpacing;
         for (const chordSymbolContainer of sourceStaffEntry.ChordContainers) {
             const graphicalChordSymbolContainer: GraphicalChordSymbolContainer =
               new GraphicalChordSymbolContainer(chordSymbolContainer,
                                                 graphicalStaffEntry.PositionAndShape,
-                                                EngravingRules.Rules.ChordSymbolTextHeight,
+                                                rules.ChordSymbolTextHeight,
                                                 transposeHalftones);
             const graphicalLabel: GraphicalLabel = graphicalChordSymbolContainer.GetGraphicalLabel;
-            graphicalLabel.PositionAndShape.RelativePosition.y -= EngravingRules.Rules.ChordSymbolYOffset;
+            graphicalLabel.PositionAndShape.RelativePosition.y -= rules.ChordSymbolYOffset;
             graphicalLabel.PositionAndShape.RelativePosition.x += xShift;
             // TODO check for available space until next staffEntry or chord symbol (x direction)
             graphicalLabel.setLabelPositionAndShapeBorders();

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -69,7 +69,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
     /** VexFlow Tuplets */
     private vftuplets: { [voiceID: number]: Vex.Flow.Tuplet[]; } = {};
     // The engraving rules of OSMD.
-    private rules: EngravingRules = this.parentMusicSystem.rules;
+    public rules: EngravingRules;
 
     // Sets the absolute coordinates of the VFStave on the canvas
     public setAbsoluteCoordinates(x: number, y: number): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -39,6 +39,18 @@ export class VexFlowMeasure extends GraphicalMeasure {
     constructor(staff: Staff, staffLine: StaffLine = undefined, sourceMeasure: SourceMeasure = undefined) {
         super(staff, sourceMeasure, staffLine);
         this.minimumStaffEntriesWidth = -1;
+
+        /*
+         * There is no case in which `staffLine === undefined && sourceMeasure === undefined` holds.
+         * Hence, it is not necessary to specify an `else` case.
+         * One can verify this through a usage search for this constructor.
+         */
+        if (staffLine) {
+            this.rules = staffLine.ParentMusicSystem.rules;
+        } else if (sourceMeasure) {
+            this.rules = sourceMeasure.Rules;
+        }
+
         this.resetLayout();
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -101,9 +101,6 @@ export class VexFlowMeasure extends GraphicalMeasure {
         }
         // the correct bar types seem to be set later
 
-        //if (nextMeasureIndex >= EngravingRules.Rules.MinMeasureToDrawIndex && nextMeasureIndex <= EngravingRules.Rules.MaxMeasureToDrawIndex) {
-        //this.stave.setBegBarType(Vex.Flow.Barline.type.NONE);
-
         this.updateInstructionWidth();
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -366,6 +366,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   }
 
   protected graphicalMeasureCreatedCalculations(measure: GraphicalMeasure): void {
+    (measure as VexFlowMeasure).rules = this.rules;
     (measure as VexFlowMeasure).graphicalMeasureCreatedCalculations();
   }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -38,7 +38,6 @@ import { Slur } from "../../VoiceData/Expressions/ContinuousExpressions/Slur";
 // import { VexFlowStaffLine } from "./VexFlowStaffLine";
 // import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
 */
-import { EngravingRules } from "../EngravingRules";
 import { PointF2D } from "../../../Common/DataObjects/PointF2D";
 import { TextAlignmentEnum, TextAlignment } from "../../../Common/Enums/TextAlignment";
 import { GraphicalSlur } from "../GraphicalSlur";
@@ -147,11 +146,11 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
 
       for (const measure of measures) {
         // determine whether to align rests
-        if (EngravingRules.Rules.AlignRests === AlignRestOption.Never) {
+        if (this.rules.AlignRests === AlignRestOption.Never) {
           (measure as VexFlowMeasure).formatVoices = formatVoicesDefault;
-        } else if (EngravingRules.Rules.AlignRests === AlignRestOption.Always) {
+        } else if (this.rules.AlignRests === AlignRestOption.Always) {
           (measure as VexFlowMeasure).formatVoices = formatVoicesAlignRests;
-        } else if (EngravingRules.Rules.AlignRests === AlignRestOption.Auto) {
+        } else if (this.rules.AlignRests === AlignRestOption.Auto) {
           let alignRests: boolean = false;
           for (const staffEntry of measure.staffEntries) {
             let collidableVoiceEntries: number = 0;
@@ -244,18 +243,18 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
           const lyricsEntry: GraphicalLyricEntry = staffEntry.LyricsEntries[j];
           // const lyricsEntryText = lyricsEntry.LyricsEntry.Text; // for easier debugging
           const lyricAlignment: TextAlignmentEnum = lyricsEntry.GraphicalLabel.Label.textAlignment;
-          let minLyricsSpacing: number = EngravingRules.Rules.HorizontalBetweenLyricsDistance;
+          let minLyricsSpacing: number = this.rules.HorizontalBetweenLyricsDistance;
           // for quarter note in Vexflow, where spacing is halfed for each smaller note duration.
 
           let lyricOverlapAllowedIntoNextMeasure: number =
-            EngravingRules.Rules.LyricOverlapAllowedIntoNextMeasure;
+            this.rules.LyricOverlapAllowedIntoNextMeasure;
           // TODO allow more overlap if there are no lyrics in next measure
 
           // spacing for multi-syllable words
           if (lyricsEntry.ParentLyricWord) {
             if (lyricsEntry.LyricsEntry.SyllableIndex > 0) { // syllables after first
               // give a little more spacing for dash between syllables
-              minLyricsSpacing = EngravingRules.Rules.BetweenSyllableMinimumDistance;
+              minLyricsSpacing = this.rules.BetweenSyllableMinimumDistance;
               if (TextAlignment.IsCenterAligned(lyricsEntry.GraphicalLabel.Label.textAlignment)) {
                 minLyricsSpacing += 1.0; // TODO check for previous lyric alignment too. though center is not standard
                 // without this, there's not enough space for dashes between long syllables on eigth notes
@@ -480,7 +479,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   }
 
   protected calculateDynamicExpressionsForMultiExpression(multiExpression: MultiExpression, measureIndex: number, staffIndex: number): void {
-    if (measureIndex < EngravingRules.Rules.MinMeasureToDrawIndex || measureIndex > EngravingRules.Rules.MaxMeasureToDrawIndex) {
+    if (measureIndex < this.rules.MinMeasureToDrawIndex || measureIndex > this.rules.MaxMeasureToDrawIndex) {
       return;
       // we do already use the min/max in MusicSheetCalculator.calculateDynamicsExpressions,
       // but this may be necessary for StaffLinkedExpressions, not tested.
@@ -537,16 +536,16 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
           //duration: metronomeExpression.beatUnit
           duration: "q"
       },
-      EngravingRules.Rules.MetronomeMarkYShift * unitInPixels);
+      this.rules.MetronomeMarkYShift * unitInPixels);
        // -50, -30), 0); //needs Vexflow PR
        //.setShiftX(-50);
 
     (<any>vfStave.getModifiers()[vfStave.getModifiers().length - 1]).setShiftX(
-      EngravingRules.Rules.MetronomeMarkXShift * unitInPixels
+      this.rules.MetronomeMarkXShift * unitInPixels
     );
     // TODO calculate bounding box of metronome mark instead of hacking skyline to fix lyricist collision
     const skyline: number[] = this.graphicalMusicSheet.MeasureList[0][0].ParentStaffLine.SkyLine;
-    skyline[0] = Math.min(skyline[0], -4.5 + EngravingRules.Rules.MetronomeMarkYShift);
+    skyline[0] = Math.min(skyline[0], -4.5 + this.rules.MetronomeMarkYShift);
     // somehow this is called repeatedly in Clementi, so skyline[0] = Math.min instead of -=
   }
 
@@ -564,8 +563,8 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     const startTimeStamp: Fraction = octaveShift.ParentStartMultiExpression.Timestamp;
     const endTimeStamp: Fraction = octaveShift.ParentEndMultiExpression.Timestamp;
 
-    const minMeasureToDrawIndex: number = EngravingRules.Rules.MinMeasureToDrawIndex;
-    const maxMeasureToDrawIndex: number = EngravingRules.Rules.MaxMeasureToDrawIndex;
+    const minMeasureToDrawIndex: number = this.rules.MinMeasureToDrawIndex;
+    const maxMeasureToDrawIndex: number = this.rules.MaxMeasureToDrawIndex;
 
     let startStaffLine: StaffLine = this.graphicalMusicSheet.MeasureList[measureIndex][staffIndex].ParentStaffLine;
     if (startStaffLine === undefined) { // fix for rendering range set. all of these can probably done cleaner.

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -17,7 +17,6 @@ import { VexFlowInstrumentBrace } from "./VexFlowInstrumentBrace";
 import { GraphicalLyricEntry } from "../GraphicalLyricEntry";
 import { VexFlowStaffLine } from "./VexFlowStaffLine";
 import { StaffLine } from "../StaffLine";
-import { EngravingRules } from "../EngravingRules";
 import { GraphicalSlur } from "../GraphicalSlur";
 import { PlacementEnum } from "../../VoiceData/Expressions/AbstractExpression";
 import { GraphicalInstantaneousTempoExpression } from "../GraphicalInstantaneousTempoExpression";
@@ -42,6 +41,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
                 backend: VexFlowBackend,
                 drawingParameters: DrawingParameters = new DrawingParameters()) {
         super(new VexFlowTextMeasurer(), drawingParameters);
+
         this.backend = backend;
     }
 
@@ -83,7 +83,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     protected drawStaffLine(staffLine: StaffLine): void {
         super.drawStaffLine(staffLine);
         const absolutePos: PointF2D = staffLine.PositionAndShape.AbsolutePosition;
-        if (EngravingRules.Rules.RenderSlurs) {
+        if (this.rules.RenderSlurs) {
             this.drawSlurs(staffLine as VexFlowStaffLine, absolutePos);
         }
     }
@@ -195,7 +195,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
 
         const absolute: PointF2D = startPosition;
         if (indices.length > 0) {
-            const samplingUnit: number = EngravingRules.Rules.SamplingUnit;
+            const samplingUnit: number = this.rules.SamplingUnit;
 
             let horizontalStart: PointF2D = new PointF2D(absolute.x, absolute.y);
             let horizontalEnd: PointF2D = new PointF2D(indices[0] / samplingUnit + absolute.x, absolute.y);
@@ -246,7 +246,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
                 this.drawLabel(graphicalChordContainer.GetGraphicalLabel, <number>GraphicalLayers.Notes);
             }
         }
-        if (EngravingRules.Rules.RenderLyrics) {
+        if (this.rules.RenderLyrics) {
             if (staffEntry.LyricsEntries.length > 0) {
                 this.drawLyrics(staffEntry.LyricsEntries, <number>GraphicalLayers.Notes);
             }
@@ -363,10 +363,10 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         const height: number = graphicalLabel.Label.fontHeight * unitInPixels;
         const { fontStyle, font, text } = graphicalLabel.Label;
         let color: string;
-        if (EngravingRules.Rules.ColoringEnabled) {
+        if (this.rules.ColoringEnabled) {
             color = graphicalLabel.Label.colorDefault;
             if (!color) {
-                color = EngravingRules.Rules.DefaultColorLabel;
+                color = this.rules.DefaultColorLabel;
             }
         }
         this.backend.renderText(height, fontStyle, font, text, heightInPixel, screenPosition, color);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -39,7 +39,7 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                     // whole rest: length = measure length. (4/4 in a 4/4 time signature, 3/4 in a 3/4 time signature, 1/4 in a 1/4 time signature, etc.)
                     // see Note.isWholeRest(), which is currently not safe
                     this.PositionAndShape.RelativePosition.x +=
-                        this.staffEntryParent.parentMeasure.parentSourceMeasure.Rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
+                        this.parentMeasure.parentSourceMeasure.Rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
                     gve.PositionAndShape.BorderLeft = -0.7;
                     gve.PositionAndShape.BorderRight = 0.7;
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -5,7 +5,6 @@ import { SourceStaffEntry } from "../../VoiceData/SourceStaffEntry";
 import { unitInPixels } from "./VexFlowMusicSheetDrawer";
 import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
 import { Note } from "../../VoiceData/Note";
-import { EngravingRules } from "../EngravingRules";
 
 export class VexFlowStaffEntry extends GraphicalStaffEntry {
     constructor(measure: VexFlowMeasure, sourceStaffEntry: SourceStaffEntry, staffEntryParent: VexFlowStaffEntry) {
@@ -40,7 +39,7 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                     // whole rest: length = measure length. (4/4 in a 4/4 time signature, 3/4 in a 3/4 time signature, 1/4 in a 1/4 time signature, etc.)
                     // see Note.isWholeRest(), which is currently not safe
                     this.PositionAndShape.RelativePosition.x +=
-                        EngravingRules.Rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
+                        this.staffEntryParent.parentMeasure.parentMusicSystem.rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
                     gve.PositionAndShape.BorderLeft = -0.7;
                     gve.PositionAndShape.BorderRight = 0.7;
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -39,7 +39,7 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
                     // whole rest: length = measure length. (4/4 in a 4/4 time signature, 3/4 in a 3/4 time signature, 1/4 in a 1/4 time signature, etc.)
                     // see Note.isWholeRest(), which is currently not safe
                     this.PositionAndShape.RelativePosition.x +=
-                        this.staffEntryParent.parentMeasure.parentMusicSystem.rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
+                        this.staffEntryParent.parentMeasure.parentSourceMeasure.Rules.WholeRestXShiftVexflow - 0.1; // xShift from VexFlowConverter
                     gve.PositionAndShape.BorderLeft = -0.7;
                     gve.PositionAndShape.BorderRight = 0.7;
                 }

--- a/src/MusicalScore/MusicSheet.ts
+++ b/src/MusicalScore/MusicSheet.ts
@@ -122,10 +122,10 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
         // this method name should remain for a while to maintain compatibility even when Instrument is renamed to Part
         return this.instruments;
     }
-     public get SheetPlaybackSetting(): PlaybackSettings {
+    public get SheetPlaybackSetting(): PlaybackSettings {
         return this.playbackSettings;
     }
-     public set SheetPlaybackSetting(value: PlaybackSettings) {
+    public set SheetPlaybackSetting(value: PlaybackSettings) {
         this.playbackSettings = value;
     }
     public get DrawErroneousMeasures(): boolean {
@@ -337,17 +337,17 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
         return this.sourceMeasures[this.sourceMeasures.length - 1];
     }
     public resetAllNoteStates(): void {
-       const iterator: MusicPartManagerIterator = this.MusicPartManager.getIterator();
-       while (!iterator.EndReached && iterator.CurrentVoiceEntries !== undefined) {
-           for (let idx: number = 0, len: number = iterator.CurrentVoiceEntries.length; idx < len; ++idx) {
-               const voiceEntry: VoiceEntry = iterator.CurrentVoiceEntries[idx];
-               for (let idx2: number = 0, len2: number = voiceEntry.Notes.length; idx2 < len2; ++idx2) {
-                   const note: Note = voiceEntry.Notes[idx2];
-                   note.state = NoteState.Normal;
-               }
-           }
-           iterator.moveToNext();
-       }
+        const iterator: MusicPartManagerIterator = this.MusicPartManager.getIterator();
+        while (!iterator.EndReached && iterator.CurrentVoiceEntries !== undefined) {
+            for (let idx: number = 0, len: number = iterator.CurrentVoiceEntries.length; idx < len; ++idx) {
+                const voiceEntry: VoiceEntry = iterator.CurrentVoiceEntries[idx];
+                for (let idx2: number = 0, len2: number = voiceEntry.Notes.length; idx2 < len2; ++idx2) {
+                    const note: Note = voiceEntry.Notes[idx2];
+                    note.state = NoteState.Normal;
+                }
+            }
+            iterator.moveToNext();
+        }
     }
     public getMusicSheetInstrumentIndex(instrument: Instrument): number {
         return this.Instruments.indexOf(instrument);
@@ -496,13 +496,13 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
     //    this.musicSheetParameterChangedDelegate = value;
     //}
     public get FullNameString(): string {
-       return this.ComposerString + " " + this.TitleString;
+        return this.ComposerString + " " + this.TitleString;
     }
     public get IdString(): string {
-       return this.idString;
+        return this.idString;
     }
     public set IdString(value: string) {
-       this.idString = value;
+        this.idString = value;
     }
     // (*)
     // public Dispose(): void {

--- a/src/MusicalScore/MusicSheet.ts
+++ b/src/MusicalScore/MusicSheet.ts
@@ -32,7 +32,6 @@ export class PlaybackSettings {
  */
 export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet>*/ {
     constructor() {
-        this.rules = EngravingRules.Rules;
         this.playbackSettings = new PlaybackSettings();
         // FIXME?
         // initialize SheetPlaybackSetting with default values
@@ -47,7 +46,6 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
 
     public userStartTempoInBPM: number;
     public pageWidth: number;
-    public rules: EngravingRules;
 
     private idString: string = "random idString, not initialized";
     private sourceMeasures: SourceMeasure[] = [];
@@ -77,7 +75,7 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
     private hasBeenOpenedForTheFirstTime: boolean = false;
     private currentEnrolledPosition: Fraction = new Fraction(0, 1);
     // (*) private musicSheetParameterObject: MusicSheetParameterObject = undefined;
-    private engravingRules: EngravingRules;
+    private rules: EngravingRules;
     // (*) private musicSheetParameterChangedDelegate: MusicSheetParameterChangedDelegate;
     /*
      * The BPM info is present in the sheet, if it is set to false, means each measure's
@@ -215,10 +213,10 @@ export class MusicSheet /*implements ISettableMusicSheet, IComparable<MusicSheet
         this.lyricist = value;
     }
     public get Rules(): EngravingRules {
-       return this.engravingRules;
+        return this.rules;
     }
     public set Rules(value: EngravingRules) {
-       this.engravingRules = value;
+        this.rules = value;
     }
     public get SheetErrors(): MusicSheetErrors {
         return this.musicSheetErrors;

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -21,10 +21,11 @@ import {MusicSymbolModuleFactory} from "./MusicSymbolModuleFactory";
 import {IAfterSheetReadingModule} from "../Interfaces/IAfterSheetReadingModule";
 import {RepetitionInstructionReader} from "./MusicSymbolModules/RepetitionInstructionReader";
 import {RepetitionCalculator} from "./MusicSymbolModules/RepetitionCalculator";
+import { EngravingRules } from "../Graphical";
 
 export class MusicSheetReader /*implements IMusicSheetReader*/ {
 
-    constructor(afterSheetReadingModules: IAfterSheetReadingModule[] = undefined) {
+    constructor(afterSheetReadingModules: IAfterSheetReadingModule[] = undefined, rules: EngravingRules = new EngravingRules()) {
      if (afterSheetReadingModules === undefined) {
        this.afterSheetReadingModules = [];
      } else {
@@ -32,6 +33,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
      }
      this.repetitionInstructionReader = MusicSymbolModuleFactory.createRepetitionInstructionReader();
      this.repetitionCalculator = MusicSymbolModuleFactory.createRepetitionCalculator();
+     this.rules = rules;
     }
 
     private repetitionInstructionReader: RepetitionInstructionReader;
@@ -42,6 +44,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
     private currentMeasure: SourceMeasure;
     private previousMeasure: SourceMeasure;
     private currentFraction: Fraction;
+    private rules: EngravingRules;
 
     public get CompleteNumberOfStaves(): number {
         return this.completeNumberOfStaves;
@@ -116,6 +119,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
         let sourceMeasureCounter: number = 0;
         this.musicSheet = new MusicSheet();
         this.musicSheet.Path = path;
+        this.musicSheet.Rules = this.rules;
         if (root === undefined) {
             throw new MusicSheetReadingException("Undefined root element");
         }

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -146,7 +146,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
             if (this.currentMeasure !== undefined && this.currentMeasure.endsPiece) {
                 sourceMeasureCounter = 0;
             }
-            this.currentMeasure = new SourceMeasure(this.completeNumberOfStaves);
+            this.currentMeasure = new SourceMeasure(this.completeNumberOfStaves, this.musicSheet.Rules);
             for (const instrumentReader of instrumentReaders) {
                 try {
                     couldReadMeasure = couldReadMeasure && instrumentReader.readNextXmlMeasure(this.currentMeasure, this.currentFraction, guitarPro);

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -16,7 +16,6 @@ import {PlacementEnum} from "../../VoiceData/Expressions/AbstractExpression";
 import {TextAlignmentEnum} from "../../../Common/Enums/TextAlignment";
 import {ITextTranslation} from "../../Interfaces/ITextTranslation";
 import * as log from "loglevel";
-import { EngravingRules } from "../../Graphical/EngravingRules";
 
 export class ExpressionReader {
     private musicSheet: MusicSheet;
@@ -544,7 +543,7 @@ export class ExpressionReader {
             }
         }
         let textAlignment: TextAlignmentEnum = TextAlignmentEnum.CenterBottom;
-        if (EngravingRules.Rules.CompactMode) {
+        if (this.musicSheet.Rules.CompactMode) {
             textAlignment = TextAlignmentEnum.LeftBottom;
         }
         const unknownExpression: UnknownExpression = new UnknownExpression(

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -11,7 +11,7 @@ import {MultiTempoExpression} from "./Expressions/MultiTempoExpression";
 import {KeyInstruction} from "./Instructions/KeyInstruction";
 import {AbstractNotationInstruction} from "./Instructions/AbstractNotationInstruction";
 import {Repetition} from "../MusicSource/Repetition";
-import {GraphicalMeasure, SystemLinesEnum} from "../Graphical";
+import {GraphicalMeasure, SystemLinesEnum, EngravingRules} from "../Graphical";
 //import {BaseIdClass} from "../../Util/BaseIdClass"; // SourceMeasure originally extended BaseIdClass, but ids weren't used.
 
 /**
@@ -24,7 +24,7 @@ export class SourceMeasure {
      * so that existing objects can be referred to by staff index.
      * @param completeNumberOfStaves
      */
-    constructor(completeNumberOfStaves: number) {
+    constructor(completeNumberOfStaves: number, rules: EngravingRules) {
         this.completeNumberOfStaves = completeNumberOfStaves;
         this.implicitMeasure = false;
         this.breakSystemAfter = false;
@@ -33,6 +33,7 @@ export class SourceMeasure {
         this.endingBarStyleEnum = SystemLinesEnum.SingleThin;
         this.firstInstructionsStaffEntries = new Array(completeNumberOfStaves);
         this.lastInstructionsStaffEntries = new Array(completeNumberOfStaves);
+        this.rules = rules;
         this.TempoInBPM = 0;
         for (let i: number = 0; i < completeNumberOfStaves; i++) {
             this.graphicalMeasureErrors.push(false);
@@ -69,6 +70,7 @@ export class SourceMeasure {
     private lastInstructionsStaffEntries: SourceStaffEntry[];
     private firstRepetitionInstructions: RepetitionInstruction[] = [];
     private lastRepetitionInstructions: RepetitionInstruction[] = [];
+    private rules: EngravingRules;
     private tempoInBPM: number;
     private verticalMeasureList: GraphicalMeasure[]; // useful, see GraphicalMusicSheet.GetGraphicalFromSourceStaffEntry
 
@@ -171,6 +173,10 @@ export class SourceMeasure {
         return undefined;
     }
 
+    public get Rules(): EngravingRules {
+        return this.rules;
+    }
+
     public get VerticalMeasureList(): GraphicalMeasure[] {
         return this.verticalMeasureList;
     }
@@ -186,6 +192,7 @@ export class SourceMeasure {
     public set TempoInBPM(value: number) {
         this.tempoInBPM = value;
     }
+
     /**
      * Check at the given timestamp if a VerticalContainer exists, if not creates a new, timestamp-ordered one,
      * and at the given index, if a [[SourceStaffEntry]] exists, and if not, creates a new one.

--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -17,6 +17,7 @@ export class Cursor {
   constructor(container: HTMLElement, openSheetMusicDisplay: OpenSheetMusicDisplay) {
     this.container = container;
     this.openSheetMusicDisplay = openSheetMusicDisplay;
+    this.rules = this.openSheetMusicDisplay.EngravingRules;
     const curs: HTMLElement = document.createElement("img");
     curs.style.position = "absolute";
     curs.style.zIndex = "-1";
@@ -26,6 +27,7 @@ export class Cursor {
 
   private container: HTMLElement;
   private openSheetMusicDisplay: OpenSheetMusicDisplay;
+  private rules: EngravingRules;
   private manager: MusicPartManager;
   protected iterator: MusicPartManagerIterator;
   private graphic: GraphicalMusicSheet;
@@ -58,9 +60,9 @@ export class Cursor {
 
     // set selection start, so that when there's MinMeasureToDraw set, the cursor starts there right away instead of at measure 1
     const lastSheetMeasureIndex: number = this.openSheetMusicDisplay.Sheet.SourceMeasures.length - 1; // last measure in data model
-    let startMeasureIndex: number = EngravingRules.Rules.MinMeasureToDrawIndex;
+    let startMeasureIndex: number = this.rules.MinMeasureToDrawIndex;
     startMeasureIndex = Math.min(startMeasureIndex, lastSheetMeasureIndex);
-    let endMeasureIndex: number = EngravingRules.Rules.MaxMeasureToDrawIndex;
+    let endMeasureIndex: number = this.rules.MaxMeasureToDrawIndex;
     endMeasureIndex = Math.min(endMeasureIndex, lastSheetMeasureIndex);
 
     if (this.openSheetMusicDisplay.Sheet && this.openSheetMusicDisplay.Sheet.SourceMeasures.length > startMeasureIndex) {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -143,13 +143,11 @@ export class OpenSheetMusicDisplay {
             return Promise.reject(new Error("OpenSheetMusicDisplay: Document is not a valid 'partwise' MusicXML"));
         }
         const score: IXmlElement = new IXmlElement(scorePartwiseElement);
-        const reader: MusicSheetReader = new MusicSheetReader();
+        const reader: MusicSheetReader = new MusicSheetReader(undefined, this.rules);
         this.sheet = reader.createMusicSheet(score, "Untitled Score");
         if (this.sheet === undefined) {
             // error loading sheet, probably already logged, do nothing
             return Promise.reject(new Error("given music sheet was incomplete or could not be loaded."));
-        } else {
-            this.sheet.Rules = this.rules;
         }
         log.info(`[OSMD] Loaded sheet ${this.sheet.TitleString} successfully.`);
 

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -148,6 +148,8 @@ export class OpenSheetMusicDisplay {
         if (this.sheet === undefined) {
             // error loading sheet, probably already logged, do nothing
             return Promise.reject(new Error("given music sheet was incomplete or could not be loaded."));
+        } else {
+            this.sheet.Rules = this.rules;
         }
         log.info(`[OSMD] Loaded sheet ${this.sheet.TitleString} successfully.`);
 

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -246,7 +246,7 @@ export class OpenSheetMusicDisplay {
                 // musicSheetCalculator.clearRecreatedObjects();
             }
             if (options.backend === undefined || options.backend.toLowerCase() === "svg") {
-                this.backend = new SvgVexFlowBackend();
+                this.backend = new SvgVexFlowBackend(this.rules);
             } else {
                 this.backend = new CanvasVexFlowBackend();
             }

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -70,6 +70,7 @@ export class OpenSheetMusicDisplay {
     private drawer: VexFlowMusicSheetDrawer;
     private graphic: GraphicalMusicSheet;
     private drawingParameters: DrawingParameters;
+    private rules: EngravingRules;
     private autoResizeEnabled: boolean;
     private resizeHandlerAttached: boolean;
     private followCursor: boolean;
@@ -217,6 +218,9 @@ export class OpenSheetMusicDisplay {
      *  For example, setOptions({autoResize: false}) will disable autoResize even during runtime.
      */
     public setOptions(options: IOSMDOptions): void {
+        if (!this.rules) {
+            this.rules = new EngravingRules();
+        }
         if (!this.drawingParameters) {
             this.drawingParameters = new DrawingParameters();
         }
@@ -255,14 +259,14 @@ export class OpenSheetMusicDisplay {
 
         // individual drawing parameters options
         if (options.autoBeam !== undefined) {
-            EngravingRules.Rules.AutoBeamNotes = options.autoBeam;
+            this.rules.AutoBeamNotes = options.autoBeam;
         }
         const autoBeamOptions: AutoBeamOptions = options.autoBeamOptions;
         if (autoBeamOptions) {
             if (autoBeamOptions.maintain_stem_directions === undefined) {
                 autoBeamOptions.maintain_stem_directions = false;
             }
-            EngravingRules.Rules.AutoBeamOptions = autoBeamOptions;
+            this.rules.AutoBeamOptions = autoBeamOptions;
             if (autoBeamOptions.groups && autoBeamOptions.groups.length) {
                 for (const fraction of autoBeamOptions.groups) {
                     if (fraction.length !== 2) {
@@ -273,16 +277,16 @@ export class OpenSheetMusicDisplay {
         }
 
         if (options.alignRests !== undefined) {
-            EngravingRules.Rules.AlignRests = options.alignRests;
+            this.rules.AlignRests = options.alignRests;
         }
         if (options.coloringMode !== undefined) {
             this.setColoringMode(options);
         }
         if (options.coloringEnabled !== undefined) {
-            EngravingRules.Rules.ColoringEnabled = options.coloringEnabled;
+            this.rules.ColoringEnabled = options.coloringEnabled;
         }
         if (options.colorStemsLikeNoteheads !== undefined) {
-            EngravingRules.Rules.ColorStemsLikeNoteheads = options.colorStemsLikeNoteheads;
+            this.rules.ColorStemsLikeNoteheads = options.colorStemsLikeNoteheads;
         }
         if (options.disableCursor) {
             this.drawingParameters.drawCursors = false;
@@ -312,70 +316,70 @@ export class OpenSheetMusicDisplay {
             this.drawingParameters.DrawPartNames = options.drawPartNames; // indirectly writes to EngravingRules
         }
         if (options.drawPartAbbreviations !== undefined) {
-            EngravingRules.Rules.RenderPartAbbreviations = options.drawPartAbbreviations;
+            this.rules.RenderPartAbbreviations = options.drawPartAbbreviations;
         }
         if (options.drawFingerings === false) {
-            EngravingRules.Rules.RenderFingerings = false;
+            this.rules.RenderFingerings = false;
         }
         if (options.drawMeasureNumbers !== undefined) {
-            EngravingRules.Rules.RenderMeasureNumbers = options.drawMeasureNumbers;
+            this.rules.RenderMeasureNumbers = options.drawMeasureNumbers;
         }
         if (options.drawLyrics !== undefined) {
-            EngravingRules.Rules.RenderLyrics = options.drawLyrics;
+            this.rules.RenderLyrics = options.drawLyrics;
         }
         if (options.drawSlurs !== undefined) {
-            EngravingRules.Rules.RenderSlurs = options.drawSlurs;
+            this.rules.RenderSlurs = options.drawSlurs;
         }
         if (options.measureNumberInterval !== undefined) {
-            EngravingRules.Rules.MeasureNumberLabelOffset = options.measureNumberInterval;
+            this.rules.MeasureNumberLabelOffset = options.measureNumberInterval;
         }
         if (options.fingeringPosition !== undefined) {
-            EngravingRules.Rules.FingeringPosition = AbstractExpression.PlacementEnumFromString(options.fingeringPosition);
+            this.rules.FingeringPosition = AbstractExpression.PlacementEnumFromString(options.fingeringPosition);
         }
         if (options.fingeringInsideStafflines !== undefined) {
-            EngravingRules.Rules.FingeringInsideStafflines = options.fingeringInsideStafflines;
+            this.rules.FingeringInsideStafflines = options.fingeringInsideStafflines;
         }
         if (options.fillEmptyMeasuresWithWholeRest !== undefined) {
-            EngravingRules.Rules.FillEmptyMeasuresWithWholeRest = options.fillEmptyMeasuresWithWholeRest;
+            this.rules.FillEmptyMeasuresWithWholeRest = options.fillEmptyMeasuresWithWholeRest;
         }
         if (options.followCursor !== undefined) {
             this.FollowCursor = options.followCursor;
         }
         if (options.setWantedStemDirectionByXml !== undefined) {
-            EngravingRules.Rules.SetWantedStemDirectionByXml = options.setWantedStemDirectionByXml;
+            this.rules.SetWantedStemDirectionByXml = options.setWantedStemDirectionByXml;
         }
         if (options.defaultColorNotehead) {
-            EngravingRules.Rules.DefaultColorNotehead = options.defaultColorNotehead;
+            this.rules.DefaultColorNotehead = options.defaultColorNotehead;
         }
         if (options.defaultColorRest) {
-            EngravingRules.Rules.DefaultColorRest = options.defaultColorRest;
+            this.rules.DefaultColorRest = options.defaultColorRest;
         }
         if (options.defaultColorStem) {
-            EngravingRules.Rules.DefaultColorStem = options.defaultColorStem;
+            this.rules.DefaultColorStem = options.defaultColorStem;
         }
         if (options.defaultColorLabel) {
-            EngravingRules.Rules.DefaultColorLabel = options.defaultColorLabel;
+            this.rules.DefaultColorLabel = options.defaultColorLabel;
         }
         if (options.defaultColorTitle) {
-            EngravingRules.Rules.DefaultColorTitle = options.defaultColorTitle;
+            this.rules.DefaultColorTitle = options.defaultColorTitle;
         }
         if (options.defaultFontFamily) {
-            EngravingRules.Rules.DefaultFontFamily = options.defaultFontFamily; // default "Times New Roman", also used if font family not found
+            this.rules.DefaultFontFamily = options.defaultFontFamily; // default "Times New Roman", also used if font family not found
         }
         if (options.drawUpToMeasureNumber) {
-            EngravingRules.Rules.MaxMeasureToDrawIndex = options.drawUpToMeasureNumber - 1;
+            this.rules.MaxMeasureToDrawIndex = options.drawUpToMeasureNumber - 1;
         }
         if (options.drawFromMeasureNumber) {
-            EngravingRules.Rules.MinMeasureToDrawIndex = options.drawFromMeasureNumber - 1;
+            this.rules.MinMeasureToDrawIndex = options.drawFromMeasureNumber - 1;
         }
         if (options.tupletsRatioed) {
-            EngravingRules.Rules.TupletsRatioed = true;
+            this.rules.TupletsRatioed = true;
         }
         if (options.tupletsBracketed) {
-            EngravingRules.Rules.TupletsBracketed = true;
+            this.rules.TupletsBracketed = true;
         }
         if (options.tripletsBracketed) {
-            EngravingRules.Rules.TripletsBracketed = true;
+            this.rules.TripletsBracketed = true;
         }
         if (options.autoResize) {
             if (!this.resizeHandlerAttached) {
@@ -390,7 +394,7 @@ export class OpenSheetMusicDisplay {
 
     public setColoringMode(options: IOSMDOptions): void {
         if (options.coloringMode === ColoringModes.XML) {
-            EngravingRules.Rules.ColoringMode = ColoringModes.XML;
+            this.rules.ColoringMode = ColoringModes.XML;
             return;
         }
         const noteIndices: NoteEnum[] = [NoteEnum.C, NoteEnum.D, NoteEnum.E, NoteEnum.F, NoteEnum.G, NoteEnum.A, NoteEnum.B, -1];
@@ -421,9 +425,9 @@ export class OpenSheetMusicDisplay {
             coloringSetCurrent.setValue(noteIndices[i], colorSetString[i]);
         }
         coloringSetCurrent.setValue(-1, colorSetString[7]);
-        EngravingRules.Rules.ColoringSetCurrent = coloringSetCurrent;
+        this.rules.ColoringSetCurrent = coloringSetCurrent;
 
-        EngravingRules.Rules.ColoringMode = options.coloringMode;
+        this.rules.ColoringMode = options.coloringMode;
     }
 
     /**
@@ -625,7 +629,7 @@ export class OpenSheetMusicDisplay {
         return this.drawingParameters;
     }
     public get EngravingRules(): EngravingRules { // custom getter, useful for engraving parameter setting in Demo
-        return EngravingRules.Rules;
+        return this.rules;
     }
     /** Returns the version of OSMD this object is built from (the version you are using). */
     public get Version(): string {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -225,6 +225,7 @@ export class OpenSheetMusicDisplay {
         }
         if (!this.drawingParameters) {
             this.drawingParameters = new DrawingParameters();
+            this.drawingParameters.Rules = this.rules;
         }
         if (options === undefined || options === null) {
             log.warn("warning: osmd.setOptions() called without an options parameter, has no effect."

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -1,7 +1,8 @@
 import chai = require("chai");
 import { OpenSheetMusicDisplay } from "../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
 import { TestUtils } from "../../Util/TestUtils";
-import { VoiceEntry, Instrument, Note, Staff, Voice, GraphicalStaffEntry, GraphicalNote, Fraction, Pitch, AccidentalEnum } from "../../../src";
+import { VoiceEntry, Instrument, Note, Staff, Voice, GraphicalStaffEntry, GraphicalNote,
+            Fraction, Pitch, AccidentalEnum, DrawingParametersEnum, IOSMDOptions } from "../../../src";
 
 describe("OpenSheetMusicDisplay Main Export", () => {
     let container1: HTMLElement;
@@ -19,6 +20,67 @@ describe("OpenSheetMusicDisplay Main Export", () => {
             return new OpenSheetMusicDisplay(div);
         }).to.not.throw(Error);
         done();
+    });
+
+    it("multiple instances", () => {
+        const musicSheetFragmentContainer: HTMLElement = TestUtils.getDivElement(document);
+        const fullMusicSheetContainer: HTMLElement = TestUtils.getDivElement(document);
+
+        const musicSheetFragmentOptions: IOSMDOptions = {
+            drawComposer: false,
+            drawCredits: false,
+            drawFingerings: false,
+            drawHiddenNotes: false,
+            drawLyricist: false,
+            drawPartAbbreviations: false,
+            drawPartNames: false,
+            drawSubtitle: false,
+            drawTitle: false,
+            drawUpToMeasureNumber: 1,
+            drawingParameters: DrawingParametersEnum.compact
+        };
+        const fullMusicSheetOptions: IOSMDOptions = {
+            drawUpToMeasureNumber: 10
+        };
+
+        const musicSheetFragment: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(
+            musicSheetFragmentContainer,
+            musicSheetFragmentOptions
+        );
+        const fullMusicSheet: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(fullMusicSheetContainer, fullMusicSheetOptions);
+
+        const musicSheet: Document = TestUtils.getScore("MuzioClementi_SonatinaOpus36No1_Part1.xml");
+        const musicSheetXML: string = new XMLSerializer().serializeToString(musicSheet);
+
+        return musicSheetFragment.load(musicSheetXML)
+                            .then(() => {
+                                musicSheetFragment.render();
+
+                                return fullMusicSheet.load(musicSheetXML);
+                            })
+                            .then(() => {
+                                fullMusicSheet.render();
+
+                                // Verify that the music sheet fragment has its options set correctly.
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderComposer).to.equal(musicSheetFragmentOptions.drawComposer);
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderFingerings).to.equal(musicSheetFragmentOptions.drawFingerings);
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderLyricist).to.equal(musicSheetFragmentOptions.drawLyricist);
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderPartAbbreviations).to.equal(musicSheetFragmentOptions.drawPartAbbreviations);
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderPartNames).to.equal(musicSheetFragmentOptions.drawPartNames);
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderSubtitle).to.equal(musicSheetFragmentOptions.drawSubtitle);
+                                chai.expect(musicSheetFragment.Sheet.Rules.RenderTitle).to.equal(musicSheetFragmentOptions.drawTitle);
+                                chai.expect(musicSheetFragment.Sheet.Rules.MaxMeasureToDrawIndex).to.equal(musicSheetFragmentOptions.drawUpToMeasureNumber - 1);
+
+                                // Verify that the full music sheet has its options set correctly.
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderComposer).to.not.equal(musicSheetFragmentOptions.drawComposer);
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderFingerings).to.not.equal(musicSheetFragmentOptions.drawFingerings);
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderLyricist).to.not.equal(musicSheetFragmentOptions.drawLyricist);
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderPartAbbreviations).to.not.equal(musicSheetFragmentOptions.drawPartAbbreviations);
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderPartNames).to.not.equal(musicSheetFragmentOptions.drawPartNames);
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderSubtitle).to.not.equal(musicSheetFragmentOptions.drawSubtitle);
+                                chai.expect(fullMusicSheet.Sheet.Rules.RenderTitle).to.not.equal(musicSheetFragmentOptions.drawTitle);
+                                chai.expect(fullMusicSheet.Sheet.Rules.MaxMeasureToDrawIndex).to.equal(fullMusicSheetOptions.drawUpToMeasureNumber - 1);
+                            });
     });
 
     it("load MXL from string", (done: MochaDone) => {

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -28,7 +28,7 @@ describe("VexFlow Measure", () => {
 
    it.skip("Simple Measure", (done: MochaDone) => {
       const sheet: MusicSheet = new MusicSheet();
-      const measure: SourceMeasure = new SourceMeasure(1);
+      const measure: SourceMeasure = new SourceMeasure(1, sheet.Rules);
       sheet.addMeasure(measure);
       const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();
       const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
@@ -41,7 +41,7 @@ describe("VexFlow Measure", () => {
 
    it.skip("Empty Measure", (done: MochaDone) => {
       const sheet: MusicSheet = new MusicSheet();
-      const measure: SourceMeasure = new SourceMeasure(1);
+      const measure: SourceMeasure = new SourceMeasure(1, sheet.Rules);
       measure.FirstInstructionsStaffEntries[0] = new SourceStaffEntry(undefined, undefined);
       sheet.addMeasure(measure);
       const calc: MusicSheetCalculator = new VexFlowMusicSheetCalculator();


### PR DESCRIPTION
# What does this PR contribute?
The PR allows for multiple OSMD instances with different `OSMDOptions` on the same page. This was not possible until now as  described in #559.

# How does this PR achieve its contribution?
The PR adds a reference to an instance of `EngravingRules` to the following classes:

- `OpenSheetMusicDisplay`: contains an instance of `EngravingRules` which was previously only provided statically
- `SourceMeasure` as [suggested](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/559#issuecomment-544885999) by @matt-uib to cover most of the uses of `EngravingRules`
- `MusicSheetReader` to set `rules` of `MusicSheet`
- `DrawingParameters` to a use of `EngravingRules` where no other class instance with a reference to `EngravingRules` is available
- `SvgVexFlowBackend` to a use of `EngravingRules` where no other class instance with a reference to `EngravingRules` is available

The PR also adds a test case to verify that multiple instance of OSMD on the same page can feature different `OSMDOptions`.

# What problems still persist with this PR?

There are three occasions ([here](https://github.com/dnlfrst/opensheetmusicdisplay/blob/fix/entangled-engraving-rules/src/MusicalScore/Graphical/DrawingParameters.ts#L23), [here](https://github.com/dnlfrst/opensheetmusicdisplay/blob/fix/entangled-engraving-rules/src/MusicalScore/Graphical/GraphicalVoiceEntry.ts#L24), and [here](https://github.com/dnlfrst/opensheetmusicdisplay/blob/fix/entangled-engraving-rules/src/MusicalScore/ScoreIO/MusicSheetReader.ts#L28)) where I conditionally instantiate `EngravingRules`. Could anyone verify that this does not pose any issues?

# What is still left to do?

- [x]  Remove the [use](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/blob/develop/src/MusicalScore/Graphical/GraphicalLabel.ts#L44) of `EngravingRules` in `GraphicalLabel`. The class does not contain another class instance with a reference to the `EngravingRules` instance. I could not come up with a practical solution. Any ideas?
- [x]  Remove the [use](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/blob/develop/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts#L656) of `EngravingRules` in `VexFlowConverter`. The enclosing static method is used only two times but I could not come up with a practical solution. Any ideas?
- [x] Remove the static instance of `EngravingRules`.

# When is this PR ready to be merged?
As soon as the above problems are mitigated and someone reviewed this PR. @matt-uib @sschmidTU 