### PR TITLE
Chord accidentals

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -763,8 +763,8 @@ export class EngravingRules {
 
     public resetChordNames(): void {
         // addChordName(alternateName, chordKindText, adds, alters, subtracts)
-        this.addChordName("alt", "major", ["#5", "b9", "#9"], ["b5"], []);
-        this.addChordName("7alt", "dominant", ["#5", "b9", "#9"], ["b5"], []);
+        this.addChordName("alt", "major", ["♯5", "♭9", "♯9"], ["♭5"], []);
+        this.addChordName("7alt", "dominant", ["♯5", "♭9", "♯9"], ["♭5"], []);
         this.addChordName("7sus4", "dominant", ["4"], [], ["3"]);
         this.addChordName("7sus4", "suspendedfourth", ["7"], [], []);
         this.addChordName("9sus4", "dominantninth", ["4"], [], ["3"]);
@@ -775,7 +775,7 @@ export class EngravingRules {
         this.addChordName("13sus4", "suspendedfourth", ["13"], [], []);
         this.addChordName("7sus2", "dominant", ["2"], [], ["3"]);
         this.addChordName("7sus2", "suspendedsecond", ["7"], [], []);
-        this.addChordName("m7b5", "minorseventh", [], ["b5"], []);
+        this.addChordName("m7b5", "minorseventh", [], ["♭5"], []);
         this.addChordName("9sus2", "dominantninth", ["2"], [], ["3"]);
         this.addChordName("9sus2", "suspendedsecond", ["9"], [], []);
         this.addChordName("11sus2", "dominant11th", ["2"], [], ["3"]);

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -719,7 +719,7 @@ export class EngravingRules {
         chordtexts.setValue(ChordSymbolEnum.minorseventh, "m7");
         chordtexts.setValue(ChordSymbolEnum.diminishedseventh, "dim7");
         chordtexts.setValue(ChordSymbolEnum.augmentedseventh, "aug7");
-        chordtexts.setValue(ChordSymbolEnum.halfdiminished, "m7b5");
+        chordtexts.setValue(ChordSymbolEnum.halfdiminished, "m7♭5");
         chordtexts.setValue(ChordSymbolEnum.majorminor, "m(maj7)");
         chordtexts.setValue(ChordSymbolEnum.majorsixth, "maj6");
         chordtexts.setValue(ChordSymbolEnum.minorsixth, "m6");

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -7,7 +7,7 @@ import { AutoBeamOptions, AlignRestOption, FillEmptyMeasuresWithWholeRests } fro
 import { ColoringModes as ColoringMode } from "./DrawingParameters";
 import { Dictionary } from "typescript-collections";
 import { FontStyles } from "../../Common/Enums";
-import { NoteEnum } from "../../Common/DataObjects/Pitch";
+import { NoteEnum, AccidentalEnum } from "../../Common/DataObjects/Pitch";
 import { ChordSymbolEnum, CustomChord, DegreesInfo } from "../../MusicalScore/VoiceData/ChordSymbolContainer";
 import { GraphicalNote } from "./GraphicalNote";
 import { Note } from "../VoiceData/Note";
@@ -120,6 +120,7 @@ export class EngravingRules {
     public ChordSymbolYAlignment: boolean;
     public ChordSymbolYAlignmentScope: string;
     public ChordSymbolLabelTexts: Dictionary<ChordSymbolEnum, string>;
+    public ChordAccidentalTexts: Dictionary<AccidentalEnum, string>;
     public CustomChords: CustomChord[];
     public RepetitionSymbolsYOffset: number;
     public RehearsalMarkXOffset: number;
@@ -466,6 +467,8 @@ export class EngravingRules {
         this.ChordSymbolYPadding = 0.0;
         this.ChordSymbolYAlignment = true;
         this.ChordSymbolYAlignmentScope = "staffline"; // "measure" or "staffline"
+        this.ChordAccidentalTexts = new Dictionary<AccidentalEnum, string>();
+        this.resetChordAccidentalTexts(this.ChordAccidentalTexts, false);
         this.ChordSymbolLabelTexts = new Dictionary<ChordSymbolEnum, string>();
         this.resetChordSymbolLabelTexts(this.ChordSymbolLabelTexts);
         this.CustomChords = [];
@@ -707,6 +710,13 @@ export class EngravingRules {
         this.NoteToGraphicalNoteMapObjectCount = 0;
     }
 
+    public resetChordAccidentalTexts(chordAccidentalTexts: Dictionary<AccidentalEnum, string>, useChordAccidentalsUnicode: boolean): void {
+        chordAccidentalTexts.setValue(AccidentalEnum.SHARP, useChordAccidentalsUnicode ? "♯" : "#");
+        chordAccidentalTexts.setValue(AccidentalEnum.FLAT, useChordAccidentalsUnicode ? "♭" : "b");
+        chordAccidentalTexts.setValue(AccidentalEnum.DOUBLEFLAT, useChordAccidentalsUnicode ? "𝄫" : "bb");
+        chordAccidentalTexts.setValue(AccidentalEnum.DOUBLESHARP, useChordAccidentalsUnicode ? "𝄪" : "x");
+    }
+
     public setChordSymbolLabelText(key: ChordSymbolEnum, value: string): void {
         this.ChordSymbolLabelTexts.setValue(key, value);
     }
@@ -719,7 +729,7 @@ export class EngravingRules {
         chordtexts.setValue(ChordSymbolEnum.minorseventh, "m7");
         chordtexts.setValue(ChordSymbolEnum.diminishedseventh, "dim7");
         chordtexts.setValue(ChordSymbolEnum.augmentedseventh, "aug7");
-        chordtexts.setValue(ChordSymbolEnum.halfdiminished, "m7♭5");
+        chordtexts.setValue(ChordSymbolEnum.halfdiminished, `m7${this.ChordAccidentalTexts.getValue(AccidentalEnum.FLAT)}5`);
         chordtexts.setValue(ChordSymbolEnum.majorminor, "m(maj7)");
         chordtexts.setValue(ChordSymbolEnum.majorsixth, "maj6");
         chordtexts.setValue(ChordSymbolEnum.minorsixth, "m6");
@@ -762,9 +772,11 @@ export class EngravingRules {
     }
 
     public resetChordNames(): void {
+        const sharp: string = this.ChordAccidentalTexts.getValue(AccidentalEnum.SHARP);
+        const flat: string = this.ChordAccidentalTexts.getValue(AccidentalEnum.FLAT);
         // addChordName(alternateName, chordKindText, adds, alters, subtracts)
-        this.addChordName("alt", "major", ["♯5", "♭9", "♯9"], ["♭5"], []);
-        this.addChordName("7alt", "dominant", ["♯5", "♭9", "♯9"], ["♭5"], []);
+        this.addChordName("alt", "major", [`${sharp}5`, `${flat}9`, `${sharp}9`], [`${flat}5`], []);
+        this.addChordName("7alt", "dominant", [`${sharp}5`, `${flat}9`, `${sharp}9`], [`${flat}5`], []);
         this.addChordName("7sus4", "dominant", ["4"], [], ["3"]);
         this.addChordName("7sus4", "suspendedfourth", ["7"], [], []);
         this.addChordName("9sus4", "dominantninth", ["4"], [], ["3"]);
@@ -775,7 +787,7 @@ export class EngravingRules {
         this.addChordName("13sus4", "suspendedfourth", ["13"], [], []);
         this.addChordName("7sus2", "dominant", ["2"], [], ["3"]);
         this.addChordName("7sus2", "suspendedsecond", ["7"], [], []);
-        this.addChordName("m7♭5", "minorseventh", [], ["♭5"], []);
+        this.addChordName(`m7${flat}5`, "minorseventh", [], [`${flat}5`], []);
         this.addChordName("9sus2", "dominantninth", ["2"], [], ["3"]);
         this.addChordName("9sus2", "suspendedsecond", ["9"], [], []);
         this.addChordName("11sus2", "dominant11th", ["2"], [], ["3"]);

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -775,7 +775,7 @@ export class EngravingRules {
         this.addChordName("13sus4", "suspendedfourth", ["13"], [], []);
         this.addChordName("7sus2", "dominant", ["2"], [], ["3"]);
         this.addChordName("7sus2", "suspendedsecond", ["7"], [], []);
-        this.addChordName("m7b5", "minorseventh", [], ["♭5"], []);
+        this.addChordName("m7♭5", "minorseventh", [], ["♭5"], []);
         this.addChordName("9sus2", "dominantninth", ["2"], [], ["3"]);
         this.addChordName("9sus2", "suspendedsecond", ["9"], [], []);
         this.addChordName("11sus2", "dominant11th", ["2"], [], ["3"]);

--- a/src/MusicalScore/VoiceData/ChordSymbolContainer.ts
+++ b/src/MusicalScore/VoiceData/ChordSymbolContainer.ts
@@ -58,7 +58,7 @@ export class ChordSymbolContainer {
         let text: string = Pitch.getNoteEnumString(transposedRootPitch.FundamentalNote);
         // main alteration
         if (transposedRootPitch.Accidental !== AccidentalEnum.NONE) {
-            text += this.getTextForAccidental(transposedRootPitch.Accidental);
+            text += chordSymbol.getTextForAccidental(transposedRootPitch.Accidental);
         }
 
         // degrees
@@ -72,7 +72,7 @@ export class ChordSymbolContainer {
             if (chordDegree) {
                 let t: string = "";
                 if (chordDegree.alteration !== AccidentalEnum.NONE) {
-                    t += this.getTextForAccidental(chordDegree.alteration);
+                    t += chordSymbol.getTextForAccidental(chordDegree.alteration);
                 }
                 t += chordDegree.value;
                 switch (chordDegree.text) {
@@ -145,29 +145,14 @@ export class ChordSymbolContainer {
             }
             text += "/";
             text += Pitch.getNoteEnumString(transposedBassPitch.FundamentalNote);
-            text += this.getTextForAccidental(transposedBassPitch.Accidental);
+            text += chordSymbol.getTextForAccidental(transposedBassPitch.Accidental);
         }
         return text;
     }
 
-    private static getTextForAccidental(alteration: AccidentalEnum): string {
-        let text: string = "";
-        switch (alteration) {
-            case AccidentalEnum.DOUBLEFLAT:
-                text += "♭♭";
-                break;
-            case AccidentalEnum.FLAT:
-                text += "♭";
-                break;
-            case AccidentalEnum.SHARP:
-                text += "♯";
-                break;
-            case AccidentalEnum.DOUBLESHARP:
-                text += "𝄪";
-                break;
-            default:
-        }
-        return text;
+    private getTextForAccidental(alteration: AccidentalEnum): string {
+        const text: string = this.rules.ChordAccidentalTexts.getValue(alteration);
+        return text !== undefined ? text : "";
     }
 
     private getTextFromChordKindEnum(kind: ChordSymbolEnum): string {

--- a/src/MusicalScore/VoiceData/ChordSymbolContainer.ts
+++ b/src/MusicalScore/VoiceData/ChordSymbolContainer.ts
@@ -154,16 +154,16 @@ export class ChordSymbolContainer {
         let text: string = "";
         switch (alteration) {
             case AccidentalEnum.DOUBLEFLAT:
-                text += "bb";
+                text += "♭♭";
                 break;
             case AccidentalEnum.FLAT:
-                text += "b";
+                text += "♭";
                 break;
             case AccidentalEnum.SHARP:
-                text += "#";
+                text += "♯";
                 break;
             case AccidentalEnum.DOUBLESHARP:
-                text += "x";
+                text += "𝄪";
                 break;
             default:
         }


### PR DESCRIPTION
This PR replaces "b", "#" and "x" chord accidentals with their more accurate counterparts "♭", "♯" and "𝄪". This helps clarify the chord display, as per attached screenshot.

![screenshot-blog karimratib me-2022 03 06-13_09_56](https://user-images.githubusercontent.com/92977/156942343-a2084f63-7e83-4b35-a5b9-ee51032fcbd4.png)
