### PR TITLE
fix: show rhythm in first system measure, if last system ended with end-barline

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -57,6 +57,7 @@ export class EngravingRules {
     private betweenKeySymbolsDistance: number;
     private keyRightMargin: number;
     private rhythmRightMargin: number;
+    private showRhythmAgainAfterPartEndOrFinalBarline: boolean;
     private inStaffClefScalingFactor: number;
     private distanceBetweenNaturalAndSymbolWhenCancelling: number;
     private noteHelperLinesOffset: number;
@@ -289,6 +290,7 @@ export class EngravingRules {
         this.betweenKeySymbolsDistance = 0.2;
         this.keyRightMargin = 0.75;
         this.rhythmRightMargin = 1.25;
+        this.showRhythmAgainAfterPartEndOrFinalBarline = true;
         this.inStaffClefScalingFactor = 0.8;
         this.distanceBetweenNaturalAndSymbolWhenCancelling = 0.4;
 
@@ -731,6 +733,12 @@ export class EngravingRules {
     }
     public set RhythmRightMargin(value: number) {
         this.rhythmRightMargin = value;
+    }
+    public get ShowRhythmAgainAfterPartEndOrFinalBarline(): boolean {
+        return this.showRhythmAgainAfterPartEndOrFinalBarline;
+    }
+    public set ShowRhythmAgainAfterPartEndOrFinalBarline(value: boolean) {
+        this.showRhythmAgainAfterPartEndOrFinalBarline = value;
     }
     public get InStaffClefScalingFactor(): number {
         return this.inStaffClefScalingFactor;

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -90,9 +90,14 @@ export class MusicSystemBuilder {
             const measureStartLine: SystemLinesEnum = this.getMeasureStartLine();
             currentMeasureBeginInstructionsWidth += this.getLineWidth(graphicalMeasures[0], measureStartLine, isSystemStartMeasure);
             if (!this.leadSheet) {
+                let forceShowRhythm: boolean = false;
+                if (prevMeasureEndsPart && this.rules.ShowRhythmAgainAfterPartEndOrFinalBarline) {
+                    forceShowRhythm = true;
+                }
                 currentMeasureBeginInstructionsWidth += this.addBeginInstructions(  graphicalMeasures,
                                                                                     isSystemStartMeasure,
-                                                                                    isFirstSourceMeasure || prevMeasureEndsPart);
+                                                                                    isFirstSourceMeasure || forceShowRhythm);
+                // forceShowRhythm could be a fourth parameter instead in addBeginInstructions, but only affects RhythmInstruction for now.
                 currentMeasureEndInstructionsWidth += this.addEndInstructions(graphicalMeasures);
             }
             let currentMeasureVarWidth: number = 0;
@@ -129,12 +134,13 @@ export class MusicSystemBuilder {
                 if (sourceMeasureEndsPart) {
                     this.finalizeCurrentAndCreateNewSystem(graphicalMeasures, true);
                 }
+                prevMeasureEndsPart = sourceMeasureEndsPart;
             } else {
                 // finalize current system and prepare a new one
                 this.finalizeCurrentAndCreateNewSystem(graphicalMeasures, false, doXmlPageBreak);
                 // don't increase measure index to check this measure now again
+                // don't set prevMeasureEndsPart in this case! because we will loop with the same measure again.
             }
-            prevMeasureEndsPart = sourceMeasureEndsPart;
         }
         if (this.currentSystemParams.systemMeasures.length > 0) {
             this.finalizeCurrentAndCreateNewSystem(this.measureList[this.measureList.length - 1], true);

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -55,6 +55,7 @@ export class MusicSystemBuilder {
 
     public buildMusicSystems(): MusicSystem[] {
         const systemMaxWidth: number = this.getFullPageSystemWidth();
+        let prevMeasureEndsPart: boolean = false;
         this.measureListIndex = 0;
         this.currentSystemParams = new SystemBuildParameters();
 
@@ -75,7 +76,7 @@ export class MusicSystemBuilder {
                 graphicalMeasures[idx].resetLayout();
             }
             const sourceMeasure: SourceMeasure = graphicalMeasures[0].parentSourceMeasure;
-            const sourceMeasureEndsSystem: boolean = sourceMeasure.BreakSystemAfter;
+            const sourceMeasureEndsPart: boolean = sourceMeasure.HasEndLine;
             const isSystemStartMeasure: boolean = this.currentSystemParams.IsSystemStartMeasure();
             const isFirstSourceMeasure: boolean = sourceMeasure === this.graphicalMusicSheet.ParentMusicSheet.getFirstSourceMeasure();
             let currentMeasureBeginInstructionsWidth: number = this.rules.MeasureLeftMargin;
@@ -89,7 +90,9 @@ export class MusicSystemBuilder {
             const measureStartLine: SystemLinesEnum = this.getMeasureStartLine();
             currentMeasureBeginInstructionsWidth += this.getLineWidth(graphicalMeasures[0], measureStartLine, isSystemStartMeasure);
             if (!this.leadSheet) {
-                currentMeasureBeginInstructionsWidth += this.addBeginInstructions(graphicalMeasures, isSystemStartMeasure, isFirstSourceMeasure);
+                currentMeasureBeginInstructionsWidth += this.addBeginInstructions(  graphicalMeasures,
+                                                                                    isSystemStartMeasure,
+                                                                                    isFirstSourceMeasure || prevMeasureEndsPart);
                 currentMeasureEndInstructionsWidth += this.addEndInstructions(graphicalMeasures);
             }
             let currentMeasureVarWidth: number = 0;
@@ -123,7 +126,7 @@ export class MusicSystemBuilder {
                 );
                 this.updateActiveClefs(sourceMeasure, graphicalMeasures);
                 this.measureListIndex++;
-                if (sourceMeasureEndsSystem) {
+                if (sourceMeasureEndsPart) {
                     this.finalizeCurrentAndCreateNewSystem(graphicalMeasures, true);
                 }
             } else {
@@ -131,6 +134,7 @@ export class MusicSystemBuilder {
                 this.finalizeCurrentAndCreateNewSystem(graphicalMeasures, false, doXmlPageBreak);
                 // don't increase measure index to check this measure now again
             }
+            prevMeasureEndsPart = sourceMeasureEndsPart;
         }
         if (this.currentSystemParams.systemMeasures.length > 0) {
             this.finalizeCurrentAndCreateNewSystem(this.measureList[this.measureList.length - 1], true);

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -495,8 +495,7 @@ export class InstrumentReader {
           if (this.repetitionInstructionReader !== undefined) {
            const measureEndsSystem: boolean = this.repetitionInstructionReader.handleLineRepetitionInstructions(xmlNode);
            if (measureEndsSystem) {
-             this.currentMeasure.BreakSystemAfter = true;
-             this.currentMeasure.endsPiece = true;
+             this.currentMeasure.HasEndLine = true;
            }
           }
           const location: IXmlAttribute = xmlNode.attribute("location");

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -147,7 +147,7 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
         }
 
         while (couldReadMeasure) {
-            if (this.currentMeasure !== undefined && this.currentMeasure.endsPiece) {
+            if (this.currentMeasure !== undefined && this.currentMeasure.HasEndLine) {
                 sourceMeasureCounter = 0;
             }
             this.currentMeasure = new SourceMeasure(this.completeNumberOfStaves, this.musicSheet.Rules);

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -27,8 +27,7 @@ export class SourceMeasure {
     constructor(completeNumberOfStaves: number, rules: EngravingRules) {
         this.completeNumberOfStaves = completeNumberOfStaves;
         this.implicitMeasure = false;
-        this.breakSystemAfter = false;
-        this.endsPiece = false;
+        this.hasEndLine = false;
         this.endingBarStyleXml = "";
         this.endingBarStyleEnum = SystemLinesEnum.SingleThin;
         this.firstInstructionsStaffEntries = new Array(completeNumberOfStaves);
@@ -45,10 +44,6 @@ export class SourceMeasure {
      * The unique measure list index starting with 0.
      */
     public measureListIndex: number;
-    /**
-     * The measure number for showing on the music sheet. Typically starts with 1.
-     */
-    public endsPiece: boolean;
     /**
      * The style of the ending bar line.
      */
@@ -68,7 +63,7 @@ export class SourceMeasure {
     private tempoExpressions: MultiTempoExpression[] = [];
     private verticalSourceStaffEntryContainers: VerticalSourceStaffEntryContainer[] = [];
     private implicitMeasure: boolean;
-    private breakSystemAfter: boolean;
+    private hasEndLine: boolean;
     private graphicalMeasureErrors: boolean[] = [];
     private firstInstructionsStaffEntries: SourceStaffEntry[];
     private lastInstructionsStaffEntries: SourceStaffEntry[];
@@ -122,12 +117,12 @@ export class SourceMeasure {
         this.implicitMeasure = value;
     }
 
-    public get BreakSystemAfter(): boolean {
-        return this.breakSystemAfter;
+    public get HasEndLine(): boolean {
+        return this.hasEndLine;
     }
 
-    public set BreakSystemAfter(value: boolean) {
-        this.breakSystemAfter = value;
+    public set HasEndLine(value: boolean) {
+        this.hasEndLine = value;
     }
 
     public get StaffLinkedExpressions(): MultiExpression[][] {


### PR DESCRIPTION
implemented showing the current rhythm in any case if there was an end line given in the last system.