### PR TITLE
Update eslint dependencies

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,5 @@
 parserOptions: {
-        ecmaVersion: 7, // the ecmaVersion isn't set in stone, for now added to satisfy eslint 
+        ecmaVersion: 8, // 8 = ECMA2017 necessary for promises/async. The ecmaVersion isn't set in stone, for now mostly adapted for eslint.
     }
 extends: standard
 rules:

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",
-    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",
     "html-webpack-plugin": "^3.2.0",
     "jquery": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "clean-webpack-plugin": "^1.0.1",
     "cross-env": "^7.0.0",
     "cz-conventional-changelog": "^3.0.0",
-    "eslint": "^6.2.2",
+    "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",


### PR DESCRIPTION
updated eslint-plugin-promise and eslint. eslint-plugin-import was updated earlier outside of the branch.
eslintrc: ecmaversion set to 8 to handle await/promises
tested, builds fine.