### PR TITLE
Fix measure number skyline offset

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -372,11 +372,8 @@ export abstract class MusicSheetCalculator {
         let start: number = relativeX;
         let end: number = relativeX - graphicalLabel.PositionAndShape.BorderLeft + graphicalLabel.PositionAndShape.BorderMarginRight;
 
-        // take into account the InstrumentNameLabel's at the beginning of the first MusicSystem
-        if (staffLine === musicSystem.StaffLines[0] && musicSystem === this.musicSystems[0]) {
-            start -= staffLine.PositionAndShape.RelativePosition.x;
-            end -= staffLine.PositionAndShape.RelativePosition.x;
-        }
+        start -= staffLine.PositionAndShape.RelativePosition.x;
+        end -= staffLine.PositionAndShape.RelativePosition.x;
 
         // get the minimum corresponding SkyLine value
         const skyLineMinValue: number = skyBottomLineCalculator.getSkyLineMinInRange(start, end);


### PR DESCRIPTION
The staffline offset was only being taken into account for the first staffline. Removed this check.

The visual diff seems to be only related to the measure numbers and some spacing as a result of that:
[visual_diff.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4745793/visual_diff.zip)

Karma results:
[test_results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4745794/test_results.txt)

