### PR TITLE
#700, Rendering fix for half note tuplets

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -61,7 +61,7 @@ export class VexFlowConverter {
           return "w";
       } else if (dur < 1 && dur >= 0.5) {
         // change to the next higher straight note to get the correct note display type
-        if (isTuplet) {
+        if (isTuplet && dur > 0.5) {
           return "w";
         }
         return "h";


### PR DESCRIPTION
Conditional was added to ensure that TypeLength value did not override the duration improperly.
Duplicated from logic present for all smaller note values to accommodate half notes.

User provided sample now renders correctly:
![user-sample](https://user-images.githubusercontent.com/14796797/78467514-a36d8300-76db-11ea-9eac-418ce0cfb518.png)

Test task results:
[test_results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4432980/test_results.txt)

One failure, but this also failed on a fresh copy of develop, so assuming it is environment related:
```
FAILED TESTS:
  OpenSheetMusicDisplay Main Export
    ✖ load invalid URL
      HeadlessChrome 80.0.3987 (Linux 0.0.0)
```

Visual regression test results:
[results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4432974/results.txt)
```
Found 41 current and 41 blessed png files (not tested if valid). Continuing.\n
Running 41 tests with threshold 0.0001 (nproc=4)...
Progress : [########################################] 100%
Results stored in ./visual_regression/diff/results.txt
All images with a difference over threshold, 0.0001, are
available in ./visual_regression/diff, sorted by perceptual hash.

Success - All diffs under threshold!
```