### PR TITLE
refactor: merge changes from feat/vexflow4 branch (#1139) (style changes etc)

### DIFF
--- a/src/MusicalScore/Graphical/PlainSkyBottomLineBatchCalculatorBackend.ts
+++ b/src/MusicalScore/Graphical/PlainSkyBottomLineBatchCalculatorBackend.ts
@@ -1,3 +1,5 @@
+import Vex from "vexflow";
+import VF = Vex.Flow;
 import { EngravingRules } from "./EngravingRules";
 import { VexFlowMeasure } from "./VexFlow/VexFlowMeasure";
 import { SkyBottomLineCalculationResult } from "./SkyBottomLineCalculationResult";
@@ -30,7 +32,7 @@ export class PlainSkyBottomLineBatchCalculatorBackend extends SkyBottomLineBatch
 
     protected calculateFromCanvas(
         canvas: HTMLCanvasElement,
-        vexFlowContext: Vex.Flow.CanvasContext,
+        vexFlowContext: VF.CanvasContext,
         measures: VexFlowMeasure[],
         samplingUnit: number,
         tableConfiguration: ISkyBottomLineBatchCalculatorBackendTableConfiguration

--- a/src/MusicalScore/Graphical/SkyBottomLineBatchCalculatorBackend.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineBatchCalculatorBackend.ts
@@ -1,3 +1,5 @@
+import Vex from "vexflow";
+import VF = Vex.Flow;
 import { EngravingRules } from "./EngravingRules";
 import { SkyBottomLineCalculationResult } from "./SkyBottomLineCalculationResult";
 import { CanvasVexFlowBackend } from "./VexFlow/CanvasVexFlowBackend";
@@ -117,7 +119,7 @@ export abstract class SkyBottomLineBatchCalculatorBackend {
      */
     protected abstract calculateFromCanvas(
         canvas: HTMLCanvasElement,
-        context: Vex.Flow.CanvasContext,
+        context: VF.CanvasContext,
         measures: VexFlowMeasure[],
         samplingUnit: number,
         tableConfiguration: ISkyBottomLineBatchCalculatorBackendTableConfiguration
@@ -133,7 +135,7 @@ export abstract class SkyBottomLineBatchCalculatorBackend {
         const elementHeight: number = this.elementHeight;
         const numElementsPerTable: number = numColumns * numRows;
 
-        const vexFlowContext: Vex.Flow.CanvasContext = this.canvas.getContext();
+        const vexFlowContext: VF.CanvasContext = this.canvas.getContext();
         const context: CanvasRenderingContext2D = vexFlowContext as unknown as CanvasRenderingContext2D;
         const canvasElement: HTMLCanvasElement = this.canvas.getCanvas() as HTMLCanvasElement;
 
@@ -149,7 +151,7 @@ export abstract class SkyBottomLineBatchCalculatorBackend {
 
             for (let j: number = 0; j < measures.length; ++j) {
                 const measure: VexFlowMeasure = measures[j];
-                const vsStaff: Vex.Flow.Stave = measure.getVFStave();
+                const vsStaff: VF.Stave = measure.getVFStave();
 
                 // (u, v) is the position of measure in the table
                 const u: number = j % numColumns;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -13,7 +13,6 @@ import {VexFlowStaffEntry} from "./VexFlowStaffEntry";
 import {Beam} from "../../VoiceData/Beam";
 import {GraphicalNote} from "../GraphicalNote";
 import {GraphicalStaffEntry} from "../GraphicalStaffEntry";
-import StaveConnector = VF.StaveConnector;
 import StaveNote = VF.StaveNote;
 import StemmableNote = VF.StemmableNote;
 import NoteSubGroup = VF.NoteSubGroup;
@@ -41,7 +40,7 @@ import { GraphicalTie } from "../GraphicalTie";
 // type StemmableNote = VF.StemmableNote;
 
 export class VexFlowMeasure extends GraphicalMeasure {
-    constructor(staff: Staff, sourceMeasure: SourceMeasure = undefined, staffLine: StaffLine = undefined) {
+    constructor(staff: Staff, sourceMeasure?: SourceMeasure, staffLine?: StaffLine) {
         super(staff, sourceMeasure, staffLine);
         this.minimumStaffEntriesWidth = -1;
 
@@ -54,6 +53,8 @@ export class VexFlowMeasure extends GraphicalMeasure {
             this.rules = staffLine.ParentMusicSystem.rules;
         } else if (sourceMeasure) {
             this.rules = sourceMeasure.Rules;
+        } else {
+            this.rules = new EngravingRules();
         }
 
         this.resetLayout();
@@ -65,23 +66,23 @@ export class VexFlowMeasure extends GraphicalMeasure {
     /** The VexFlow Voices in the measure */
     public vfVoices: { [voiceID: number]: VF.Voice } = {};
     /** Call this function (if present) to x-format all the voices in the measure */
-    public formatVoices: (width: number, parent: VexFlowMeasure) => void;
+    public formatVoices?: (width: number, parent: VexFlowMeasure) => void;
     /** The VexFlow Ties in the measure */
     public vfTies: VF.StaveTie[] = [];
     /** The repetition instructions given as words or symbols (coda, dal segno..) */
     public vfRepetitionWords: VF.Repetition[] = [];
     /** The VexFlow Stave (= one measure in a staffline) */
-    protected stave: VF.Stave;
+    protected stave!: VF.Stave;
     /** VexFlow StaveConnectors (vertical lines) */
     protected connectors: VF.StaveConnector[] = [];
     /** Intermediate object to construct beams */
-    private beams: { [voiceID: number]: [Beam, VexFlowVoiceEntry[]][] } = {};
+    private beams: { [voiceID: number]: [Beam, VexFlowVoiceEntry[]] [] } = {};
     /** Beams created by (optional) autoBeam function. */
-    private autoVfBeams: VF.Beam[];
+    private autoVfBeams: VF.Beam[] = [];
     /** Beams of tuplet notes created by (optional) autoBeam function. */
-    private autoTupletVfBeams: VF.Beam[];
+    private autoTupletVfBeams: VF.Beam[] = [];
     /** VexFlow Beams */
-    private vfbeams: { [voiceID: number]: VF.Beam[] };
+    private vfbeams: { [voiceID: number]: VF.Beam[] } = {};
     /** Intermediate object to construct tuplets */
     protected tuplets: { [voiceID: number]: [Tuplet, VexFlowVoiceEntry[]][] } = {};
     /** VexFlow Tuplets */
@@ -400,18 +401,17 @@ export class VexFlowMeasure extends GraphicalMeasure {
     public addMeasureNumber(): void {
         const text: string = this.MeasureNumber.toString();
         const position: number = StavePositionEnum.ABOVE;  //VF.StaveModifier.Position.ABOVE;
-        const options: any = {
+        this.stave.setText(text, position, {
             justification: 1,
             shift_x: 0,
             shift_y: 0,
-          };
-
-        this.stave.setText(text, position, options);
+          }
+        );
     }
 
     public addWordRepetition(repetitionInstruction: RepetitionInstruction): void {
-        let instruction: VF.Repetition.type = undefined;
-        let position: any = VF.StaveModifier.Position.END;
+        let instruction: number | undefined;
+        let position: number = VF.StaveModifier.Position.END;
         const xShift: number = this.beginInstructionsWidth;
         switch (repetitionInstruction.type) {
           case RepetitionInstructionEnum.Segno:
@@ -1534,7 +1534,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
      * @param lineType
      */
     public lineTo(top: VexFlowMeasure, lineType: any): void {
-        const connector: StaveConnector = new VF.StaveConnector(top.getVFStave(), this.stave);
+        const connector: VF.StaveConnector = new VF.StaveConnector(top.getVFStave(), this.stave);
         connector.setType(lineType);
         this.connectors.push(connector);
     }

--- a/src/MusicalScore/Graphical/WebGLSkyBottomLineBatchCalculatorBackend.ts
+++ b/src/MusicalScore/Graphical/WebGLSkyBottomLineBatchCalculatorBackend.ts
@@ -1,3 +1,5 @@
+import Vex from "vexflow";
+import VF = Vex.Flow;
 import { EngravingRules } from "./EngravingRules";
 import { VexFlowMeasure } from "./VexFlow/VexFlowMeasure";
 import { SkyBottomLineCalculationResult } from "./SkyBottomLineCalculationResult";
@@ -167,7 +169,7 @@ export class WebGLSkyBottomLineBatchCalculatorBackend extends SkyBottomLineBatch
 
     protected calculateFromCanvas(
         canvas: HTMLCanvasElement,
-        _: Vex.Flow.CanvasContext,
+        _: VF.CanvasContext,
         measures: VexFlowMeasure[],
         samplingUnit: number,
         tableConfiguration: ISkyBottomLineBatchCalculatorBackendTableConfiguration


### PR DESCRIPTION
to lessen merge conflicts with feat/vexflow4 branch

visual regression tests pass.

a few of the changes couldn't be transferred because vexflow 1 doesn't have the methods or our definitions are incomplete, so we need to use `any`.
I'm preparing a PR to DefinitelyTyped to add these, because it would be much cleaner and less annoying to not use `any` when these methods/accessors are standard and public, but just missing in these definitions.
examples: stave.setNumLines(), stave.options, timesignature.setStyle(), stave.endClef/stave.getEndClef()