### PR TITLE
Add option for untracked local env config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ node_modules/
 bin/gh_pages_deploy_key
 bin/gh_pages_deploy_key.pub
 package-lock.json
+
+#local env files
+webpack.local.js

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:webpack-dev": "webpack --progress --colors --config webpack.dev.js",
     "build:webpack-sourcemap": "webpack --progress --colors --config webpack.sourcemap.js",
     "start": "webpack-dev-server --progress --colors --config webpack.dev.js",
+    "start:local": "webpack-dev-server --progress --colors --config webpack.local.js",
     "generatePNG": "node ./test/Util/generateImages_browserless.js ../../build ./test/data ./export 1000 1600 allSmall --debug",
     "generatePNG:single": "node ./test/Util/generateImages_browserless.js ../../build ./test/data ./export 0 0 ^Beethoven",
     "generatePNG:legacyslow": "node ./test/Util/generateDiffImagesPuppeteerLocalhost.js ./test/data ./export 0 0 all",


### PR DESCRIPTION
@sschmidTU,

I think this is a good option to have, let me know if you think there are any issues with having this included in the codebase.

Specifically, I needed to add the 'allowedHosts' option with a custom entry for my local environment. I can imagine other local-specific environment options could exist for other developers as well.