### PR TITLE
Turkish accidentals

### DIFF
--- a/src/Common/DataObjects/Pitch.ts
+++ b/src/Common/DataObjects/Pitch.ts
@@ -25,6 +25,12 @@ export enum AccidentalEnum {
     TRIPLEFLAT,
     QUARTERTONESHARP,
     QUARTERTONEFLAT,
+    THREEQUARTERSSHARP,
+    THREEQUARTERSFLAT,
+    FIVECOMMASSHARP,
+    FIVECOMMASFLAT,
+    EIGHTCOMMASSHARP,
+    EIGHTCOMMASFLAT,
 }
 
 // This class represents a musical note. The middle A (440 Hz) lies in the octave with the value 1.
@@ -208,14 +214,26 @@ export class Pitch {
                 return 2;
             case AccidentalEnum.DOUBLEFLAT:
                 return -2;
-            case AccidentalEnum.QUARTERTONESHARP:
-                return 0.5;
-            case AccidentalEnum.QUARTERTONEFLAT:
-                return -0.5;
             case AccidentalEnum.TRIPLESHARP: // very rare, in some classical pieces
                 return 3;
             case AccidentalEnum.TRIPLEFLAT:
                 return -3;
+            case AccidentalEnum.QUARTERTONESHARP:
+                return 0.5;
+            case AccidentalEnum.QUARTERTONEFLAT:
+                return -0.5;
+            case AccidentalEnum.THREEQUARTERSSHARP:
+                return 1.5;
+            case AccidentalEnum.THREEQUARTERSFLAT:
+                return -1.5;
+            case AccidentalEnum.FIVECOMMASSHARP:
+                return 2.5;
+            case AccidentalEnum.FIVECOMMASFLAT:
+                return -2.5;
+            case AccidentalEnum.EIGHTCOMMASSHARP:
+                return 4;
+            case AccidentalEnum.EIGHTCOMMASFLAT:
+                return -4;
             default:
                 throw new Error("Unhandled AccidentalEnum value");
                 // return 0;
@@ -235,14 +253,26 @@ export class Pitch {
                 return AccidentalEnum.DOUBLESHARP;
             case -2:
                 return AccidentalEnum.DOUBLEFLAT;
-            case 0.5:
-                return AccidentalEnum.QUARTERTONESHARP;
-            case -0.5:
-                return AccidentalEnum.QUARTERTONEFLAT;
             case 3:
                 return AccidentalEnum.TRIPLESHARP;
             case -3:
                 return AccidentalEnum.TRIPLEFLAT;
+            case 0.5:
+                return AccidentalEnum.QUARTERTONESHARP;
+            case -0.5:
+                return AccidentalEnum.QUARTERTONEFLAT;
+            case 1.5:
+                return AccidentalEnum.THREEQUARTERSSHARP;
+            case -1.5:
+                return AccidentalEnum.THREEQUARTERSFLAT;
+            case 2.5:
+                return AccidentalEnum.FIVECOMMASSHARP;
+            case -2.5:
+                return AccidentalEnum.FIVECOMMASFLAT;
+            case 4:
+                return AccidentalEnum.EIGHTCOMMASSHARP;
+            case -4:
+                return AccidentalEnum.EIGHTCOMMASFLAT;
             default:
                 if (halfTones > 0 && halfTones < 1) {
                     return AccidentalEnum.QUARTERTONESHARP;
@@ -276,7 +306,7 @@ export class Pitch {
                 acc = "##";
                 break;
             case AccidentalEnum.TRIPLESHARP:
-                acc = "++";
+                acc = "###";
                 break;
             case AccidentalEnum.DOUBLEFLAT:
                 acc = "bb";
@@ -290,6 +320,24 @@ export class Pitch {
             case AccidentalEnum.QUARTERTONEFLAT:
                 acc = "d";
                 break;
+            case AccidentalEnum.THREEQUARTERSSHARP:
+                acc = "++";
+                break;
+            case AccidentalEnum.THREEQUARTERSFLAT:
+                acc = "db";
+                break;
+            case AccidentalEnum.FIVECOMMASSHARP:
+                acc = "+-";
+                break
+            case AccidentalEnum.FIVECOMMASFLAT:
+                acc = "bs";
+                break
+            case AccidentalEnum.EIGHTCOMMASSHARP:
+                acc = "++-";
+                break
+            case AccidentalEnum.EIGHTCOMMASFLAT:
+                acc = "bss";
+                break
             default:
         }
         return acc;

--- a/src/Common/DataObjects/Pitch.ts
+++ b/src/Common/DataObjects/Pitch.ts
@@ -328,16 +328,16 @@ export class Pitch {
                 break;
             case AccidentalEnum.FIVECOMMASSHARP:
                 acc = "+-";
-                break
+                break;
             case AccidentalEnum.FIVECOMMASFLAT:
                 acc = "bs";
-                break
+                break;
             case AccidentalEnum.EIGHTCOMMASSHARP:
                 acc = "++-";
-                break
+                break;
             case AccidentalEnum.EIGHTCOMMASFLAT:
                 acc = "bss";
-                break
+                break;
             default:
         }
         return acc;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -423,7 +423,7 @@ export class VexFlowConverter {
         for (let i: number = 0, len: number = notes.length; i < len; i += 1) {
             (notes[i] as VexFlowGraphicalNote).setIndex(vfnote, i);
             if (accidentals[i]) {
-                if (accidentals[i] === "++") { // triple sharp
+                if (accidentals[i] === "###") { // triple sharp
                     vfnote.addAccidental(i, new Vex.Flow.Accidental("##"));
                     vfnote.addAccidental(i, new Vex.Flow.Accidental("#"));
                     continue;

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
@@ -20,7 +20,7 @@ export class ArticulationReader {
       case "sharp":
         return AccidentalEnum.SHARP;
       case "flat":
-          return AccidentalEnum.FLAT;
+        return AccidentalEnum.FLAT;
       case "natural":
         return AccidentalEnum.NATURAL;
       case "double-sharp":
@@ -29,14 +29,26 @@ export class ArticulationReader {
       case "double-flat":
       case "flat-flat":
         return AccidentalEnum.DOUBLEFLAT;
+      case "triple-sharp":
+        return AccidentalEnum.TRIPLESHARP;
+      case "triple-flat":
+        return AccidentalEnum.TRIPLEFLAT;
       case "quarter-sharp":
         return AccidentalEnum.QUARTERTONESHARP;
       case "quarter-flat":
         return AccidentalEnum.QUARTERTONEFLAT;
-      case "triple-sharp":
-          return AccidentalEnum.TRIPLESHARP;
-      case "triple-flat":
-        return AccidentalEnum.TRIPLEFLAT;
+      case "three-quarters-sharp":
+        return AccidentalEnum.THREEQUARTERSSHARP;
+      case "three-quarters-flat":
+        return AccidentalEnum.THREEQUARTERSFLAT;
+      case "five-commas-sharp":
+        return AccidentalEnum.FIVECOMMASSHARP
+      case "five-commas-flat":
+        return AccidentalEnum.FIVECOMMASFLAT;
+      case "eight-commas-sharp":
+        return AccidentalEnum.EIGHTCOMMASSHARP;
+      case "eight-commas-flat":
+        return AccidentalEnum.EIGHTCOMMASFLAT;
       default:
         return AccidentalEnum.NONE;
     }

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
@@ -42,7 +42,7 @@ export class ArticulationReader {
       case "three-quarters-flat":
         return AccidentalEnum.THREEQUARTERSFLAT;
       case "five-commas-sharp":
-        return AccidentalEnum.FIVECOMMASSHARP
+        return AccidentalEnum.FIVECOMMASSHARP;
       case "five-commas-flat":
         return AccidentalEnum.FIVECOMMASFLAT;
       case "eight-commas-sharp":


### PR DESCRIPTION
Hi all! I added support for all turkish accidentals as well as 3-quarter-flat/sharps just in case someone else wants them. 
This PR is related to https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/215

I based my example file on the microtonal file found here: https://github.com/cuthbertLab/musicxmlTestSuite/blob/master/xmlFiles/01d-Pitches-Microtones.xml
And added four more missing accidentals (5 commas flat/sharp, 8 commas flat/sharp)

[01d-Pitches-Microtones-Modified.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/6200625/01d-Pitches-Microtones.zip)
It renders correctly like this now
![image](https://user-images.githubusercontent.com/7935362/112387488-8110b300-8cfa-11eb-8d10-2f7c1b7d044e.png)

The only thing I changed in the existing code is your workaround for the triple sharp because you were using the "++" symbol which corresponds to three quartertones sharp as per here: https://github.com/0xfe/vexflow/wiki/Microtonal-Support
So I converted it to "###" so that it doesn't collide with the quartertone symbol.
