### PR TITLE
Fix implicit measure spacing

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -250,6 +250,10 @@ export class EngravingRules {
     public VoiceSpacingMultiplierVexflow: number;
     public VoiceSpacingAddendVexflow: number;
     public PickupMeasureWidthMultiplier: number;
+    /** The spacing between a repetition that is followed by an implicit/pickup/incomplete measure.
+     *  (E.g. in a 4/4 time signature, a measure that repeats after the 3rd beat, continuing with a pickup measure)
+     */
+    public PickupMeasureRepetitionSpacing: number;
     public DisplacedNoteMargin: number;
     public MinNoteDistance: number;
     public SubMeasureXSpacingThreshold: number;
@@ -630,6 +634,7 @@ export class EngravingRules {
         this.VoiceSpacingMultiplierVexflow = 0.85;
         this.VoiceSpacingAddendVexflow = 3.0;
         this.PickupMeasureWidthMultiplier = 1.0;
+        this.PickupMeasureRepetitionSpacing = 0.8;
         this.DisplacedNoteMargin = 0.1;
         this.MinNoteDistance = 2.0;
         this.SubMeasureXSpacingThreshold = 35;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -210,7 +210,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         //   without this the pickup measures were always too long.
 
         // add more than the original staffEntries scaling again: (removing it above makes it too short)
-        if (maxStaffEntries > 1) { // not necessary for only 1 StaffEntry
+        if (true || maxStaffEntries > 1) { // not necessary for only 1 StaffEntry
           minStaffEntriesWidth += maxStaffEntriesPlusAccidentals * staffEntryFactor * 1.5; // don't scale this for implicit measures
           // in fact overscale it, this needs a lot of space the more staffEntries (and modifiers like accidentals) there are
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -58,6 +58,7 @@ import { TabNote } from "../../VoiceData/TabNote";
 import { PlacementEnum } from "../../VoiceData/Expressions";
 import { GraphicalChordSymbolContainer } from "../GraphicalChordSymbolContainer";
 import { RehearsalExpression } from "../../VoiceData/Expressions/RehearsalExpression";
+import { SystemLinesEnum } from "../SystemLinesEnum";
 
 export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   /** space needed for a dash for lyrics spacing, calculated once */
@@ -209,8 +210,23 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         // it seems like this should be respected by staffEntries.length and preCaculateMinTotalWidth, but apparently not,
         //   without this the pickup measures were always too long.
 
+        let barlineSpacing: number = 0;
+        const measureListIndex: number = parentSourceMeasure.measureListIndex;
+        if (measureListIndex > 1) {
+          // only give this implicit measure more space if the previous one had a thick barline (e.g. repeat end)
+          for (const gMeasure of this.graphicalMusicSheet.MeasureList[measureListIndex - 1]) {
+            const endingBarStyleEnum: SystemLinesEnum = gMeasure?.parentSourceMeasure.endingBarStyleEnum;
+            if (endingBarStyleEnum === SystemLinesEnum.ThinBold ||
+                endingBarStyleEnum === SystemLinesEnum.DotsThinBold
+            ) {
+              barlineSpacing = 1.5;
+              break;
+            }
+          }
+        }
+        minStaffEntriesWidth += barlineSpacing;
         // add more than the original staffEntries scaling again: (removing it above makes it too short)
-        if (true || maxStaffEntries > 1) { // not necessary for only 1 StaffEntry
+        if (maxStaffEntries > 1) { // not necessary for only 1 StaffEntry
           minStaffEntriesWidth += maxStaffEntriesPlusAccidentals * staffEntryFactor * 1.5; // don't scale this for implicit measures
           // in fact overscale it, this needs a lot of space the more staffEntries (and modifiers like accidentals) there are
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -219,7 +219,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             if (endingBarStyleEnum === SystemLinesEnum.ThinBold ||
                 endingBarStyleEnum === SystemLinesEnum.DotsThinBold
             ) {
-              barlineSpacing = 1.5;
+              barlineSpacing = this.rules.PickupMeasureRepetitionSpacing;
               break;
             }
           }


### PR DESCRIPTION
before:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/33069673/191599248-f70a7ebb-f43a-486d-83d4-8b2f7e6bee3f.png">

after:
<img width="172" alt="image" src="https://user-images.githubusercontent.com/33069673/191599293-4e607c53-e348-4bef-8591-28616e953f3b.png">

visual diffs after aed4bba34190ca09709948953861b7cd474d7ce7:
[diff_implicit-spacing.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/9620019/diff_implicit-spacing.zip)
(only Mozart Clarinet Quintet taking very slightly more space, but giving the implicit measure a nice bit of additional space too)