### PR TITLE
Fix Rehearsal mark position shift when EngravingRules.RehearsalMarkFontSize increased

### DIFF
--- a/src/VexFlowPatch/src/stavesection.js
+++ b/src/VexFlowPatch/src/stavesection.js
@@ -37,7 +37,7 @@ export class StaveSection extends StaveModifier {
     const text_width = text_measurements.width;
     let text_height = text_measurements.height;
     if (!text_height) {
-      text_height = text_measurements.emHeightAscent; // node canvas / generateImages fix
+      text_height = text_measurements.emHeightAscent + 2; // node canvas / generateImages fix
     }
     let width = text_width + 6;  // add left & right padding
     if (width < 18) width = 18;


### PR DESCRIPTION
Fixes #1176

`osmd.EngravingRules.RehearsalMarkFontSize = 20`
before:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/33069673/177577017-a394e5c5-031c-4e26-ab2a-e068185cfda8.png">

after:
<img width="156" alt="image" src="https://user-images.githubusercontent.com/33069673/177577115-481b1638-2502-4f5d-9f33-903c8eb66c17.png">

sample: `test_rehearsal_marks_simple_one_measure.musicxml`


Also fix the issue that the generateImages script would not add a box around the rehearsal mark, because `.height` doesn't exist in node canvas for some reason.

before:
![image](https://user-images.githubusercontent.com/33069673/177576827-cdfa5693-59b4-460a-861a-75a3a4bc3a77.png)

after:
![image](https://user-images.githubusercontent.com/33069673/177577238-1d59df2b-5406-43e2-ac34-404d59d9dc16.png)

visual diffs:
[diff_rehearsalmarks.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/9055802/diff_rehearsalmarks.zip)
(very small delta, only for rehearsal marks, no negatives)