### PR TITLE
Fix doc comment for useXMLMeasureNumbers option

### DIFF
--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -92,7 +92,7 @@ export interface IOSMDOptions {
     drawTimeSignatures?: boolean;
     /** The interval of measure numbers to draw, i.e. it draws the measure number above the beginning label every x measures. Default 2. */
     measureNumberInterval?: number;
-    /** Whether to read the first measure number from the "number" attribute in the xml file as opposed to defaulting to start at measure 1. Default false. */
+    /** Whether to read measure numbers from the "number" attribute in the xml file as opposed to defaulting to start at measure 1. Default true. */
     useXMLMeasureNumbers?: boolean;
     /** Whether to draw fingerings (only left to the note for now). Default true (unless solo part). */
     drawFingerings?: boolean;


### PR DESCRIPTION
Related to https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/pull/879. Documents the behavior described by  https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/541#issuecomment-687360793 correctly in the code in case someone goes looking.