### PR TITLE
Fixes for single Drumline

### DIFF
--- a/src/Common/DataObjects/Pitch.ts
+++ b/src/Common/DataObjects/Pitch.ts
@@ -347,20 +347,6 @@ export class Pitch {
         ", Note: " + this.fundamentalNote + ", octave: " + this.octave.toString();
     }
 
-    public IndexOf(array: Array<Pitch>, start: number = 0): number {
-        if (start > array.length - 1) {
-            return -1;
-        }
-
-        for (let i: number = start; i < array.length; i++) {
-            const p2: Pitch = array[i];
-            if (this.OperatorEquals(p2)) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
     public OperatorEquals(p2: Pitch): boolean {
         const p1: Pitch = this;
         // if (ReferenceEquals(p1, p2)) {
@@ -378,7 +364,7 @@ export class Pitch {
     }
 
     //These don't take into account accidentals! which isn't needed for our current purpose
-    public OperatorGreaterThan(p2: Pitch): boolean {
+    public OperatorFundamentalGreaterThan(p2: Pitch): boolean {
         const p1: Pitch = this;
         if (p1.Octave === p2.Octave) {
             return p1.FundamentalNote > p2.FundamentalNote;
@@ -387,7 +373,7 @@ export class Pitch {
         }
     }
 
-    public OperatorLessThan(p2: Pitch): boolean {
+    public OperatorFundamentalLessThan(p2: Pitch): boolean {
         const p1: Pitch = this;
         if (p1.Octave === p2.Octave) {
             return p1.FundamentalNote < p2.FundamentalNote;

--- a/src/Common/DataObjects/Pitch.ts
+++ b/src/Common/DataObjects/Pitch.ts
@@ -347,6 +347,20 @@ export class Pitch {
         ", Note: " + this.fundamentalNote + ", octave: " + this.octave.toString();
     }
 
+    public IndexOf(array: Array<Pitch>, start: number = 0): number {
+        if (start > array.length - 1) {
+            return -1;
+        }
+
+        for (let i: number = start; i < array.length; i++) {
+            const p2: Pitch = array[i];
+            if (this.OperatorEquals(p2)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public OperatorEquals(p2: Pitch): boolean {
         const p1: Pitch = this;
         // if (ReferenceEquals(p1, p2)) {
@@ -361,6 +375,25 @@ export class Pitch {
     public OperatorNotEqual(p2: Pitch): boolean {
         const p1: Pitch = this;
         return !(p1 === p2);
+    }
+
+    //These don't take into account accidentals! which isn't needed for our current purpose
+    public OperatorGreaterThan(p2: Pitch): boolean {
+        const p1: Pitch = this;
+        if (p1.Octave === p2.Octave) {
+            return p1.FundamentalNote > p2.FundamentalNote;
+        } else {
+            return p1.Octave > p2.Octave;
+        }
+    }
+
+    public OperatorLessThan(p2: Pitch): boolean {
+        const p1: Pitch = this;
+        if (p1.Octave === p2.Octave) {
+            return p1.FundamentalNote < p2.FundamentalNote;
+        } else {
+            return p1.Octave < p2.Octave;
+        }
     }
 
     // This method returns a new Pitch factor-Halftones higher than the current Pitch

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -290,8 +290,8 @@ export class EngravingRules {
         // Beam Sizing Variables
         this.clefLeftMargin = 0.5;
         this.clefRightMargin = 0.75;
-        this.percussionOneLineCutoff = 4;
-        this.percussionForceVoicesOneLineCutoff = 3;
+        this.percussionOneLineCutoff = 3;
+        this.percussionForceVoicesOneLineCutoff = 1;
         this.betweenKeySymbolsDistance = 0.2;
         this.keyRightMargin = 0.75;
         this.rhythmRightMargin = 1.25;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -303,7 +303,7 @@ export abstract class MusicSheetCalculator {
     }
 
     protected layoutVoiceEntry(voiceEntry: VoiceEntry, graphicalNotes: GraphicalNote[],
-                               graphicalStaffEntry: GraphicalStaffEntry, hasPitchedNote: boolean, staffIndex: number): void {
+                               graphicalStaffEntry: GraphicalStaffEntry, hasPitchedNote: boolean): void {
         throw new Error("abstract, not implemented");
     }
 
@@ -1548,7 +1548,7 @@ export abstract class MusicSheetCalculator {
                 graphicalNote = MusicSheetCalculator.symbolFactory.createGraceNote(note, gve, activeClef, octaveShiftValue);
             } else {
                 graphicalNote = MusicSheetCalculator.symbolFactory.createNote(note, gve, activeClef, octaveShiftValue, undefined);
-                MusicSheetCalculator.stafflineNoteCalculator.trackNote(graphicalNote, staffIndex);
+                MusicSheetCalculator.stafflineNoteCalculator.trackNote(graphicalNote);
             }
             if (note.Pitch) {
                 this.checkNoteForAccidental(graphicalNote, accidentalCalculator, activeClef, octaveShiftValue);
@@ -1614,7 +1614,7 @@ export abstract class MusicSheetCalculator {
                 }
                 const voiceEntry: VoiceEntry = graphicalNotes[0].sourceNote.ParentVoiceEntry;
                 const hasPitchedNote: boolean = graphicalNotes[0].sourceNote.Pitch !== undefined;
-                this.layoutVoiceEntry(voiceEntry, graphicalNotes, graphicalStaffEntry, hasPitchedNote, staffIndex);
+                this.layoutVoiceEntry(voiceEntry, graphicalNotes, graphicalStaffEntry, hasPitchedNote);
             }
         }
     }
@@ -2144,7 +2144,7 @@ export abstract class MusicSheetCalculator {
                                                                                                    gve,
                                                                                                    new ClefInstruction(),
                                                                                                    OctaveEnum.NONE, undefined);
-                MusicSheetCalculator.stafflineNoteCalculator.trackNote(graphicalNote, staffIndex);
+                MusicSheetCalculator.stafflineNoteCalculator.trackNote(graphicalNote);
                 gve.notes.push(graphicalNote);
             }
         }

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -168,7 +168,7 @@ export abstract class MusicSheetCalculator {
         }
 
         const staffIsPercussionArray: Array<boolean> =
-                        activeClefs.map(clef => (clef.ClefType === ClefEnum.percussion) ? true : false);
+                        activeClefs.map(clef => (clef.ClefType === ClefEnum.percussion));
 
         this.handleStaffEntries(staffIsPercussionArray);
         this.calculateVerticalContainersList();

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -166,7 +166,11 @@ export abstract class MusicSheetCalculator {
             );
             measureList.push(graphicalMeasures);
         }
-        this.handleStaffEntries(activeClefs);
+
+        const staffIsPercussionArray: Array<boolean> =
+                        activeClefs.map(clef => (clef.ClefType === ClefEnum.percussion) ? true : false);
+
+        this.handleStaffEntries(staffIsPercussionArray);
         this.calculateVerticalContainersList();
         this.setIndicesToVerticalGraphicalContainers();
     }
@@ -2177,7 +2181,7 @@ export abstract class MusicSheetCalculator {
     //     return graphicalStaffEntry;
     // }
 
-    private handleStaffEntries(activeClefs: ClefInstruction[]): void {
+    private handleStaffEntries(staffIsPercussionArray: Array<boolean>): void {
         for (let idx: number = 0, len: number = this.graphicalMusicSheet.MeasureList.length; idx < len; ++idx) {
             const measures: GraphicalMeasure[] = this.graphicalMusicSheet.MeasureList[idx];
             for (let idx2: number = 0, len2: number = measures.length; idx2 < len2; ++idx2) {
@@ -2185,7 +2189,7 @@ export abstract class MusicSheetCalculator {
                 //This property is active...
                 if (this.rules.PercussionOneLineCutoff !== undefined && this.rules.PercussionOneLineCutoff !== 0) {
                     //We have a percussion clef, check to see if this property applies...
-                    if (activeClefs[idx2].ClefType === ClefEnum.percussion) {
+                    if (staffIsPercussionArray[idx2]) {
                         //-1 means always trigger, or we are under the cutoff number specified
                         if (this.rules.PercussionOneLineCutoff === -1 ||
                             MusicSheetCalculator.stafflineNoteCalculator.getStafflineUniquePositionCount(idx2) < this.rules.PercussionOneLineCutoff) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -397,8 +397,10 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
    * @param hasPitchedNote
    */
   protected layoutVoiceEntry(voiceEntry: VoiceEntry, graphicalNotes: GraphicalNote[], graphicalStaffEntry: GraphicalStaffEntry,
-                             hasPitchedNote: boolean): void {
-    return;
+                             hasPitchedNote: boolean, staffIndex: number): void {
+      for (let i: number = 0; i < graphicalNotes.length; i++) {
+        graphicalNotes[i] = MusicSheetCalculator.stafflineNoteCalculator.positionNote(graphicalNotes[i], staffIndex);
+      }
   }
 
   /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -397,9 +397,9 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
    * @param hasPitchedNote
    */
   protected layoutVoiceEntry(voiceEntry: VoiceEntry, graphicalNotes: GraphicalNote[], graphicalStaffEntry: GraphicalStaffEntry,
-                             hasPitchedNote: boolean, staffIndex: number): void {
+                             hasPitchedNote: boolean): void {
       for (let i: number = 0; i < graphicalNotes.length; i++) {
-        graphicalNotes[i] = MusicSheetCalculator.stafflineNoteCalculator.positionNote(graphicalNotes[i], staffIndex);
+        graphicalNotes[i] = MusicSheetCalculator.stafflineNoteCalculator.positionNote(graphicalNotes[i]);
       }
   }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator.ts
@@ -1,89 +1,156 @@
 import { IStafflineNoteCalculator } from "../../Interfaces/IStafflineNoteCalculator";
 import { GraphicalNote } from "../GraphicalNote";
-import { ClefInstruction, ClefEnum } from "../../VoiceData";
-import { Pitch, NoteEnum, AccidentalEnum } from "../../../Common";
+import { ClefEnum, StemDirectionType, VoiceEntry } from "../../VoiceData";
+import { Pitch, NoteEnum } from "../../../Common";
 import { VexFlowGraphicalNote } from "./VexFlowGraphicalNote";
 import { Dictionary } from "typescript-collections";
 import { EngravingRules } from "../EngravingRules";
 
 export class VexflowStafflineNoteCalculator implements IStafflineNoteCalculator {
-    private instrumentVoiceMapping: Dictionary<string, Dictionary<number, {note: NoteEnum, octave: number}>> =
-                                                new Dictionary<string, Dictionary<number, {note: NoteEnum, octave: number}>>();
     private rules: EngravingRules;
-    private voiceIdx: number = 0;
+    private staffPitchListMapping: Dictionary<number, Array<Pitch>> = new Dictionary<number, Array<Pitch>>();
+    //These render on the single line by default
+    private baseLineNote: NoteEnum = NoteEnum.B;
+    private baseLineOctave: number = 1;
 
     constructor(rules: EngravingRules) {
         this.rules = rules;
     }
-  /**
-   * This method is called for each note, and should make any necessary position changes based on the number of stafflines, clef, etc.
-   * Right now this just directly maps a voice number to a position above or below a staffline
-   * @param graphicalNote The note to be checked/positioned
-   * @param currentClef The clef that is active for this note
-   * @param stafflineCount The number of stafflines we are rendering on
-   * @returns the minimum required x width of the source measure (=list of staff measures)
-   */
-    public positionNote(graphicalNote: GraphicalNote, currentClef: ClefInstruction, stafflineCount: number): GraphicalNote {
-        if (!(graphicalNote instanceof VexFlowGraphicalNote) || currentClef.ClefType !== ClefEnum.percussion ||
-        graphicalNote.sourceNote.isRest() || stafflineCount > 1 || this.rules.PercussionOneLineCutoff === 0 ) {
-            return graphicalNote;
+    /**
+     * This method is called for each note during the calc phase. We want to track all possible positions to make decisions
+     * during layout about where notes should be positioned.
+     * This directly notes that share a line to the same position, regardless of voice
+     * @param graphicalNote The note to be checked/positioned
+     * @param staffIndex The staffline the note is on
+     */
+    public trackNote(graphicalNote: GraphicalNote, staffIndex: number): void {
+        if (!(graphicalNote instanceof VexFlowGraphicalNote) || graphicalNote.Clef().ClefType !== ClefEnum.percussion ||
+        graphicalNote.sourceNote.isRest() || this.rules.PercussionOneLineCutoff === 0 ||
+        this.rules.PercussionForceVoicesOneLineCutoff === -1) {
+            return;
         }
 
-        const forceOneLineCutoff: number = this.rules.PercussionForceVoicesOneLineCutoff;
-        const forceOneLine: boolean = (forceOneLineCutoff !== undefined && forceOneLineCutoff !== 0) &&
-                                       (forceOneLineCutoff === -1 ||
-                                        graphicalNote.sourceNote.ParentStaff.ParentInstrument.SubInstruments.length < forceOneLineCutoff);
-
-        const instrumentId: string = graphicalNote.sourceNote.PlaybackInstrumentId;
-        const voiceNumber: number = graphicalNote.parentVoiceEntry.parentVoiceEntry.ParentVoice.VoiceId;
-        let currentInstrumentMapping: Dictionary<number, {note: NoteEnum, octave: number}> = undefined;
-
-        if (!this.instrumentVoiceMapping.containsKey(instrumentId)) {
-            currentInstrumentMapping = new Dictionary<number, {note: NoteEnum, octave: number}>();
-            this.instrumentVoiceMapping.setValue(instrumentId, currentInstrumentMapping);
-        } else {
-            currentInstrumentMapping = this.instrumentVoiceMapping.getValue(instrumentId);
+        let currentPitchList: Array<Pitch> = undefined;
+        if (!this.staffPitchListMapping.containsKey(staffIndex)) {
+            this.staffPitchListMapping.setValue(staffIndex, new Array<Pitch>());
         }
+        currentPitchList = this.staffPitchListMapping.getValue(staffIndex);
+        const pitch: Pitch = graphicalNote.sourceNote.Pitch;
+        VexflowStafflineNoteCalculator.findOrInsert(currentPitchList, pitch);
+    }
 
-        let fundamental: NoteEnum = NoteEnum.B;
-        let octave: number = 1;
-        const vfGraphicalNote: VexFlowGraphicalNote = graphicalNote as VexFlowGraphicalNote;
-
-        //if we are forcing to one line, just set to B
-        if (!forceOneLine) {
-            if (!currentInstrumentMapping.containsKey(voiceNumber)) {
-                //Direct mapping for more than one voice, position voices
-                switch (this.voiceIdx % 5) {
-                    case 1:
-                        fundamental = NoteEnum.A;
-                        break;
-                    case 2:
-                        fundamental = NoteEnum.F;
-                        break;
-                    case 3:
-                        fundamental = NoteEnum.D;
-                        break;
-                    case 4:
-                        fundamental = NoteEnum.B;
-                        octave = 0;
-                        break;
-                    default:
-                        fundamental = NoteEnum.C;
-                        octave = 2;
-                        break;
-                }
-                //For every new instrument/voice for a instrument, render on diff line
-                this.voiceIdx++;
-                currentInstrumentMapping.setValue(voiceNumber, {note: fundamental, octave: octave});
+    private static findOrInsert(array: Array<Pitch>, pitch: Pitch): number {
+        for (let i: number = 0; i < array.length; i++) {
+            const p2: Pitch = array[i];
+            if (pitch.OperatorEquals(p2)) {
+                return i;
             } else {
-                const storageObj: {note: NoteEnum, octave: number} = currentInstrumentMapping.getValue(voiceNumber);
-                fundamental = storageObj.note;
-                octave = storageObj.octave;
+                if (pitch.OperatorLessThan(p2)) {
+                    array.splice(i, 0, pitch);
+                    return i;
+                }
             }
         }
+        //If we reach here, we've reached the end of the array.
+        //Means its the greatest pitch
+        array.push(pitch);
+        return array.length - 1;
+    }
 
-        //TODO: Check for playback side effects
-        vfGraphicalNote.setAccidental(new Pitch(fundamental, octave, AccidentalEnum.NONE));
-        return graphicalNote;
+    /**
+     * This method is called for each note, and should make any necessary position changes based on the number of stafflines, clef, etc.
+     * @param graphicalNote The note to be checked/positioned
+     * @param staffIndex The staffline that this note exists on
+     * @returns the newly positioned note
+     */
+    public positionNote(graphicalNote: GraphicalNote, staffIndex: number): GraphicalNote {
+        if (!(graphicalNote instanceof VexFlowGraphicalNote) || graphicalNote.sourceNote.isRest()
+            || !this.staffPitchListMapping.containsKey(staffIndex)) {
+            return graphicalNote;
+        }
+        const currentPitchList: Array<Pitch> = this.staffPitchListMapping.getValue(staffIndex);
+        //Don't need to position notes. We aren't under the cutoff
+        if (currentPitchList.length > this.rules.PercussionOneLineCutoff) {
+            return graphicalNote;
+        }
+        const vfGraphicalNote: VexFlowGraphicalNote = graphicalNote as VexFlowGraphicalNote;
+        const notePitch: Pitch = graphicalNote.sourceNote.Pitch;
+
+        //If we only need to render on one line
+        if (currentPitchList.length <= this.rules.PercussionForceVoicesOneLineCutoff) {
+            vfGraphicalNote.setAccidental(new Pitch(this.baseLineNote, this.baseLineOctave, notePitch.Accidental));
+        } else {
+            const pitchIndex: number = notePitch.IndexOf(currentPitchList);
+            if (pitchIndex > -1) {
+                let fundamental: NoteEnum = this.baseLineNote;
+                let octave: number = this.baseLineOctave;
+                const half: number = Math.ceil(currentPitchList.length / 2);
+                //position above
+                if (pitchIndex >= half) {
+                    octave = 2;
+                    switch ((pitchIndex - half) % 5) {
+                        case 1:
+                            fundamental = NoteEnum.E;
+                            break;
+                        case 2:
+                            fundamental = NoteEnum.G;
+                            break;
+                        case 3:
+                            fundamental = NoteEnum.B;
+                            break;
+                        case 4:
+                            fundamental = NoteEnum.D;
+                            octave = 3;
+                            break;
+                        default:
+                            fundamental = NoteEnum.C;
+                            break;
+                    }
+                } else { //position below
+                    switch (pitchIndex % 5) {
+                        case 1:
+                            fundamental = NoteEnum.F;
+                            break;
+                        case 2:
+                            fundamental = NoteEnum.D;
+                            break;
+                        case 3:
+                            fundamental = NoteEnum.B;
+                            octave = 0;
+                            break;
+                        case 4:
+                            fundamental = NoteEnum.G;
+                            octave = 0;
+                            break;
+                        default:
+                            fundamental = NoteEnum.A;
+                            break;
+                    }
+                }
+                const mappedPitch: Pitch = new Pitch(fundamental, octave, notePitch.Accidental);
+                //Map the pitch, set stems properly
+                vfGraphicalNote.setAccidental(mappedPitch);
+                const parentVoiceEntry: VoiceEntry = vfGraphicalNote.parentVoiceEntry.parentVoiceEntry;
+                if (parentVoiceEntry.Notes.length < 2) { // Only switch stems if we aren't sharing stems with another note
+                    if (mappedPitch.Octave > this.baseLineOctave ||
+                        (mappedPitch.FundamentalNote === this.baseLineNote && mappedPitch.Octave === this.baseLineOctave)) {
+                        vfGraphicalNote.parentVoiceEntry.parentVoiceEntry.WantedStemDirection = StemDirectionType.Up;
+                    } else {
+                        vfGraphicalNote.parentVoiceEntry.parentVoiceEntry.WantedStemDirection = StemDirectionType.Down;
+                    }
+                }
+            }
+        }
+        return vfGraphicalNote;
+    }
+    /**
+     * Get the number of unique "voices" or note positions
+     * @param staffIndex The Staffline to get the count of
+     */
+    public getStafflineUniquePositionCount(staffIndex: number): number {
+        if (this.staffPitchListMapping.containsKey(staffIndex)) {
+            return this.staffPitchListMapping.getValue(staffIndex).length;
+        }
+        return 0;
     }
 }

--- a/src/MusicalScore/Interfaces/IStafflineNoteCalculator.ts
+++ b/src/MusicalScore/Interfaces/IStafflineNoteCalculator.ts
@@ -1,7 +1,7 @@
 import { GraphicalNote } from "../Graphical/GraphicalNote";
 
 export interface IStafflineNoteCalculator {
-    trackNote(graphicalNote: GraphicalNote, staffIndex: number): void;
-    positionNote(graphicalNote: GraphicalNote, staffIndex: number): GraphicalNote;
+    trackNote(graphicalNote: GraphicalNote): void;
+    positionNote(graphicalNote: GraphicalNote): GraphicalNote;
     getStafflineUniquePositionCount(staffIndex: number): number;
 }

--- a/src/MusicalScore/Interfaces/IStafflineNoteCalculator.ts
+++ b/src/MusicalScore/Interfaces/IStafflineNoteCalculator.ts
@@ -1,6 +1,7 @@
 import { GraphicalNote } from "../Graphical/GraphicalNote";
-import { ClefInstruction } from "../VoiceData";
 
 export interface IStafflineNoteCalculator {
-    positionNote(graphicalNote: GraphicalNote, currentClef: ClefInstruction, stafflineCount: number): GraphicalNote;
+    trackNote(graphicalNote: GraphicalNote, staffIndex: number): void;
+    positionNote(graphicalNote: GraphicalNote, staffIndex: number): GraphicalNote;
+    getStafflineUniquePositionCount(staffIndex: number): number;
 }


### PR DESCRIPTION
Using different criteria to render a single percussion line - Existing note positions. Also utilizing smarter positioning where pitches are sorted and positioned above and below the line (weighted for bottom).

Test results:
[test_results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4770756/test_results.txt)

Visual Test Results:
[results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/4770757/results.txt)
