### PR TITLE
Adapt the cursor to single line and multiple lines

### DIFF
--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -171,8 +171,12 @@ export class Cursor {
       this.updateStyle(newWidth);
     }
     if (this.openSheetMusicDisplay.FollowCursor) {
-      const diff: number = this.cursorElement.getBoundingClientRect().top;
-      this.cursorElement.scrollIntoView({behavior: diff < 1000 ? "smooth" : "auto", block: "center"});
+      if (!this.openSheetMusicDisplay.EngravingRules.RenderSingleHorizontalStaffline) {
+        const diff: number = this.cursorElement.getBoundingClientRect().top;
+        this.cursorElement.scrollIntoView({behavior: diff < 1000 ? "smooth" : "auto", block: "center"});
+      } else {
+        this.cursorElement.scrollIntoView({behavior: "smooth", inline: "center"});
+      }
     }
     // Show cursor
     // // Old cursor: this.graphic.Cursors.push(cursor);


### PR DESCRIPTION
In single-line rendering, the cursor is always set to block:center, which will cause the vertical axis to be centered, but users may have their own needs, so block should not be set during single-line rendering, but inline needs to be set to follow cursor