### PR TITLE
Move `gl` to `optionalDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-standard": "^4.1.0",
-    "gl": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "jquery": "^3.6.0",
     "jsdom": "^19.0.0",
@@ -119,6 +118,9 @@
     "webpack-dev-server": "^4.7.0",
     "webpack-merge": "^5.8.0",
     "webpack-visualizer-plugin2": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "gl": "^5.0.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "generate:current:webgl": "node ./test/Util/generateImages_browserless.mjs ../../build ./test/data ./visual_regression/current png 0 0 allSmall --osmdtesting 0 --webgl",
     "generate:current:debug": "node ./test/Util/generateImages_browserless.mjs ../../build ./test/data ./visual_regression/current png 0 0 allSmall --debugosmdtesting",
     "generate:current:singletest": "node test/Util/generateImages_browserless.mjs ../../build ./test/data ./visual_regression/current png 0 0 ^Beethoven --osmdtestingsingle",
+    "generate:blessed": "node ./test/Util/generateImages_browserless.mjs ../../build ./test/data ./visual_regression/blessed png 0 0 allSmall --osmdtesting",
     "test:visual": "bash ./test/Util/visual_regression.sh ./visual_regression",
     "test:visual:build": "npm-run-all prebuild build:webpack generate:current test:visual",
     "test:visual:build:batch": "npm-run-all prebuild build:webpack generate:current:batch test:visual",

--- a/test/Util/generateImages_browserless.mjs
+++ b/test/Util/generateImages_browserless.mjs
@@ -1,7 +1,6 @@
 import Blob from "cross-blob";
 import FS from "fs";
 import jsdom from "jsdom";
-import headless_gl from "gl";
 import OSMD from "../../build/opensheetmusicdisplay.min.js"; // window needs to be available before we can require OSMD
 /*
   Render each OSMD sample, grab the generated images, and
@@ -108,25 +107,32 @@ async function init () {
     }
 
     // For WebGLSkyBottomLineCalculatorBackend
-    const oldCreateElement = document.createElement.bind(document);
-    document.createElement = function (tagName, options) {
-        if (tagName.toLowerCase() === "canvas") {
-            const canvas = oldCreateElement(tagName, options);
-            const oldGetContext = canvas.getContext.bind(canvas);
-            canvas.getContext = function (contextType, contextAttributes) {
-                if (contextType.toLowerCase() === "webgl" || contextType.toLowerCase() === "experimental-webgl") {
-                    const gl = headless_gl(canvas.width, canvas.height, contextAttributes);
-                    gl.canvas = canvas;
-                    return gl;
-                } else {
-                    return oldGetContext(contextType, contextAttributes);
-                }
-            };
-            return canvas;
-        } else {
-            return oldCreateElement(tagName, options);
+    try {
+        const { default: headless_gl } = await import("gl");
+        const oldCreateElement = document.createElement.bind(document);
+        document.createElement = function (tagName, options) {
+            if (tagName.toLowerCase() === "canvas") {
+                const canvas = oldCreateElement(tagName, options);
+                const oldGetContext = canvas.getContext.bind(canvas);
+                canvas.getContext = function (contextType, contextAttributes) {
+                    if (contextType.toLowerCase() === "webgl" || contextType.toLowerCase() === "experimental-webgl") {
+                        const gl = headless_gl(canvas.width, canvas.height, contextAttributes);
+                        gl.canvas = canvas;
+                        return gl;
+                    } else {
+                        return oldGetContext(contextType, contextAttributes);
+                    }
+                };
+                return canvas;
+            } else {
+                return oldCreateElement(tagName, options);
+            }
+        };
+    } catch {
+        if (skyBottomLinePreference === "--webgl") {
+            console.log("WebGL image generation was requested but gl is not installed; using non-WebGL generation.");
         }
-    };
+    }
 
     // fix Blob not found (to support external modules like is-blob)
     global.Blob = Blob;


### PR DESCRIPTION
# Summary
The `gl` npm package added by PR #1158 is hard to install. This PR is to move `gl` to `optionalDependencies` so the developers can install OSMD easily as before. Before merging this PR, I want to find the exact circumstances under which `gl` can be installed. In addition, I think now is the time to add instructions about the batch and the WebGL visual regression tests to [the wiki](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/wiki/Testing#visual-regression-tests-unixmacwsl2-only-for-now).

I've tested Windows 10 using the Windows Sandbox, and it seems like `gl` can be installed without Python 2 or Visual C++ (which is contrary to [the docs](https://www.npmjs.com/package/gl#system-dependencies)). I will add test results for macOS or Ubuntu as well.

(+ Update) It seems like I removed `generate:blessed` NPM script in #1158... I've just restored it.