### PR TITLE
Fix Fingering collisions (#1081), make Above/Below default position

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
           }
         }
     ],
-    "ignorePatterns": ["webpack*.js"],
+    "ignorePatterns": ["webpack*.js","karma.conf.js"],
     "rules": {
         "@typescript-eslint/dot-notation": "error",
         "@typescript-eslint/explicit-function-return-type": "error",

--- a/demo/index.js
+++ b/demo/index.js
@@ -445,7 +445,8 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             // drawTitle: false,
             // drawSubtitle: false,
             drawFingerings: true,
-            fingeringPosition: "left", // left is default. try right. experimental: auto, above, below.
+            //fingeringPosition: "left", // Above/Below is default. try left or right. experimental: above, below.
+            //fingeringPositionFromXML: false, // do this if you want them always left, for example.
             // fingeringInsideStafflines: "true", // default: false. true draws fingerings directly above/below notes
             setWantedStemDirectionByXml: true, // try false, which was previously the default behavior
             // drawUpToMeasureNumber: 3, // draws only up to measure 3, meaning it draws measure 1 to 3 of the piece.
@@ -476,6 +477,9 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             // tripletsBracketed: true,
             // tupletsRatioed: true, // unconventional; renders ratios for tuplets (3:2 instead of 3 for triplets)
         });
+        //openSheetMusicDisplay.DrawSkyLine = true;
+        //openSheetMusicDisplay.DrawBottomLine = true;
+        //openSheetMusicDisplay.setDrawBoundingBox("GraphicalLabel", false);
         openSheetMusicDisplay.setLogLevel('info'); // set this to 'debug' if you want to see more detailed control flow information in console
         document.body.appendChild(canvas);
 

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -294,6 +294,9 @@ export class EngravingRules {
     public FingeringInsideStafflines: boolean;
     public FingeringLabelFontHeight: number;
     public FingeringOffsetX: number;
+    public FingeringOffsetY: number;
+    public FingeringPaddingY: number;
+    public FingeringTextSize: number;
     /** Whether to render string numbers in classical scores, i.e. not the string numbers in tabs, but e.g. for violin. */
     public RenderStringNumbersClassical: boolean;
     /** This is not for tabs, but for classical scores, especially violin. */
@@ -608,11 +611,14 @@ export class EngravingRules {
         this.RenderKeySignatures = true;
         this.RenderTimeSignatures = true;
         this.ArticulationPlacementFromXML = true;
-        this.FingeringPosition = PlacementEnum.Left; // easier to get bounding box, and safer for vertical layout
+        this.FingeringPosition = PlacementEnum.AboveOrBelow; // AboveOrBelow = correct bounding boxes
         this.FingeringPositionFromXML = true;
         this.FingeringInsideStafflines = false;
         this.FingeringLabelFontHeight = 1.7;
         this.FingeringOffsetX = 0.0;
+        this.FingeringOffsetY = 0.0;
+        this.FingeringPaddingY = -0.2;
+        this.FingeringTextSize = 1.5;
         this.RenderStringNumbersClassical = true;
         this.StringNumberOffsetY = 0.0;
         this.NewSystemAtXMLNewSystemAttribute = false;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -291,6 +291,7 @@ export class EngravingRules {
     /** Position of fingering label in relation to corresponding note (left, right supported, above, below experimental) */
     public FingeringPosition: PlacementEnum;
     public FingeringPositionFromXML: boolean;
+    public FingeringPositionGrace: PlacementEnum;
     public FingeringInsideStafflines: boolean;
     public FingeringLabelFontHeight: number;
     public FingeringOffsetX: number;
@@ -613,6 +614,7 @@ export class EngravingRules {
         this.ArticulationPlacementFromXML = true;
         this.FingeringPosition = PlacementEnum.AboveOrBelow; // AboveOrBelow = correct bounding boxes
         this.FingeringPositionFromXML = true;
+        this.FingeringPositionGrace = PlacementEnum.Left;
         this.FingeringInsideStafflines = false;
         this.FingeringLabelFontHeight = 1.7;
         this.FingeringOffsetX = 0.0;

--- a/src/MusicalScore/Graphical/GraphicalMeasure.ts
+++ b/src/MusicalScore/Graphical/GraphicalMeasure.ts
@@ -313,6 +313,29 @@ export abstract class GraphicalMeasure extends GraphicalObject {
         }
     }
 
+    public isPianoRightHand(): boolean {
+        return this.isUpperStaffOfInstrument();
+    }
+
+    public isPianoLeftHand(): boolean {
+        return this.isLowerStaffOfInstrument();
+    }
+
+    public isUpperStaffOfInstrument(): boolean {
+        if (this.parentStaff.ParentInstrument.Staves.length === 1) {
+            return true;
+        }
+        return this.ParentStaff === this.parentStaff.ParentInstrument.Staves[0];
+    }
+
+    public isLowerStaffOfInstrument(): boolean {
+        if (this.parentStaff.ParentInstrument.Staves.length === 1) {
+            return false; // technically this could be true as well, but we want this to be treated as upper and not return the same value.
+            // e.g. for a violin, fingerings should go above.
+        }
+        return this.ParentStaff === this.ParentStaff.ParentInstrument.Staves.last();
+    }
+
     public beginsWithLineRepetition(): boolean {
         const sourceMeasure: SourceMeasure = this.parentSourceMeasure;
         if (!sourceMeasure) {

--- a/src/MusicalScore/Graphical/GraphicalStaffEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalStaffEntry.ts
@@ -18,6 +18,7 @@ import {CollectionUtil} from "../../Util/CollectionUtil";
 import { GraphicalVoiceEntry } from "./GraphicalVoiceEntry";
 import { MusicSheetCalculator } from "./MusicSheetCalculator";
 import { Tie } from "../VoiceData/Tie";
+import { GraphicalLabel } from "./GraphicalLabel";
 
 /**
  * The graphical counterpart of a [[SourceStaffEntry]].
@@ -38,6 +39,7 @@ export abstract class GraphicalStaffEntry extends GraphicalObject {
         if (sourceStaffEntry) {
             this.relInMeasureTimestamp = sourceStaffEntry.Timestamp;
         }
+        this.FingeringEntries = [];
     }
 
     public graphicalChordContainers: GraphicalChordSymbolContainer[] = [];
@@ -57,6 +59,7 @@ export abstract class GraphicalStaffEntry extends GraphicalObject {
     public ties: Tie[] = [];
     private graphicalTies: GraphicalTie[] = [];
     private lyricsEntries: GraphicalLyricEntry[] = [];
+    public FingeringEntries: GraphicalLabel[];
 
     public get GraphicalInstructions(): AbstractGraphicalInstruction[] {
         return this.graphicalInstructions;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -2552,7 +2552,7 @@ export abstract class MusicSheetCalculator {
                         for (const voiceEntry of gse.graphicalVoiceEntries) {
                             for (const note of voiceEntry.notes) {
                                 const sourceNote: Note = note.sourceNote;
-                                if (sourceNote.Fingering) {
+                                if (sourceNote.Fingering && !sourceNote.IsGraceNote) {
                                     fingerings.push(sourceNote.Fingering);
                                 }
                             }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1379,10 +1379,12 @@ export class VexFlowMeasure extends GraphicalMeasure {
             }
             fingeringIndex++; // 0 for first fingering
             let fingeringPosition: PlacementEnum = this.rules.FingeringPosition;
-            if (this.rules.FingeringPosition === PlacementEnum.AboveOrBelow) {
-                if (this.isPianoRightHand()) {
+            //currently only relevant for grace notes, because we create other fingerings above/below in MusicSheetCalculator.createFingerings
+            if (this.rules.FingeringPositionGrace === PlacementEnum.AboveOrBelow) {
+                //if (this.rules.FingeringPosition === PlacementEnum.AboveOrBelow) {
+                if (this.isUpperStaffOfInstrument()) { // (e.g. piano right hand)
                     fingeringPosition = PlacementEnum.Above;
-                } else if (this.isPianoLeftHand()) {
+                } else if (this.isLowerStaffOfInstrument()) {
                     fingeringPosition = PlacementEnum.Below;
                 }
             }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1249,7 +1249,10 @@ export class VexFlowMeasure extends GraphicalMeasure {
 
                 // add fingering
                 if (voiceEntry.parentVoiceEntry && this.rules.RenderFingerings) {
-                    this.createFingerings(voiceEntry);
+                    if (this.rules.FingeringPosition === PlacementEnum.Left ||
+                        this.rules.FingeringPosition === PlacementEnum.Right) {
+                            this.createFingerings(voiceEntry);
+                    } // else created in MusicSheetCalculater.createFingerings() as Labels
                     this.createStringNumber(voiceEntry);
                 }
 
@@ -1376,6 +1379,13 @@ export class VexFlowMeasure extends GraphicalMeasure {
             }
             fingeringIndex++; // 0 for first fingering
             let fingeringPosition: PlacementEnum = this.rules.FingeringPosition;
+            if (this.rules.FingeringPosition === PlacementEnum.AboveOrBelow) {
+                if (this.isPianoRightHand()) {
+                    fingeringPosition = PlacementEnum.Above;
+                } else if (this.isPianoLeftHand()) {
+                    fingeringPosition = PlacementEnum.Below;
+                }
+            }
             if (fingering.placement !== PlacementEnum.NotYetDefined) {
                 fingeringPosition = fingering.placement;
             }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -307,6 +307,11 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
 
 
     private drawStaffEntry(staffEntry: GraphicalStaffEntry): void {
+        if (staffEntry.FingeringEntries.length > 0) {
+            for (const fingeringEntry of staffEntry.FingeringEntries) {
+                this.drawLabel(fingeringEntry, GraphicalLayers.Notes);
+            }
+        }
         // Draw ChordSymbols
         if (staffEntry.graphicalChordContainers !== undefined && staffEntry.graphicalChordContainers.length > 0) {
             for (const graphicalChordContainer of staffEntry.graphicalChordContainers) {

--- a/src/MusicalScore/VoiceData/Expressions/AbstractExpression.ts
+++ b/src/MusicalScore/VoiceData/Expressions/AbstractExpression.ts
@@ -27,6 +27,8 @@ export class AbstractExpression {
                 return PlacementEnum.Above;
             case "below":
                 return PlacementEnum.Below;
+            case "aboveorbelow":
+                return PlacementEnum.AboveOrBelow;
             case "left":
                 return PlacementEnum.Left;
             case "right":
@@ -43,5 +45,6 @@ export enum PlacementEnum {
     Below = 1,
     Left = 2,
     Right = 3,
-    NotYetDefined = 4
+    NotYetDefined = 4,
+    AboveOrBelow = 5, // for piano scores, above for right hand, below for left hand
 }

--- a/test/data/test_Fingerings_Simple_Chords_Treble_Bass.musicxml
+++ b/test/data/test_Fingerings_Simple_Chords_Treble_Bass.musicxml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Fingerings_Simple_Chords_Treble_Bass</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.6.2</software>
+      <encoding-date>2021-11-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1697.14</page-height>
+      <page-width>1200</page-width>
+      <page-margins type="even">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">Fingerings_Simple_Chords_Treble_Bass</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="334.90">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>65.90</left-margin>
+            <right-margin>627.77</right-margin>
+            </system-margins>
+          <top-system-distance>172.37</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="86.99" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <staff>1</staff>
+        <notations>
+          <technical>
+            <fingering>1</fingering>
+            </technical>
+          </notations>
+        </note>
+      <note default-x="86.99" default-y="5.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <staff>1</staff>
+        <notations>
+          <technical>
+            <fingering>3</fingering>
+            </technical>
+          </notations>
+        </note>
+      <note default-x="86.99" default-y="20.00">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <staff>1</staff>
+        <notations>
+          <technical>
+            <fingering>5</fingering>
+            </technical>
+          </notations>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="86.99" default-y="-165.00">
+        <pitch>
+          <step>C</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <fingering placement="below">4</fingering>
+            </technical>
+          </notations>
+        </note>
+      <note default-x="86.99" default-y="-155.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <fingering placement="below">2</fingering>
+            </technical>
+          </notations>
+        </note>
+      <note default-x="86.99" default-y="-145.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>whole</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <fingering placement="below">1</fingering>
+            </technical>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
before: (left / FingeringPositionFromXML)
![image](https://user-images.githubusercontent.com/33069673/141197184-43d076ca-6508-4c4e-912d-a83fffc2c810.png)

after: (AboveOrBelow, FingeringPositionFromXML)
![image](https://user-images.githubusercontent.com/33069673/141197308-f42faa40-d010-4e38-b9fd-9382c0fd493d.png)
[test_Fingerings_Simple_Chords_Treble_Bass.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/7516089/test_Fingerings_Simple_Chords_Treble_Bass.zip)

visual diffs:
[diffs_fingering_above_below_collision_fix2.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/7516223/diffs_fingering_above_below_collision_fix2.zip)

a valid alternative to the new above/below default, also to save space, is left (or right) positioning:
```js
osmd.EngravingRules.FingeringPosition = 2; // PlacementEnum.Left
osmd.EngravingRules.FingeringPositionFromXML = false; // otherwise an XML placement 'below' will put fingering for those notes below
```

![image](https://user-images.githubusercontent.com/33069673/141197918-8d5483ca-3014-4f02-9f39-0d0e53dcd5a7.png)