### PR TITLE
Improved lyrics handling

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1160,7 +1160,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   }
 
   protected handleVoiceEntryLyrics(voiceEntry: VoiceEntry, graphicalStaffEntry: GraphicalStaffEntry, lyricWords: LyricWord[]): void {
-    voiceEntry.LyricsEntries.forEach((key: number, lyricsEntry: LyricsEntry) => {
+    voiceEntry.LyricsEntries.forEach((key: string, lyricsEntry: LyricsEntry) => {
       const graphicalLyricEntry: GraphicalLyricEntry = new GraphicalLyricEntry(lyricsEntry,
                                                                                graphicalStaffEntry,
                                                                                this.rules.LyricsHeight,

--- a/src/MusicalScore/Instrument.ts
+++ b/src/MusicalScore/Instrument.ts
@@ -32,7 +32,7 @@ export class Instrument extends InstrumentalGroup {
     private hasChordSymbols: boolean = false;
     private playbackTranspose: number;
 
-    private lyricVersesNumbers: number[] = [];
+    private lyricVersesNumbers: string[] = [];
     private subInstruments: SubInstrument[] = [];
     private partAbbreviation: string;
 
@@ -57,10 +57,10 @@ export class Instrument extends InstrumentalGroup {
     public set HasChordSymbols(value: boolean) {
         this.hasChordSymbols = value;
     }
-    public get LyricVersesNumbers(): number[] {
+    public get LyricVersesNumbers(): string[] {
         return this.lyricVersesNumbers;
     }
-    public set LyricVersesNumbers(value: number[]) {
+    public set LyricVersesNumbers(value: string[]) {
         this.lyricVersesNumbers = value;
     }
     public get Name(): string {

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/LyricsReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/LyricsReader.ts
@@ -71,28 +71,9 @@ export class LyricsReader {
                                     syllabic = "middle";
                                 }
                             }
-                            let currentLyricVerseNumber: number = 1;
-                            let errorNumberParse1: boolean = false;
+                            let currentLyricVerseNumber: string = "1";
                             if (lyricNode.attributes() !== undefined && lyricNode.attribute("number")) {
-                                try {
-                                    currentLyricVerseNumber = parseInt(lyricNode.attribute("number").value, 10); // usually doesn't throw error, but returns NaN
-                                } catch (err) {
-                                    errorNumberParse1 = true;
-                                }
-                                errorNumberParse1 = errorNumberParse1 || isNaN(currentLyricVerseNumber);
-                                if (errorNumberParse1) {
-                                    try { // Sibelius format: "part1verse1"
-                                        const result: string[] = lyricNode.attribute("number").value.toLowerCase().split("verse");
-                                        if (result.length > 1) {
-                                            currentLyricVerseNumber = parseInt(result[1], 10);
-                                        }
-                                    } catch (err) {
-                                        const errorMsg: string =
-                                        ITextTranslation.translateText("ReaderErrorMessages/LyricVerseNumberError", "Invalid lyric verse number");
-                                        this.musicSheet.SheetErrors.pushMeasureError(errorMsg);
-                                        continue;
-                                    }
-                                }
+                                currentLyricVerseNumber = lyricNode.attribute("number").value;
                             }
                             let lyricsEntry: LyricsEntry = undefined;
                             if (syllabic === "single" || syllabic === "end") {
@@ -138,7 +119,7 @@ export class LyricsReader {
                                     }
                                 }
                                 // save in currentInstrument the verseNumber (only once)
-                                if (!currentVoiceEntry.ParentVoice.Parent.LyricVersesNumbers[currentLyricVerseNumber]) {
+                                if (!currentVoiceEntry.ParentVoice.Parent.LyricVersesNumbers.includes(currentLyricVerseNumber)) {
                                     currentVoiceEntry.ParentVoice.Parent.LyricVersesNumbers.push(currentLyricVerseNumber);
                                 }
                             }
@@ -150,9 +131,6 @@ export class LyricsReader {
                     continue;
                 }
             }
-            // Squash to unique numbers
-            currentVoiceEntry.ParentVoice.Parent.LyricVersesNumbers =
-            currentVoiceEntry.ParentVoice.Parent.LyricVersesNumbers.filter((lvn, index, self) => self.indexOf(lvn) === index);
         }
     }
 }

--- a/src/MusicalScore/VoiceData/Lyrics/LyricsEntry.ts
+++ b/src/MusicalScore/VoiceData/Lyrics/LyricsEntry.ts
@@ -1,8 +1,9 @@
 import {LyricWord} from "./LyricsWord";
 import {VoiceEntry} from "../VoiceEntry";
+import { FontStyles } from "../../../Common";
 
 export class LyricsEntry {
-    constructor(text: string, verseNumber: number, word: LyricWord, parent: VoiceEntry, syllableNumber: number = -1) {
+    constructor(text: string, verseNumber: string, word: LyricWord, parent: VoiceEntry, syllableNumber: number = -1) {
         this.text = text;
         this.word = word;
         this.parent = parent;
@@ -14,7 +15,7 @@ export class LyricsEntry {
     private text: string;
     private word: LyricWord;
     private parent: VoiceEntry;
-    private verseNumber: number;
+    private verseNumber: string;
     private syllableIndex: number;
     public extend: boolean;
 
@@ -34,11 +35,23 @@ export class LyricsEntry {
         this.parent = value;
     }
 
-    public get VerseNumber(): number {
+    public get VerseNumber(): string {
         return this.verseNumber;
     }
 
     public get SyllableIndex(): number {
         return this.syllableIndex;
+    }
+
+    public get IsTranslation(): boolean {
+        return this.VerseNumber.endsWith("translation");
+    }
+
+    public get IsChorus(): boolean {
+        return this.VerseNumber.startsWith("chorus");
+    }
+
+    public get FontStyle(): FontStyles {
+        return this.IsChorus || this.IsTranslation ? FontStyles.Italic : FontStyles.Regular;
     }
 }

--- a/src/MusicalScore/VoiceData/VoiceEntry.ts
+++ b/src/MusicalScore/VoiceData/VoiceEntry.ts
@@ -56,7 +56,7 @@ export class VoiceEntry {
     private graceSlur: boolean; // TODO grace slur system could be refined to be non-binary
     private articulations: Articulation[] = [];
     private technicalInstructions: TechnicalInstruction[] = [];
-    private lyricsEntries: Dictionary<number, LyricsEntry> = new Dictionary<number, LyricsEntry>();
+    private lyricsEntries: Dictionary<string, LyricsEntry> = new Dictionary<string, LyricsEntry>();
     /** The Arpeggio consisting of this VoiceEntry's notes. Undefined if no arpeggio exists. */
     private arpeggio: Arpeggio;
     private ornamentContainer: OrnamentContainer;
@@ -117,7 +117,7 @@ export class VoiceEntry {
     public get TechnicalInstructions(): TechnicalInstruction[] {
         return this.technicalInstructions;
     }
-    public get LyricsEntries(): Dictionary<number, LyricsEntry> {
+    public get LyricsEntries(): Dictionary<string, LyricsEntry> {
         return this.lyricsEntries;
     }
     public get Arpeggio(): Arpeggio {
@@ -230,9 +230,9 @@ export class VoiceEntry {
         }
         return false;
     }
-    public getVerseNumberForLyricEntry(lyricsEntry: LyricsEntry): number {
-        let verseNumber: number = 1;
-        this.lyricsEntries.forEach((key: number, value: LyricsEntry): void => {
+    public getVerseNumberForLyricEntry(lyricsEntry: LyricsEntry): string {
+        let verseNumber: string = "1";
+        this.lyricsEntries.forEach((key: string, value: LyricsEntry): void => {
             if (lyricsEntry === value) {
                 verseNumber = key;
             }


### PR DESCRIPTION
Changed the lyrics verse numbers from type number to type string according to the MusicXML specification. This fixes a lot of issues when importing MusicXML files that were created with Dorico or Sibelius. When using Dorico, refrain/chorus and translations are now recognized and rendered in italics. Issues #1271 and #1272 are fixed now and lyrics with non-numeric identifiers are no longer rendered on top of the staffs.