### PR TITLE
Fix skyline not being calculated for slurs properly

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -409,7 +409,7 @@ export class EngravingRules {
 
         // Line Widths
         this.minimumStaffLineDistance = 4.0;
-        this.minimumSkyBottomLineDistance = 2.0; // default. 1.0 for compacttight mode (1.0 can cause overlaps)
+        this.minimumSkyBottomLineDistance = 1.0; // default. compacttight mode sets it to 1.0 (as well).
         this.minimumCrossedBeamDifferenceMargin = 0.0001;
 
         // xSpacing Variables

--- a/src/MusicalScore/Graphical/GraphicalCurve.ts
+++ b/src/MusicalScore/Graphical/GraphicalCurve.ts
@@ -33,7 +33,7 @@ export class GraphicalCurve {
      * @param relativePosition
      */
     public calculateCurvePointAtIndex(relativePosition: number): PointF2D {
-        const index: number =  Math.round(relativePosition);
+        const index: number =  Math.round(relativePosition * GraphicalCurve.bezierCurveStepSize);
         if (index < 0 || index >= GraphicalCurve.bezierCurveStepSize) {
             return new PointF2D();
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -222,7 +222,8 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     private drawSampledLine(line: number[], startPosition: PointF2D, width: number, color: string = "#FF0000FF"): void {
         const indices: number[] = [];
         let currentValue: number = 0;
-
+        //Loops through bottom line, grabs all indices that don't equal the previously grabbed index
+        //Starting with 0 (gets index of all line changes)
         for (let i: number = 0; i < line.length; i++) {
             if (line[i] !== currentValue) {
                 indices.push(i);


### PR DESCRIPTION
Test results:
[test_results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4717967/test_results.txt)

Visual Results:
[results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4717954/results.txt)
Differences seem to be related to spacing based on incorrect skyline, with current being more compact.