### PR TITLE
Certain xml docs cause hang when loading

### DIFF
--- a/src/Common/DataObjects/Fraction.ts
+++ b/src/Common/DataObjects/Fraction.ts
@@ -64,7 +64,7 @@ export class Fraction {
       return 1;
     }
 
-    while (b !== 0) {
+    while (Math.abs(b) > 0.0000001) {
       if (a > b) {
         a -= b;
       } else {


### PR DESCRIPTION
The `greatestCommonDenominator` function has no guard against non-convergence due to floating-point errors and this causes loading of some musicxml docs to spin forever in the for loop.

Basically, in some cases `b` becomes very small (< `2.0e-14`) and never converges to 0.