### PR TITLE
handle undefined parentStaffEntry

### DIFF
--- a/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
+++ b/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
@@ -569,7 +569,7 @@ export class GraphicalMusicSheet {
     public GetNearestVoiceEntry(clickPosition: PointF2D): GraphicalVoiceEntry {
         return this.GetNearestGraphicalObject<GraphicalVoiceEntry>(clickPosition, GraphicalVoiceEntry.name, 5, 20, 5,
                                                                    (object: GraphicalVoiceEntry) =>
-                                                                        object.parentStaffEntry.relInMeasureTimestamp !== undefined);
+                                                                        object.parentStaffEntry?.relInMeasureTimestamp !== undefined);
     }
 
     public GetNearestNote(clickPosition: PointF2D, maxClickDist: PointF2D): GraphicalNote {


### PR DESCRIPTION
handle undefined parentStaffEntry in GraphicalMusicSheet.GetNearestVoiceEntry

issue [1029](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/1029), fix suggested by @conde2. Please merge if appropriate.