### PR TITLE
Fix notes overlapping / not staggering

### DIFF
--- a/src/VexFlowPatch/src/stavenote.js
+++ b/src/VexFlowPatch/src/stavenote.js
@@ -69,9 +69,11 @@ export class StaveNote extends StemmableNote {
     //   * 2 voices can be formatted *with or without* a stave being set but
     //     the output will be different
     //   * 3 voices can only be formatted *without* a stave
-    if (notes[0].getStave()) {
-      //return StaveNote.formatByY(notes, state);
-    }
+
+    // if this is enabled, notes are sometimes not staggered correctly, see setXShift lines below 
+    // if (notes[0].getStave()) {
+    //   return StaveNote.formatByY(notes, state); // 
+    // }
 
     const notesList = [];
 
@@ -156,8 +158,7 @@ export class StaveNote extends StemmableNote {
           //if (noteU.note.glyph.stem && noteL.note.glyph.stem) { // skip this condition: whole notes also relevant
           //If we have different dot values, must offset
           //Or If we have a non-filled in mixed with a filled in notehead, must offset
-          const noteUNonfilled = noteU.note.duration === "h" || noteU.note.duration === "w";
-          const noteLNonfilled = noteL.note.duration === "h" || noteL.note.duration === "w";
+          // const noteUNonfilled = noteU.note.duration === "h" || noteU.note.duration === "w";
           if (noteU.note.duration !== noteL.note.duration ||
                 noteU.note.dots !== noteL.note.dots) {
               noteL.note.setXShift(xShift);

--- a/src/VexFlowPatch/src/stavenote.js
+++ b/src/VexFlowPatch/src/stavenote.js
@@ -70,7 +70,7 @@ export class StaveNote extends StemmableNote {
     //     the output will be different
     //   * 3 voices can only be formatted *without* a stave
     if (notes[0].getStave()) {
-      return StaveNote.formatByY(notes, state);
+      //return StaveNote.formatByY(notes, state);
     }
 
     const notesList = [];
@@ -153,57 +153,59 @@ export class StaveNote extends StemmableNote {
           //If we are sharing a line, switch one notes stem direction.
           //If we are sharing a line and in the same voice, only then offset one note
           const lineDiff = Math.abs(noteU.line - noteL.line);
-          if (noteU.note.glyph.stem && noteL.note.glyph.stem) {
-            //If we have different dot values, must offset
-            //Or If we have a non-filled in mixed with a filled in notehead, must offset
-            if ((noteU.note.duration === "h" && noteL.note.duration !== "h") || 
-                (noteU.note.duration !== "h" && noteL.note.duration === "h") ||
-                 noteU.note.dots !== noteL.note.dots) {
-                noteL.note.setXShift(xShift);
-                if (noteU.note.dots > 0) {
-                  let foundDots = 0;
-                  for (const modifier of noteU.note.modifiers) {
-                    if (modifier instanceof Dot) {
-                      foundDots++;
-                      //offset dot(s) above the shifted note
-                      //lines + 1 to negative pixels
-                      modifier.setYShift(-10 * (noteL.maxLine - noteU.line + 1));
-                      if (foundDots === noteU.note.dots) {
-                        break;
-                      }
+          //if (noteU.note.glyph.stem && noteL.note.glyph.stem) { // skip this condition: whole notes also relevant
+          //If we have different dot values, must offset
+          //Or If we have a non-filled in mixed with a filled in notehead, must offset
+          const noteUNonfilled = noteU.note.duration === "h" || noteU.note.duration === "w";
+          const noteLNonfilled = noteL.note.duration === "h" || noteL.note.duration === "w";
+          if (noteU.note.duration !== noteL.note.duration ||
+                noteU.note.dots !== noteL.note.dots) {
+              noteL.note.setXShift(xShift);
+              if (noteU.note.dots > 0) {
+                let foundDots = 0;
+                for (const modifier of noteU.note.modifiers) {
+                  if (modifier instanceof Dot) {
+                    foundDots++;
+                    //offset dot(s) above the shifted note
+                    //lines + 1 to negative pixels
+                    modifier.setYShift(-10 * (noteL.maxLine - noteU.line + 1));
+                    if (foundDots === noteU.note.dots) {
+                      break;
                     }
                   }
                 }
-            } else if (lineDiff < 1 && lineDiff > 0) {//if the notes are quite close but not on the same line, shift
-              noteL.note.setXShift(xShift);
-            } else if (noteU.note.voice !== noteL.note.voice) {//If we are not in the same voice
-              if (noteU.stemDirection === noteL.stemDirection) {
-                if (noteU.line > noteL.line) {
-                  //noteU is above noteL
-                  if (noteU.stemDirection === 1) {
-                    noteL.note.renderFlag = false;
-                  } else {
-                    noteU.note.renderFlag = false;
-                  }
-                } else if (noteL.line > noteU.line) {
-                  //note L is above noteU
-                  if (noteL.stemDirection === 1) {
-                    noteU.note.renderFlag = false;
-                  } else {
-                    noteL.note.renderFlag = false;
-                  }
+              }
+          } else if (lineDiff < 1 && lineDiff > 0) {//if the notes are quite close but not on the same line, shift
+            noteL.note.setXShift(xShift);
+          } else if (noteU.note.voice !== noteL.note.voice) {//If we are not in the same voice
+            if (noteU.stemDirection === noteL.stemDirection) {
+              if (noteU.line > noteL.line) {
+                //noteU is above noteL
+                if (noteU.stemDirection === 1) {
+                  noteL.note.renderFlag = false;
                 } else {
-                  //same line, swap stem direction for one note
-                  if (noteL.stemDirection === 1) {
-                    noteL.stemDirection = -1;
-                    noteL.note.setStemDirection(-1);
-                  }
+                  noteU.note.renderFlag = false;
+                }
+              } else if (noteL.line > noteU.line) {
+                //note L is above noteU
+                if (noteL.stemDirection === 1) {
+                  noteU.note.renderFlag = false;
+                } else {
+                  noteL.note.renderFlag = false;
+                }
+              } else {
+                //same line, swap stem direction for one note
+                if (noteL.stemDirection === 1) {
+                  noteL.stemDirection = -1;
+                  noteL.note.setStemDirection(-1);
                 }
               }
-            } //Very close whole notes
-          } else if ((!noteU.note.glyph.stem && !noteL.note.glyph.stem && lineDiff < 1.5)) {
-            noteL.note.setXShift(xShift);
+            }
           }
+          //Very close whole notes
+          // } else if ((!noteU.note.glyph.stem && !noteL.note.glyph.stem && lineDiff < 1.5)) {
+          //   noteL.note.setXShift(xShift);
+          // }
         }
       }
 

--- a/test/data/test_note_overlap_staggering.musicxml
+++ b/test/data/test_note_overlap_staggering.musicxml
@@ -2,7 +2,7 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
   <work>
-    <work-title>note bug</work-title>
+    <work-title>test note overlap</work-title>
     </work>
   <identification>
     <encoding>
@@ -41,7 +41,7 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">note bug</credit-words>
+    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">test note overlap</credit-words>
     </credit>
   <part-list>
     <score-part id="P1">

--- a/test/data/test_note_overlap_staggering.musicxml
+++ b/test/data/test_note_overlap_staggering.musicxml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>note bug</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.6.2</software>
+      <encoding-date>2022-01-07</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1697.14</page-height>
+      <page-width>1200</page-width>
+      <page-margins type="even">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">note bug</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="371.43">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>65.90</left-margin>
+            <right-margin>591.24</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="83.49" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="101.41" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test/data/test_note_overlap_staggering_quarter.musicxml
+++ b/test/data/test_note_overlap_staggering_quarter.musicxml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding='UTF-8' standalone='no' ?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+ <work>
+  <work-title>test note overlap quarter</work-title>
+ </work>
+ <identification>
+  <encoding>
+   <encoding-date>2021-11-17</encoding-date>
+   <software>Sibelius 19.5.0</software>
+   <software>Direct export, not from Dolet</software>
+   <encoding-description>Sibelius / MusicXML 3.0</encoding-description>
+   <supports element="print" type="yes" value="yes" attribute="new-system" />
+   <supports element="print" type="yes" value="yes" attribute="new-page" />
+   <supports element="accidental" type="yes" />
+   <supports element="beam" type="yes" />
+   <supports element="stem" type="yes" />
+  </encoding>
+ </identification>
+ <defaults>
+  <scaling>
+   <millimeters>215.9</millimeters>
+   <tenths>1233</tenths>
+  </scaling>
+  <page-layout>
+   <page-height>1596</page-height>
+   <page-width>1233</page-width>
+   <page-margins type="both">
+    <left-margin>85</left-margin>
+    <right-margin>85</right-margin>
+    <top-margin>85</top-margin>
+    <bottom-margin>85</bottom-margin>
+   </page-margins>
+  </page-layout>
+  <system-layout>
+   <system-margins>
+    <left-margin>63</left-margin>
+    <right-margin>0</right-margin>
+   </system-margins>
+   <system-distance>92</system-distance>
+  </system-layout>
+  <appearance>
+   <line-width type="stem">0.9375</line-width>
+   <line-width type="beam">5</line-width>
+   <line-width type="staff">0.9375</line-width>
+   <line-width type="light barline">1.5625</line-width>
+   <line-width type="heavy barline">5</line-width>
+   <line-width type="leger">1.5625</line-width>
+   <line-width type="ending">1.5625</line-width>
+   <line-width type="wedge">1.25</line-width>
+   <line-width type="enclosure">0.9375</line-width>
+   <line-width type="tuplet bracket">1.25</line-width>
+   <line-width type="bracket">5</line-width>
+   <line-width type="dashes">1.5625</line-width>
+   <line-width type="extend">0.9375</line-width>
+   <line-width type="octave shift">1.5625</line-width>
+   <line-width type="pedal">1.5625</line-width>
+   <line-width type="slur middle">1.5625</line-width>
+   <line-width type="slur tip">0.625</line-width>
+   <line-width type="tie middle">1.5625</line-width>
+   <line-width type="tie tip">0.625</line-width>
+   <note-size type="cue">75</note-size>
+   <note-size type="grace">60</note-size>
+  </appearance>
+  <music-font font-family="Opus Std" font-size="19.8425" />
+  <lyric-font font-family="Times New Roman" font-size="11.4715" />
+  <lyric-language xml:lang="en" />
+ </defaults>
+ <part-list>
+  <part-group type="start" number="1">
+   <group-symbol>brace</group-symbol>
+  </part-group>
+  <score-part id="P1">
+   <part-name>Piano</part-name>
+   <part-name-display>
+    <display-text>Piano</display-text>
+   </part-name-display>
+   <part-abbreviation>Pno.</part-abbreviation>
+   <part-abbreviation-display>
+    <display-text>Pno.</display-text>
+   </part-abbreviation-display>
+   <score-instrument id="P1-I1">
+    <instrument-name>Piano (2) (2)</instrument-name>
+    <instrument-sound>keyboard.piano.grand</instrument-sound>
+    <solo />
+    <virtual-instrument>
+     <virtual-library>Sibelius 7 Sounds</virtual-library>
+     <virtual-name>Concert Grand Piano</virtual-name>
+    </virtual-instrument>
+   </score-instrument>
+  </score-part>
+  <part-group type="stop" number="1" />
+ </part-list>
+ <part id="P1">
+  <!--============== Part: P1, Measure: 1 ==============-->
+  <measure number="1" width="986">
+   <print new-page="yes">
+    <system-layout>
+     <system-margins>
+      <left-margin>76</left-margin>
+      <right-margin>0</right-margin>
+     </system-margins>
+     <top-system-distance>218</top-system-distance>
+    </system-layout>
+   </print>
+   <attributes>
+    <divisions>256</divisions>
+    <key color="#000000">
+     <fifths>0</fifths>
+     <mode>minor</mode>
+    </key>
+    <time color="#000000">
+     <beats>4</beats>
+     <beat-type>4</beat-type>
+    </time>
+    <staves>1</staves>
+    <clef number="1" color="#000000">
+     <sign>G</sign>
+     <line>2</line>
+    </clef>
+    <staff-details number="1" print-object="yes" />
+   </attributes>
+   <note color="#000000" default-x="96" default-y="9">
+    <pitch>
+     <step>A</step>
+     <octave>4</octave>
+    </pitch>
+    <duration>128</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>eighth</type>
+    <stem>up</stem>
+    <staff>1</staff>
+    <beam number="1">begin</beam>
+   </note>
+   <note color="#000000" default-x="249" default-y="9">
+    <pitch>
+     <step>B</step>
+     <octave>4</octave>
+    </pitch>
+    <duration>128</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>eighth</type>
+    <stem>up</stem>
+    <staff>1</staff>
+    <beam number="1">end</beam>
+   </note>
+   <note default-x="402">
+    <rest />
+    <duration>256</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <staff>1</staff>
+   </note>
+   <note default-x="613">
+    <rest />
+    <duration>512</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>half</type>
+    <staff>1</staff>
+   </note>
+   <barline>
+    <bar-style>light-heavy</bar-style>
+   </barline>
+   <backup>
+    <duration>1024</duration>
+   </backup>
+   <note color="#000000" default-x="96">
+    <pitch>
+     <step>G</step>
+     <octave>4</octave>
+    </pitch>
+    <duration>1024</duration>
+    <tie type="start" />
+    <instrument id="P1-I1" />
+    <voice>2</voice>
+    <type>whole</type>
+    <staff>1</staff>
+    <notations>
+     <tied type="start" orientation="under" />
+    </notations>
+   </note>
+   <backup>
+    <duration>768</duration>
+   </backup>
+   <note default-x="402">
+    <rest />
+    <duration>256</duration>
+    <instrument id="P1-I1" />
+    <voice>2</voice>
+    <type>quarter</type>
+    <staff>1</staff>
+   </note>
+   <note default-x="613">
+    <rest />
+    <duration>512</duration>
+    <instrument id="P1-I1" />
+    <voice>2</voice>
+    <type>half</type>
+    <staff>1</staff>
+   </note>
+  </measure>
+ </part>
+</score-partwise>


### PR DESCRIPTION
Fix #1098

![image](https://user-images.githubusercontent.com/33069673/148547033-437fa270-8aea-42dc-aaa9-0decd58061a5.png)
![image](https://user-images.githubusercontent.com/33069673/148547119-03765b71-bf81-4cfd-980b-9efb03313f76.png)

No visual regressions.
This should be caught by our tests though (there should have been a visual diff), so I've added the sample `test_note_overlap_staggering` to the visual regression tests.

@rvilarl FYI, this is an improvement on the Vexflowpatch for stavenote.js, though I believe the notes are correctly staggered in Vexflow 4 anyways, see #1098.