### PR TITLE
Fix page bbox, fix PageRightMargin PageLeftMargin EngravingRules for RenderSingleHorizontalStaffline

### DIFF
--- a/src/MusicalScore/Graphical/BoundingBox.ts
+++ b/src/MusicalScore/Graphical/BoundingBox.ts
@@ -3,8 +3,6 @@ import {ArgumentOutOfRangeException} from "../Exceptions";
 import {PointF2D} from "../../Common/DataObjects/PointF2D";
 import {SizeF2D} from "../../Common/DataObjects/SizeF2D";
 import {RectangleF2D} from "../../Common/DataObjects/RectangleF2D";
-import { StaffLineActivitySymbol } from "./StaffLineActivitySymbol";
-import { EngravingRules } from "./EngravingRules";
 import { GraphicalObject } from "./GraphicalObject";
 
 /**
@@ -378,12 +376,7 @@ export class BoundingBox {
         for (let idx: number = 0, len: number = this.ChildElements.length; idx < len; ++idx) {
             const childElement: BoundingBox = this.ChildElements[idx];
             minTop = Math.min(minTop, childElement.relativePosition.y + childElement.borderTop);
-            if (!EngravingRules.FixStafflineBoundingBox || !(childElement.dataObject instanceof StaffLineActivitySymbol)) {
-                maxBottom = Math.max(maxBottom, childElement.relativePosition.y + childElement.borderBottom);
-                // TODO there's a problem with the bottom bounding box of many stafflines, often caused by StaffLineActivitySymbol,
-                // often leading to the page SVG canvas being unnecessarily long in y-direction. This seems to be remedied by this workaround.
-                // see #643
-            }
+            maxBottom = Math.max(maxBottom, childElement.relativePosition.y + childElement.borderBottom);
             minMarginTop = Math.min(minMarginTop, childElement.relativePosition.y + childElement.borderMarginTop);
             maxMarginBottom = Math.max(maxMarginBottom, childElement.relativePosition.y + childElement.borderMarginBottom);
         }

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -354,8 +354,6 @@ export class EngravingRules {
     // this is basically a WeakMap, except we save the id in the Note instead of using a WeakMap.
     public NoteToGraphicalNoteMapObjectCount: number = 0;
 
-    public static FixStafflineBoundingBox: boolean; // TODO temporary workaround
-
     /** The skyline and bottom-line batch calculation algorithm to use.
      *  Note that this can be overridden if AlwaysSetPreferredSkyBottomLineBackendAutomatically is true (which is the default).
      */
@@ -705,8 +703,6 @@ export class EngravingRules {
         this.NewPageAtXMLNewPageAttribute = false;
         this.RestoreCursorAfterRerender = true;
         this.StretchLastSystemLine = false;
-
-        EngravingRules.FixStafflineBoundingBox = false; // TODO temporary workaround
 
         this.PageFormat = PageFormat.UndefinedPageFormat; // default: undefined / 'infinite' height page, using the canvas'/container's width and height
         this.PageBackgroundColor = undefined; // default: transparent. half-transparent white: #FFFFFF88"

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -928,13 +928,14 @@ export abstract class MusicSheetCalculator {
                 musicSystem.PositionAndShape.RelativePosition =
                     new PointF2D(musicSystem.PositionAndShape.RelativePosition.x, musicSystem.PositionAndShape.RelativePosition.y - distance);
             }
-            for (let idx2: number = 0, len2: number = graphicalMusicPage.MusicSystems.length; idx2 < len2; ++idx2) {
-                const musicSystem: MusicSystem = graphicalMusicPage.MusicSystems[idx2];
-                for (let idx3: number = 0, len3: number = musicSystem.StaffLines.length; idx3 < len3; ++idx3) {
-                    const staffLine: StaffLine = musicSystem.StaffLines[idx3];
-                    staffLine.addActivitySymbolClickArea();
-                }
-            }
+            // add ActivitySymbolClickArea - currently unused, extends boundingbox of MusicSystem unnecessarily -> PageRightMargin 0 impossible
+            // for (let idx2: number = 0, len2: number = graphicalMusicPage.MusicSystems.length; idx2 < len2; ++idx2) {
+            //     const musicSystem: MusicSystem = graphicalMusicPage.MusicSystems[idx2];
+            //     for (let idx3: number = 0, len3: number = musicSystem.StaffLines.length; idx3 < len3; ++idx3) {
+            //         const staffLine: StaffLine = musicSystem.StaffLines[idx3];
+            //         staffLine.addActivitySymbolClickArea();
+            //     }
+            // }
 
             // calculate TopBottom Borders for all elements recursively
             //   necessary for composer label (page labels) for high notes in first system
@@ -2107,6 +2108,7 @@ export abstract class MusicSheetCalculator {
     protected calculatePageLabels(page: GraphicalMusicPage): void {
         if (this.rules.RenderSingleHorizontalStaffline) {
             page.PositionAndShape.BorderRight = page.PositionAndShape.Size.width;
+            //page.PositionAndShape.BorderRight = page.PositionAndShape.Size.width + this.rules.PageRightMargin;
             page.PositionAndShape.calculateBoundingBox();
             this.graphicalMusicSheet.ParentMusicSheet.pageWidth = page.PositionAndShape.Size.width;
         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSystem.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSystem.ts
@@ -25,6 +25,7 @@ export class VexFlowMusicSystem extends MusicSystem {
         const width: number = this.calcBracketsWidth();
         this.boundingBox.BorderLeft = -width;
         this.boundingBox.BorderMarginLeft = -width;
+        //this.boundingBox.BorderRight = this.rules.SystemRightMargin;
         this.boundingBox.XBordersHaveBeenSet = true;
 
         const topSkyBottomLineCalculator: SkyBottomLineCalculator = this.staffLines[0].SkyBottomLineCalculator;

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -282,7 +282,8 @@ export class OpenSheetMusicDisplay {
         // Set page width
         let width: number = this.container.offsetWidth;
         if (this.rules.RenderSingleHorizontalStaffline) {
-            width = this.graphic.MusicPages[0].PositionAndShape.Size.width * 10 * this.zoom;
+            width = (this.EngravingRules.PageLeftMargin + this.graphic.MusicPages[0].PositionAndShape.Size.width + this.EngravingRules.PageRightMargin)
+                * 10 * this.zoom;
             // this.container.style.width = width + "px";
             // console.log("width: " + width)
         }


### PR DESCRIPTION
Page bounding box fixed by not adding unused StaffActivitySymbol bounding boxes (see #643).
They made it so that PageRightMargin 0 was not possible: there was always extra white space to the right of the score.

EngravingRules.PageRightMargin and PageLeftMargin are now also effective for EngravingRules.RenderSingleHorizontalStaffline.

(you may have to adjust your settings if you use this option)

Setting all margins to 0, you can now actually get the minimum possible score/SVG/canvas size:
<img width="168" alt="image" src="https://user-images.githubusercontent.com/33069673/193062774-30ea4423-8cca-4050-9ee5-8e2f3cb1871a.png">

previous result (OSMD 1.5.7):
<img width="181" alt="image" src="https://user-images.githubusercontent.com/33069673/193063856-0ded39bb-fd6b-4630-bcdb-eebb00702aaa.png">

Settings used:
```js
osmd.EngravingRules.PageLeftMargin = 0;
osmd.EngravingRules.PageRightMargin = 0;
osmd.EngravingRules.RenderSingleHorizontalStaffline = true;
osmd.EngravingRules.RenderTitle = false;
osmd.EngravingRules.RenderPartNames = false;
osmd.EngravingRules.SystemLabelsRightMargin = 0;
osmd.EngravingRules.PageTopMargin = 0;
osmd.EngravingRules.PageBottomMargin = 0;
```

To enable horizontal scrolling:
http://localhost:8000/?horizontalScrolling=1

(for Canvas backend, you may want to set the right and left margin to at least 0.2 in some cases)

no visual regressions.