### PR TITLE
Added support for three-quarter flats and sharps

### DIFF
--- a/src/Common/DataObjects/Pitch.ts
+++ b/src/Common/DataObjects/Pitch.ts
@@ -25,6 +25,8 @@ export enum AccidentalEnum {
     TRIPLEFLAT,
     QUARTERTONESHARP,
     QUARTERTONEFLAT,
+    THREEQUARTERSSHARP,
+    THREEQUARTERSFLAT,
 }
 
 // This class represents a musical note. The middle A (440 Hz) lies in the octave with the value 1.
@@ -208,14 +210,18 @@ export class Pitch {
                 return 2;
             case AccidentalEnum.DOUBLEFLAT:
                 return -2;
-            case AccidentalEnum.QUARTERTONESHARP:
-                return 0.5;
-            case AccidentalEnum.QUARTERTONEFLAT:
-                return -0.5;
             case AccidentalEnum.TRIPLESHARP: // very rare, in some classical pieces
                 return 3;
             case AccidentalEnum.TRIPLEFLAT:
                 return -3;
+            case AccidentalEnum.QUARTERTONESHARP:
+                return 0.5;
+            case AccidentalEnum.QUARTERTONEFLAT:
+                return -0.5;
+            case AccidentalEnum.THREEQUARTERSSHARP:
+                return 1.5;
+            case AccidentalEnum.THREEQUARTERSFLAT:
+                return -1.5;
             default:
                 throw new Error("Unhandled AccidentalEnum value");
                 // return 0;
@@ -235,14 +241,18 @@ export class Pitch {
                 return AccidentalEnum.DOUBLESHARP;
             case -2:
                 return AccidentalEnum.DOUBLEFLAT;
-            case 0.5:
-                return AccidentalEnum.QUARTERTONESHARP;
-            case -0.5:
-                return AccidentalEnum.QUARTERTONEFLAT;
             case 3:
                 return AccidentalEnum.TRIPLESHARP;
             case -3:
                 return AccidentalEnum.TRIPLEFLAT;
+            case 0.5:
+                return AccidentalEnum.QUARTERTONESHARP;
+            case -0.5:
+                return AccidentalEnum.QUARTERTONEFLAT;
+            case 1.5:
+                return AccidentalEnum.THREEQUARTERSSHARP;
+            case -1.5:
+                return AccidentalEnum.THREEQUARTERSFLAT;
             default:
                 if (halfTones > 0 && halfTones < 1) {
                     return AccidentalEnum.QUARTERTONESHARP;
@@ -276,7 +286,7 @@ export class Pitch {
                 acc = "##";
                 break;
             case AccidentalEnum.TRIPLESHARP:
-                acc = "++";
+                acc = "###";
                 break;
             case AccidentalEnum.DOUBLEFLAT:
                 acc = "bb";
@@ -289,6 +299,12 @@ export class Pitch {
                 break;
             case AccidentalEnum.QUARTERTONEFLAT:
                 acc = "d";
+                break;
+            case AccidentalEnum.THREEQUARTERSSHARP:
+                acc = "++";
+                break;
+            case AccidentalEnum.THREEQUARTERSFLAT:
+                acc = "db";
                 break;
             default:
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -423,7 +423,7 @@ export class VexFlowConverter {
         for (let i: number = 0, len: number = notes.length; i < len; i += 1) {
             (notes[i] as VexFlowGraphicalNote).setIndex(vfnote, i);
             if (accidentals[i]) {
-                if (accidentals[i] === "++") { // triple sharp
+                if (accidentals[i] === "###") { // triple sharp
                     vfnote.addAccidental(i, new Vex.Flow.Accidental("##"));
                     vfnote.addAccidental(i, new Vex.Flow.Accidental("#"));
                     continue;

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
@@ -20,7 +20,7 @@ export class ArticulationReader {
       case "sharp":
         return AccidentalEnum.SHARP;
       case "flat":
-          return AccidentalEnum.FLAT;
+        return AccidentalEnum.FLAT;
       case "natural":
         return AccidentalEnum.NATURAL;
       case "double-sharp":
@@ -29,14 +29,18 @@ export class ArticulationReader {
       case "double-flat":
       case "flat-flat":
         return AccidentalEnum.DOUBLEFLAT;
+      case "triple-sharp":
+        return AccidentalEnum.TRIPLESHARP;
+      case "triple-flat":
+        return AccidentalEnum.TRIPLEFLAT;
       case "quarter-sharp":
         return AccidentalEnum.QUARTERTONESHARP;
       case "quarter-flat":
         return AccidentalEnum.QUARTERTONEFLAT;
-      case "triple-sharp":
-          return AccidentalEnum.TRIPLESHARP;
-      case "triple-flat":
-        return AccidentalEnum.TRIPLEFLAT;
+      case "three-quarters-sharp":
+        return AccidentalEnum.THREEQUARTERSSHARP;
+      case "three-quarters-flat":
+        return AccidentalEnum.THREEQUARTERSFLAT;
       default:
         return AccidentalEnum.NONE;
     }


### PR DESCRIPTION
I made a new PR with just the three-quarter flats and shaps and without the turkish accidentals until I investigate further how they are meant to be represented in musicXML.
I also renamed the triple-sharp from `++` to `###` so that it doesn't collide with the naming of the three-quarter sharp.

![image](https://user-images.githubusercontent.com/7935362/112542425-34da7700-8dbd-11eb-9a54-297299bf1435.png)
