### PR TITLE
Feat: RenderRectangle etc returns removable node, add backend.removeNode()

### DIFF
--- a/src/MusicalScore/Graphical/GraphicalLine.ts
+++ b/src/MusicalScore/Graphical/GraphicalLine.ts
@@ -3,17 +3,21 @@ import {OutlineAndFillStyleEnum} from "./DrawingEnums";
 import {PointF2D} from "../../Common/DataObjects/PointF2D";
 
 export class GraphicalLine {
-    constructor(start: PointF2D, end: PointF2D, width: number = 0, styleEnum: OutlineAndFillStyleEnum = OutlineAndFillStyleEnum.BaseWritingColor) {
+    constructor(start: PointF2D, end: PointF2D, width: number = 0,
+        styleEnum: OutlineAndFillStyleEnum = OutlineAndFillStyleEnum.BaseWritingColor,
+        colorHex: string = undefined) {
         this.start = start;
         this.end = end;
         this.width = width;
         this.styleId = <number>styleEnum;
+        this.colorHex = colorHex;
     }
     public styleId: number;
 
     private start: PointF2D;
     private end: PointF2D;
     private width: number;
+    public colorHex: string; // will override styleId if not undefined
 
     public get Start(): PointF2D {
         return this.start;

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -531,15 +531,15 @@ export abstract class MusicSheetDrawer {
             }
         }
         if (typeMatch || dataObjectString === type) {
-            this.drawBoundingBox(startBox, true, dataObjectString, layer, undefined);
+            this.drawBoundingBox(startBox, undefined, true, dataObjectString, layer);
         }
         layer++;
         startBox.ChildElements.forEach(bb => this.drawBoundingBoxes(bb, layer, type));
     }
 
     public drawBoundingBox(bbox: BoundingBox,
-        drawCross: boolean = false, labelText: string = undefined, layer: number = 0,
-        color: string = undefined): void {
+        color: string = undefined, drawCross: boolean = false, labelText: string = undefined, layer: number = 0
+    ): void {
         let tmpRect: RectangleF2D = new RectangleF2D(bbox.AbsolutePosition.x + bbox.BorderMarginLeft,
             bbox.AbsolutePosition.y + bbox.BorderMarginTop,
             bbox.BorderMarginRight - bbox.BorderMarginLeft,

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -537,7 +537,9 @@ export abstract class MusicSheetDrawer {
         startBox.ChildElements.forEach(bb => this.drawBoundingBoxes(bb, layer, type));
     }
 
-    public drawBoundingBox(bbox: BoundingBox, drawCross: boolean = false, labelText: string = undefined, layer: number = 0, color: string = undefined) {
+    public drawBoundingBox(bbox: BoundingBox,
+        drawCross: boolean = false, labelText: string = undefined, layer: number = 0,
+        color: string = undefined): void {
         let tmpRect: RectangleF2D = new RectangleF2D(bbox.AbsolutePosition.x + bbox.BorderMarginLeft,
             bbox.AbsolutePosition.y + bbox.BorderMarginTop,
             bbox.BorderMarginRight - bbox.BorderMarginLeft,
@@ -550,7 +552,7 @@ export abstract class MusicSheetDrawer {
                 OutlineAndFillStyleEnum.BaseWritingColor,
                 color),
                 layer - 1);
-            
+
             this.drawLineAsVerticalRectangle(new GraphicalLine(
                 new PointF2D(bbox.AbsolutePosition.x, bbox.AbsolutePosition.y - 1),
                 new PointF2D(bbox.AbsolutePosition.x, bbox.AbsolutePosition.y + 1),

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -218,7 +218,7 @@ export abstract class MusicSheetDrawer {
         // empty
     }
 
-    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, colorHex: string = undefined, alpha: number = 1): void {
+    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, colorHex: string = undefined, alpha: number = 1): Node {
         throw new Error("not implemented");
     }
 
@@ -539,7 +539,7 @@ export abstract class MusicSheetDrawer {
 
     public drawBoundingBox(bbox: BoundingBox,
         color: string = undefined, drawCross: boolean = false, labelText: string = undefined, layer: number = 0
-    ): void {
+    ): Node {
         let tmpRect: RectangleF2D = new RectangleF2D(bbox.AbsolutePosition.x + bbox.BorderMarginLeft,
             bbox.AbsolutePosition.y + bbox.BorderMarginTop,
             bbox.BorderMarginRight - bbox.BorderMarginLeft,
@@ -563,12 +563,13 @@ export abstract class MusicSheetDrawer {
         }
 
         tmpRect = this.applyScreenTransformationForRect(tmpRect);
-        this.renderRectangle(tmpRect, <number>GraphicalLayers.Background, layer, color, 0.5);
+        const rectNode: Node = this.renderRectangle(tmpRect, <number>GraphicalLayers.Background, layer, color, 0.5);
         if (labelText) {
             const label: Label = new Label(labelText);
             this.renderLabel(new GraphicalLabel(label, 0.8, TextAlignmentEnum.CenterCenter, this.rules),
                 layer, tmpRect.width, tmpRect.height, tmpRect.height, new PointF2D(tmpRect.x, tmpRect.y + 12));
         }
+        return rectNode;
     }
 
     private drawMarkedAreas(system: MusicSystem): void {

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -143,13 +143,13 @@ export abstract class MusicSheetDrawer {
         throw new Error("not implemented");
     }
 
-    public drawLabel(graphicalLabel: GraphicalLabel, layer: number): void {
+    public drawLabel(graphicalLabel: GraphicalLabel, layer: number): Node[] {
         if (!this.isVisible(graphicalLabel.PositionAndShape)) {
-            return;
+            return [];
         }
         const label: Label = graphicalLabel.Label;
         if (label.text.trim() === "") {
-            return;
+            return [];
         }
         const screenPosition: PointF2D = this.applyScreenTransformation(graphicalLabel.PositionAndShape.AbsolutePosition);
         const fontHeightInPixel: number = this.calculatePixelDistance(label.fontHeight);
@@ -195,7 +195,7 @@ export abstract class MusicSheetDrawer {
                 throw new ArgumentOutOfRangeException("");
         }
 
-        this.renderLabel(graphicalLabel, layer, bitmapWidth, bitmapHeight, fontHeightInPixel, screenPosition);
+        return this.renderLabel(graphicalLabel, layer, bitmapWidth, bitmapHeight, fontHeightInPixel, screenPosition);
     }
 
     protected applyScreenTransformation(point: PointF2D): PointF2D {
@@ -235,7 +235,7 @@ export abstract class MusicSheetDrawer {
     }
 
     protected renderLabel(graphicalLabel: GraphicalLabel, layer: number, bitmapWidth: number,
-                          bitmapHeight: number, heightInPixel: number, screenPosition: PointF2D): void {
+                          bitmapHeight: number, heightInPixel: number, screenPosition: PointF2D): Node[] {
         throw new Error("not implemented");
     }
 
@@ -399,17 +399,18 @@ export abstract class MusicSheetDrawer {
         // implemented by subclass (VexFlowMusicSheetDrawer)
     }
 
-    protected drawGraphicalLine(graphicalLine: GraphicalLine, lineWidth: number, colorOrStyle: string = "black"): void {
+    protected drawGraphicalLine(graphicalLine: GraphicalLine, lineWidth: number, colorOrStyle: string = "black"): Node {
         /* TODO similar checks as in drawLabel
         if (!this.isVisible(new BoundingBox(graphicalLine.Start,)) {
             return;
         }
         */
-        this.drawLine(graphicalLine.Start, graphicalLine.End, colorOrStyle, lineWidth);
+        return this.drawLine(graphicalLine.Start, graphicalLine.End, colorOrStyle, lineWidth);
     }
 
-    protected drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number): void {
+    protected drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number): Node {
         // implemented by subclass (VexFlowMusicSheetDrawer)
+        return undefined;
     }
 
     /**
@@ -568,6 +569,7 @@ export abstract class MusicSheetDrawer {
             const label: Label = new Label(labelText);
             this.renderLabel(new GraphicalLabel(label, 0.8, TextAlignmentEnum.CenterCenter, this.rules),
                 layer, tmpRect.width, tmpRect.height, tmpRect.height, new PointF2D(tmpRect.x, tmpRect.y + 12));
+            // theoretically we should return the nodes from renderLabel here as well, so they can also be removed later
         }
         return rectNode;
     }

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -112,7 +112,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.CanvasRenderingCtx.restore();
         this.CanvasRenderingCtx.font = old;
     }
-    public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): void {
+    public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): Node {
         const old: string | CanvasGradient | CanvasPattern = this.CanvasRenderingCtx.fillStyle;
         if (colorHex) {
             this.CanvasRenderingCtx.fillStyle = colorHex;
@@ -123,6 +123,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         this.CanvasRenderingCtx.fillStyle = old;
         this.CanvasRenderingCtx.globalAlpha = 1;
+        return undefined; // can't return dom node like with SVG
     }
 
     public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number= 2): void {

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -112,9 +112,13 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.CanvasRenderingCtx.restore();
         this.CanvasRenderingCtx.font = old;
     }
-    public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
+    public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): void {
         const old: string | CanvasGradient | CanvasPattern = this.CanvasRenderingCtx.fillStyle;
-        this.CanvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);
+        if (colorHex) {
+            this.CanvasRenderingCtx.fillStyle = colorHex;
+        } else {
+            this.CanvasRenderingCtx.fillStyle = VexFlowConverter.style(styleId);
+        }
         this.CanvasRenderingCtx.globalAlpha = alpha;
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         this.CanvasRenderingCtx.fillStyle = old;

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -96,7 +96,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
     }
     public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
                       heightInPixel: number, screenPosition: PointF2D,
-                      color: string = undefined, fontFamily: string = undefined): void  {
+                      color: string = undefined, fontFamily: string = undefined): Node  {
         const old: string = this.CanvasRenderingCtx.font;
         this.CanvasRenderingCtx.save();
         this.CanvasRenderingCtx.font = VexFlowConverter.font(
@@ -111,6 +111,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.CanvasRenderingCtx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.CanvasRenderingCtx.restore();
         this.CanvasRenderingCtx.font = old;
+        return undefined; // can't return svg dom node
     }
     public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): Node {
         const old: string | CanvasGradient | CanvasPattern = this.CanvasRenderingCtx.fillStyle;
@@ -126,7 +127,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         return undefined; // can't return dom node like with SVG
     }
 
-    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number= 2): void {
+    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number= 2): Node {
         const oldStyle: string | CanvasGradient | CanvasPattern = this.CanvasRenderingCtx.strokeStyle;
         this.CanvasRenderingCtx.strokeStyle = color;
         this.CanvasRenderingCtx.beginPath();
@@ -134,6 +135,7 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         this.CanvasRenderingCtx.lineTo(stop.x, stop.y);
         this.CanvasRenderingCtx.stroke();
         this.CanvasRenderingCtx.strokeStyle = oldStyle;
+        return undefined; // can't return svg dom node
     }
 
     public renderCurve(points: PointF2D[]): void {

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -124,9 +124,13 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.ctx.restore();
     }
-    public renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number = 1): void {
+    public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): void {
         this.ctx.save();
-        this.ctx.attributes.fill = VexFlowConverter.style(styleId);
+        if (colorHex) {
+            this.ctx.attributes.fill = colorHex;
+        } else {
+            this.ctx.attributes.fill = VexFlowConverter.style(styleId);
+        }
         this.ctx.attributes["fill-opacity"] = alpha;
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         this.ctx.restore();

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -103,8 +103,9 @@ export class SvgVexFlowBackend extends VexFlowBackend {
     }
     public renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
                       heightInPixel: number, screenPosition: PointF2D,
-                      color: string = undefined, fontFamily: string = undefined): void {
+                      color: string = undefined, fontFamily: string = undefined): Node {
         this.ctx.save();
+        const node: Node = this.ctx.openGroup();
 
         if (color) {
             this.ctx.attributes.fill = color;
@@ -139,7 +140,9 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.attributes["font-style"] = fontStyleVexflow;
         this.ctx.state["font-style"] = fontStyleVexflow;
         this.ctx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
+        this.ctx.closeGroup();
         this.ctx.restore();
+        return node;
     }
     public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): Node {
         this.ctx.save();
@@ -157,8 +160,9 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         return node;
     }
 
-    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 2): void {
+    public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 2): Node {
         this.ctx.save();
+        const node: Node = this.ctx.openGroup();
         this.ctx.beginPath();
         this.ctx.moveTo(start.x, start.y);
         this.ctx.lineTo(stop.x, stop.y);
@@ -171,7 +175,9 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.lineWidth = lineWidth;
 
         this.ctx.stroke();
+        this.ctx.closeGroup();
         this.ctx.restore();
+        return node;
     }
 
     public renderCurve(points: PointF2D[]): void {

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -8,6 +8,7 @@ import {RectangleF2D} from "../../../Common/DataObjects/RectangleF2D";
 import {PointF2D} from "../../../Common/DataObjects/PointF2D";
 import {BackendType} from "../../../OpenSheetMusicDisplay/OSMDOptions";
 import {EngravingRules} from "../EngravingRules";
+import log from "loglevel";
 
 export class SvgVexFlowBackend extends VexFlowBackend {
 
@@ -51,6 +52,22 @@ export class SvgVexFlowBackend extends VexFlowBackend {
 
     public getSvgElement(): SVGElement {
         return this.ctx.svg;
+    }
+
+    removeNode(node: Node): boolean {
+        const svg: SVGElement = this.ctx?.svg;
+        if (!svg) {
+            return false;
+        }
+        // unfortunately there's no method svg.hasChild(node). traversing all nodes seems inefficient.
+        try {
+            svg.removeChild(node);
+        } catch (ex) {
+            // log.error("SvgVexFlowBackend.removeNode: error:"); // unnecessary, stacktrace is in exception
+            log.error(ex);
+            return false;
+        }
+        return true;
     }
 
     public clear(): void {
@@ -124,8 +141,9 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.fillText(text, screenPosition.x, screenPosition.y + heightInPixel);
         this.ctx.restore();
     }
-    public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): void {
+    public renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number = 1): Node {
         this.ctx.save();
+        const node: Node = this.ctx.openGroup();
         if (colorHex) {
             this.ctx.attributes.fill = colorHex;
         } else {
@@ -135,6 +153,8 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         this.ctx.fillRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         this.ctx.restore();
         this.ctx.attributes["fill-opacity"] = 1;
+        this.ctx.closeGroup();
+        return node;
     }
 
     public renderLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 2): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -90,7 +90,7 @@ public abstract getContext(): Vex.IRenderContext;
   public abstract translate(x: number, y: number): void;
   public abstract renderText(fontHeight: number, fontStyle: FontStyles, font: Fonts, text: string,
                              heightInPixel: number, screenPosition: PointF2D,
-                             color?: string, fontFamily?: string): void;
+                             color?: string, fontFamily?: string): Node;
   /**
    * Renders a rectangle with the given style to the screen.
    * It is given in screen coordinates.
@@ -101,7 +101,7 @@ public abstract getContext(): Vex.IRenderContext;
    */
   public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number): Node;
 
-  public abstract renderLine(start: PointF2D, stop: PointF2D, color: string, lineWidth: number): void;
+  public abstract renderLine(start: PointF2D, stop: PointF2D, color: string, lineWidth: number): Node;
 
   public abstract renderCurve(points: PointF2D[]): void;
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -99,7 +99,7 @@ public abstract getContext(): Vex.IRenderContext;
    * @param styleId the style id
    * @param alpha alpha value between 0 and 1
    */
-  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, alpha: number): void;
+  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number): void;
 
   public abstract renderLine(start: PointF2D, stop: PointF2D, color: string, lineWidth: number): void;
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -99,7 +99,7 @@ public abstract getContext(): Vex.IRenderContext;
    * @param styleId the style id
    * @param alpha alpha value between 0 and 1
    */
-  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number): void;
+  public abstract renderRectangle(rectangle: RectangleF2D, styleId: number, colorHex: string, alpha: number): Node;
 
   public abstract renderLine(start: PointF2D, stop: PointF2D, color: string, lineWidth: number): void;
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -445,8 +445,8 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param styleId the style id
      * @param alpha alpha value between 0 and 1
      */
-    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, colorHex: string, alpha: number): void {
-        this.backend.renderRectangle(rectangle, styleId, colorHex, alpha);
+    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, colorHex: string, alpha: number): Node {
+        return this.backend.renderRectangle(rectangle, styleId, colorHex, alpha);
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -88,7 +88,6 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         this.backend = this.backends[page.PageNumber - 1]; // TODO we may need to set this in a couple of other places. this.pageIdx is a bad solution
         super.drawPage(page);
         this.pageIdx += 1;
-        this.backend = this.backends[this.pageIdx];
     }
 
     public clear(): void {
@@ -446,8 +445,8 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param styleId the style id
      * @param alpha alpha value between 0 and 1
      */
-    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, alpha: number): void {
-        this.backend.renderRectangle(rectangle, styleId, alpha);
+    protected renderRectangle(rectangle: RectangleF2D, layer: number, styleId: number, colorHex: string, alpha: number): void {
+        this.backend.renderRectangle(rectangle, styleId, colorHex, alpha);
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -192,14 +192,14 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     /** Draws a line in the current backend. Only usable while pages are drawn sequentially, because backend reference is updated in that process.
      *  To add your own lines after rendering, use DrawOverlayLine.
      */
-    protected drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 0.2): void {
+    protected drawLine(start: PointF2D, stop: PointF2D, color: string = "#FF0000FF", lineWidth: number = 0.2): Node {
         // TODO maybe the backend should be given as an argument here as well, otherwise this can't be used after rendering of multiple pages is done.
         start = this.applyScreenTransformation(start);
         stop = this.applyScreenTransformation(stop);
         /*if (!this.backend) {
             this.backend = this.backends[0];
         }*/
-        this.backend.renderLine(start, stop, color, lineWidth * unitInPixels);
+        return this.backend.renderLine(start, stop, color, lineWidth * unitInPixels);
     }
 
     /** Lets a user/developer draw an overlay line on the score. Use this instead of drawLine, which is for OSMD internally only.
@@ -208,7 +208,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      *  To get a MusicPage, use GraphicalNote.ParentMusicPage.
      */
     public DrawOverlayLine(start: PointF2D, stop: PointF2D, musicPage: GraphicalMusicPage,
-                           color: string = "#FF0000FF", lineWidth: number = 0.2): void {
+                           color: string = "#FF0000FF", lineWidth: number = 0.2): Node {
         if (!musicPage.PageNumber || musicPage.PageNumber > this.backends.length || musicPage.PageNumber < 1) {
             console.log("VexFlowMusicSheetDrawer.drawOverlayLine: invalid page number / music page number doesn't correspond to an existing backend.");
             return;
@@ -218,7 +218,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
 
         start = this.applyScreenTransformation(start);
         stop = this.applyScreenTransformation(stop);
-        backendToUse.renderLine(start, stop, color, lineWidth * unitInPixels);
+        return backendToUse.renderLine(start, stop, color, lineWidth * unitInPixels);
     }
 
     protected drawSkyLine(staffline: StaffLine): void {
@@ -403,10 +403,11 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
      * @param screenPosition the position of the lower left corner of the text in screen coordinates
      */
     protected renderLabel(graphicalLabel: GraphicalLabel, layer: number, bitmapWidth: number,
-                          bitmapHeight: number, fontHeightInPixel: number, screenPosition: PointF2D): void {
+                          bitmapHeight: number, fontHeightInPixel: number, screenPosition: PointF2D): Node[] {
         if (!graphicalLabel.Label.print) {
-            return;
+            return [];
         }
+        const nodes: Node[] = [];
         const height: number = graphicalLabel.Label.fontHeight * unitInPixels;
         const { font } = graphicalLabel.Label;
         let color: string;
@@ -428,13 +429,16 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
             const currLine: {text: string, xOffset: number, width: number} = graphicalLabel.TextLines[i];
             const xOffsetInPixel: number = this.calculatePixelDistance(currLine.xOffset);
             const linePosition: PointF2D = new PointF2D(screenPosition.x + xOffsetInPixel, screenPosition.y);
-            this.backend.renderText(height, fontStyle, font, currLine.text, fontHeightInPixel, linePosition, color, graphicalLabel.Label.fontFamily);
+            nodes.push(
+                this.backend.renderText(height, fontStyle, font, currLine.text, fontHeightInPixel, linePosition, color, graphicalLabel.Label.fontFamily)
+            );
             screenPosition.y = screenPosition.y + fontHeightInPixel;
             if (graphicalLabel.TextLines.length > 1) {
              screenPosition.y += this.rules.SpacingBetweenTextLines;
             }
         }
         // font currently unused, replaced by fontFamily
+        return nodes;
     }
 
     /**


### PR DESCRIPTION
This makes it possible to remove drawn elements without re-rendering (SVG only).
```js
const node = osmd.drawer.DrawOverlayLine({x: 32,y: 20},{x: 34,y: 20},osmd.graphic.MusicPages[0]);
osmd.drawer.backend.removeNode(node);
```

methods returning node(s):
drawLine
drawRectangle
drawBoundingBox
drawLabel (returns node array, a node for each line / text)

see also #969 for drawBoundingBox() etc