### PR TITLE
Null check for stavenote on color method

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry.ts
@@ -107,7 +107,7 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                     }
                 }
                 if (colorBeam) {
-                    if (vfStaveNote.beam?.setStyle) {
+                    if (vfStaveNote?.beam?.setStyle) {
                         vfStaveNote.beam.setStyle({ fillStyle: noteheadColor, strokeStyle: noteheadColor});
                     }
                 }


### PR DESCRIPTION
This null check is needed for some scores - the stavenote is null and the score simply doesn't render due to the exception being thrown.

Visual results:
[visual-results.txt](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/6792482/visual-results.txt)

test results:
[test.log](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/6792487/test.log)
