### PR TITLE
fix(Ties): Fix note.NoteTie undefined for tie end note in different voice than start note

### DIFF
--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -66,7 +66,7 @@ export class VoiceGenerator {
   // private lastBeamTag: string = "";
   private openBeams: Beam[] = []; // works like a stack, with push and pop
   private beamNumberOffset: number = 0;
-  private openTieDict: { [_: number]: Tie } = {};
+  private get openTieDict(): { [_: number]: Tie } { return this.staff.openTieDict; }
   private currentOctaveShift: number = 0;
   private tupletDict: { [_: number]: Tuplet } = {};
   private openTupletNumber: number = 0;

--- a/src/MusicalScore/VoiceData/Staff.ts
+++ b/src/MusicalScore/VoiceData/Staff.ts
@@ -1,5 +1,6 @@
 import {Voice} from "./Voice";
 import {Instrument} from "../Instrument";
+import { Tie } from "./Tie";
 
 export class Staff {
 
@@ -21,6 +22,7 @@ export class Staff {
     private id: number;
     private stafflineCount: number = 5;
     public hasLyrics: boolean = false;
+    public openTieDict: { [_: number]: Tie } = {};
 
     public get ParentInstrument(): Instrument {
         return this.parentInstrument;


### PR DESCRIPTION
extended issue 51

This moves openTieDict from VoiceGenerator to Staff. That's because a different VoiceGenerator is generated for each voice (and staff), and each has its own openTieDict, so it is assumed that tie notes are all in the same voice. That may be the correct way to do it in MusicXML, but in practice, tie notes in MusicXML can be in different voices.
So we manage ties in Staff now instead of the VoiceGenerator, so ties are per Staff, not per Voice.

No visual regressions.

Fixes `osmd.graphic.MeasureList[3][0].staffEntries[0].graphicalVoiceEntries[0].notes[0].sourceNote.NoteTie` undefined in Clair de Lune.
[clair.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/8125443/clair.zip)
