### PR TITLE
Pedal support

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -47,6 +47,7 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             "OSMD Function Test - Invisible Notes": "OSMD_function_test_invisible_notes.musicxml",
             "OSMD Function Test - Notehead Shapes": "OSMD_function_test_noteheadShapes.musicxml",
             "OSMD Function Test - Ornaments": "OSMD_function_test_Ornaments.xml",
+            "OSMD Function Test - Pedals": "OSMD_Function_Test_Pedals.musicxml",
             "OSMD Function Test - Selecting Measures To Draw": "OSMD_function_test_measuresToDraw_Beethoven_AnDieFerneGeliebte.xml",
             "OSMD Function Test - System and Page Breaks": "OSMD_Function_Test_System_and_Page_Breaks_4_pages.mxl",
             "OSMD Function Test - Tabulature": "OSMD_Function_Test_Tabulature_hayden_study_1.mxl",

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -328,6 +328,7 @@ export class EngravingRules {
     public RenderClefsAtBeginningOfStaffline: boolean;
     public RenderKeySignatures: boolean;
     public RenderTimeSignatures: boolean;
+    public RenderPedals: boolean;
     public DynamicExpressionMaxDistance: number;
     public DynamicExpressionSpacer: number;
     public ArticulationPlacementFromXML: boolean;
@@ -701,6 +702,7 @@ export class EngravingRules {
         this.RenderClefsAtBeginningOfStaffline = true;
         this.RenderKeySignatures = true;
         this.RenderTimeSignatures = true;
+        this.RenderPedals = true;
         this.ArticulationPlacementFromXML = true;
         this.BreathMarkDistance = 0.8;
         this.FingeringPosition = PlacementEnum.AboveOrBelow; // AboveOrBelow = correct bounding boxes

--- a/src/MusicalScore/Graphical/GraphicalPedal.ts
+++ b/src/MusicalScore/Graphical/GraphicalPedal.ts
@@ -1,0 +1,30 @@
+import {GraphicalObject} from "./GraphicalObject";
+import {BoundingBox} from "./BoundingBox";
+import {MusicSymbol} from "./MusicSymbol";
+import { Pedal } from "../VoiceData/Expressions/ContinuousExpressions/Pedal";
+
+/**
+ * The graphical counterpart of an [[Pedal]]
+ */
+export class GraphicalPedal extends GraphicalObject {
+
+    constructor(pedal: Pedal, parent: BoundingBox) {
+        super();
+        this.getPedal = pedal;
+        this.setSymbol();
+        this.PositionAndShape = new BoundingBox(this, parent);
+    }
+
+    public getPedal: Pedal;
+    public pedalSymbol: MusicSymbol;
+
+    private setSymbol(): void {
+        if (!this.getPedal.IsLine && this.getPedal.IsSign) {
+            this.pedalSymbol = MusicSymbol.PEDAL_SYMBOL;
+        } else if (this.getPedal.IsLine && this.getPedal.IsSign){
+            this.pedalSymbol = MusicSymbol.PEDAL_MIXED;
+        } else {//Bracket is default
+            this.pedalSymbol = MusicSymbol.PEDAL_BRACKET;
+        }
+    }
+}

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -661,6 +661,16 @@ export abstract class MusicSheetCalculator {
     }
 
     /**
+     * Calculate a single Pedal for a [[MultiExpression]].
+     * @param sourceMeasure
+     * @param multiExpression
+     * @param measureIndex
+     * @param staffIndex
+     */
+    protected abstract calculateSinglePedal(sourceMeasure: SourceMeasure, multiExpression: MultiExpression,
+        measureIndex: number, staffIndex: number): void;
+
+    /**
      * Calculate all the textual [[RepetitionInstruction]]s (e.g. dal segno) for a single [[SourceMeasure]].
      * @param repetitionInstruction
      * @param measureIndex
@@ -869,6 +879,10 @@ export abstract class MusicSheetCalculator {
             this.calculateExpressionAlignements();
             // calculate all OctaveShifts
             this.calculateOctaveShifts();
+            if (this.rules.RenderPedals) {
+                // calculate all Pedal Expressions
+                this.calculatePedals();
+            }
             // calcualte RepetitionInstructions (Dal Segno, Coda, etc)
             this.calculateWordRepetitionInstructions();
         }
@@ -3228,6 +3242,24 @@ export abstract class MusicSheetCalculator {
                     for (let k: number = 0; k < sourceMeasure.StaffLinkedExpressions[j].length; k++) {
                         if ((sourceMeasure.StaffLinkedExpressions[j][k].OctaveShiftStart)) {
                             this.calculateSingleOctaveShift(sourceMeasure, sourceMeasure.StaffLinkedExpressions[j][k], i, j);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private calculatePedals(): void {
+        for (let i: number = 0; i < this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length; i++) {
+            const sourceMeasure: SourceMeasure = this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures[i];
+            for (let j: number = 0; j < sourceMeasure.StaffLinkedExpressions.length; j++) {
+                if (!this.graphicalMusicSheet.MeasureList[i] || !this.graphicalMusicSheet.MeasureList[i][j]) {
+                    continue;
+                }
+                if (this.graphicalMusicSheet.MeasureList[i][j].ParentStaff.ParentInstrument.Visible) {
+                    for (let k: number = 0; k < sourceMeasure.StaffLinkedExpressions[j].length; k++) {
+                        if ((sourceMeasure.StaffLinkedExpressions[j][k].PedalStart)) {
+                            this.calculateSinglePedal(sourceMeasure, sourceMeasure.StaffLinkedExpressions[j][k], i, j);
                         }
                     }
                 }

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -388,6 +388,8 @@ export abstract class MusicSheetDrawer {
         }
         this.drawOctaveShifts(staffLine);
 
+        this.drawPedals(staffLine);
+
         this.drawExpressions(staffLine);
 
         if (this.skyLineVisible) {
@@ -446,6 +448,8 @@ export abstract class MusicSheetDrawer {
     protected drawOctaveShifts(staffLine: StaffLine): void {
         return;
     }
+
+    protected abstract drawPedals(staffLine: StaffLine): void;
 
     protected drawStaffLines(staffLine: StaffLine): void {
         if (staffLine.StaffLines) {

--- a/src/MusicalScore/Graphical/MusicSymbol.ts
+++ b/src/MusicalScore/Graphical/MusicSymbol.ts
@@ -83,5 +83,8 @@ export enum MusicSymbol {
     MIC,
     SNAP_PIZZICATO,
     NATURAL_HARMONIC,
-    EditPen
+    EditPen,
+    PEDAL_BRACKET,
+    PEDAL_MIXED,
+    PEDAL_SYMBOL
 }

--- a/src/MusicalScore/Graphical/StaffLine.ts
+++ b/src/MusicalScore/Graphical/StaffLine.ts
@@ -13,6 +13,7 @@ import { SkyBottomLineCalculator } from "./SkyBottomLineCalculator";
 import { GraphicalOctaveShift } from "./GraphicalOctaveShift";
 import { GraphicalSlur } from "./GraphicalSlur";
 import { AbstractGraphicalExpression } from "./AbstractGraphicalExpression";
+import { GraphicalPedal } from "./GraphicalPedal";
 
 /**
  * A StaffLine contains the [[Measure]]s in one line of the music sheet
@@ -168,6 +169,8 @@ export abstract class StaffLine extends GraphicalObject {
     public set OctaveShifts(value: GraphicalOctaveShift[]) {
         this.octaveShifts = value;
     }
+
+    public Pedals: GraphicalPedal[] = [];
 
     public get StaffHeight(): number {
         return this.staffHeight;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -59,6 +59,10 @@ import { PlacementEnum } from "../../VoiceData/Expressions";
 import { GraphicalChordSymbolContainer } from "../GraphicalChordSymbolContainer";
 import { RehearsalExpression } from "../../VoiceData/Expressions/RehearsalExpression";
 import { SystemLinesEnum } from "../SystemLinesEnum";
+import { Pedal } from "../../VoiceData/Expressions/ContinuousExpressions/Pedal";
+import { VexFlowPedal } from "./VexFlowPedal";
+import { MusicSymbol } from "../MusicSymbol";
+import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
 
 export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   /** space needed for a dash for lyrics spacing, calculated once */
@@ -1007,6 +1011,326 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     } else {
       log.warn("End measure or staffLines for octave shift are undefined! This should not happen!");
     }
+  }
+
+  protected calculateSinglePedal(sourceMeasure: SourceMeasure, multiExpression: MultiExpression, measureIndex: number, staffIndex: number): void {
+    // calculate absolute Timestamp and startStaffLine (and EndStaffLine if needed)
+    const pedal: Pedal = multiExpression.PedalStart;
+
+    const startTimeStamp: Fraction = pedal.ParentStartMultiExpression.Timestamp;
+    const endTimeStamp: Fraction = pedal.ParentEndMultiExpression?.Timestamp;
+
+    const minMeasureToDrawIndex: number = this.rules.MinMeasureToDrawIndex;
+    const maxMeasureToDrawIndex: number = this.rules.MaxMeasureToDrawIndex;
+
+    let startStaffLine: StaffLine = this.graphicalMusicSheet.MeasureList[measureIndex][staffIndex].ParentStaffLine;
+    if (!startStaffLine) { // fix for rendering range set. all of these can probably be done cleaner.
+      startStaffLine = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex].ParentStaffLine;
+    }
+    let endMeasure: GraphicalMeasure = undefined;
+    if (pedal.ParentEndMultiExpression) {
+      endMeasure = this.graphicalMusicSheet.getGraphicalMeasureFromSourceMeasureAndIndex(pedal.ParentEndMultiExpression.SourceMeasureParent,
+                                                                                          staffIndex);
+    } else {
+      //return; // also possible: don't handle faulty pedal without end
+      endMeasure = this.graphicalMusicSheet.getLastGraphicalMeasureFromIndex(staffIndex, true); // get last rendered measure
+    }
+    if (endMeasure.MeasureNumber > maxMeasureToDrawIndex + 1) { //  ends in measure not rendered
+      endMeasure = this.graphicalMusicSheet.getLastGraphicalMeasureFromIndex(staffIndex, true);
+    }
+    let startMeasure: GraphicalMeasure = undefined;
+    if (pedal.ParentEndMultiExpression) {
+      startMeasure = this.graphicalMusicSheet.getGraphicalMeasureFromSourceMeasureAndIndex(pedal.ParentStartMultiExpression.SourceMeasureParent,
+        staffIndex);
+    } else {
+      startMeasure = this.graphicalMusicSheet.getGraphicalMeasureFromSourceMeasureAndIndex(
+        pedal.ParentStartMultiExpression.SourceMeasureParent,
+        staffIndex);
+      if (!startMeasure) {
+        startMeasure = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex]; // first rendered measure
+      }
+      //console.log("no end multi expression for start measure " + startMeasure.MeasureNumber);
+    }
+    if (startMeasure.MeasureNumber < minMeasureToDrawIndex + 1) { //  starts before range of measures selected to render
+      startMeasure = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex]; // first rendered measure
+    }
+
+    if (startMeasure.parentSourceMeasure.measureListIndex < minMeasureToDrawIndex ||
+        startMeasure.parentSourceMeasure.measureListIndex > maxMeasureToDrawIndex ||
+        endMeasure.parentSourceMeasure.measureListIndex < minMeasureToDrawIndex ||
+        endMeasure.parentSourceMeasure.measureListIndex > maxMeasureToDrawIndex) {
+      // completely out of drawing range, don't draw anything
+      return;
+    }
+
+    let endStaffLine: StaffLine = endMeasure.ParentStaffLine;
+    if (!endStaffLine) {
+      endStaffLine = startStaffLine;
+    }
+    if (endMeasure && startStaffLine && endStaffLine) {
+      let openEnd: boolean = false;
+      if (startStaffLine !== endStaffLine) {
+        openEnd = true;
+      }
+      // calculate GraphicalPedal and RelativePositions
+      const graphicalPedal: VexFlowPedal = new VexFlowPedal(pedal, startStaffLine.PositionAndShape, false, openEnd);
+      // calculate RelativePosition
+      let startStaffEntry: GraphicalStaffEntry = startMeasure.findGraphicalStaffEntryFromTimestamp(startTimeStamp);
+      if (!startStaffEntry) { // fix for rendering range set
+        startStaffEntry = startMeasure.staffEntries[0];
+      }
+      let endStaffEntry: GraphicalStaffEntry = endMeasure.findGraphicalStaffEntryFromTimestamp(endTimeStamp);
+      if (!endStaffEntry) { // fix for rendering range set
+        endStaffEntry = endMeasure.staffEntries[endMeasure.staffEntries.length - 1];
+        // TODO can be undefined if no notes in end measure
+      }
+      if (!graphicalPedal.setStartNote(startStaffEntry)){
+        return;
+      }
+
+      if (endStaffLine !== startStaffLine) {
+        if(graphicalPedal.pedalSymbol === MusicSymbol.PEDAL_SYMBOL){
+          graphicalPedal.setEndNote(endStaffEntry);
+          graphicalPedal.setEndMeasure(endMeasure);
+          graphicalPedal.ReleaseText = " ";
+          graphicalPedal.CalculateBoundingBox();
+          this.calculatePedalSkyBottomLine(graphicalPedal.startVfVoiceEntry, graphicalPedal.endVfVoiceEntry, graphicalPedal, startStaffLine);
+
+          const nextPedalFirstMeasure: GraphicalMeasure = endStaffLine.Measures[0];
+          // pedal starts on the first measure
+          const nextPedal: VexFlowPedal = new VexFlowPedal(pedal, nextPedalFirstMeasure.PositionAndShape);
+          const firstNote: GraphicalStaffEntry = nextPedalFirstMeasure.staffEntries[0];
+          if(!nextPedal.setStartNote(firstNote)){
+            return;
+          }
+          nextPedal.setEndNote(endStaffEntry);
+          graphicalPedal.setEndMeasure(endMeasure);
+          endStaffLine.Pedals.push(nextPedal);
+          nextPedal.CalculateBoundingBox();
+          nextPedal.DepressText = " ";
+          this.calculatePedalSkyBottomLine(nextPedal.startVfVoiceEntry, nextPedal.endVfVoiceEntry, nextPedal, endStaffLine);
+        } else {
+          let lastMeasureOfFirstShift: GraphicalMeasure = startStaffLine.Measures[startStaffLine.Measures.length - 1];
+          if (lastMeasureOfFirstShift === undefined) { // TODO handle this case correctly (when drawUpToMeasureNumber etc set)
+            lastMeasureOfFirstShift = endMeasure;
+          }
+          const lastNoteOfFirstShift: GraphicalStaffEntry = lastMeasureOfFirstShift.staffEntries[lastMeasureOfFirstShift.staffEntries.length - 1];
+          graphicalPedal.setEndNote(lastNoteOfFirstShift);
+          graphicalPedal.setEndMeasure(endMeasure);
+          graphicalPedal.ChangeEnd = false;
+
+          const systemsInBetweenCount: number = endStaffLine.ParentMusicSystem.Id - startStaffLine.ParentMusicSystem.Id;
+          if (systemsInBetweenCount > 0) {
+            //Loop through the stafflines in between to the end
+            let currentCount: number = 1;
+            for (let i: number = startStaffLine.ParentMusicSystem.Id; i < endStaffLine.ParentMusicSystem.Id; i++) {
+              const nextPedalMusicSystem: MusicSystem = this.musicSystems[i + 1];
+              const nextPedalStaffline: StaffLine = nextPedalMusicSystem.StaffLines[staffIndex];
+              const nextPedalFirstMeasure: GraphicalMeasure = nextPedalStaffline.Measures[0];
+              let nextOpenEnd: boolean = false;
+              let nextChangeEndFromParent: boolean = false;
+              if (currentCount < systemsInBetweenCount) {
+                nextOpenEnd = true;
+              } else {
+                nextChangeEndFromParent = true;
+              }
+              currentCount++;
+              // pedal starts on the first measure
+              const nextPedal: VexFlowPedal = new VexFlowPedal(pedal, nextPedalFirstMeasure.PositionAndShape, true, nextOpenEnd);
+              nextPedal.ChangeBegin = false;
+              if(nextChangeEndFromParent){
+                nextPedal.ChangeEnd = pedal.ChangeEnd;
+              } else {
+                nextPedal.ChangeEnd = false;
+              }
+              let nextPedalLastMeasure: GraphicalMeasure = nextPedalStaffline.Measures[nextPedalStaffline.Measures.length - 1];
+              const firstNote: GraphicalStaffEntry = nextPedalFirstMeasure.staffEntries[0];
+              let lastNote: GraphicalStaffEntry = nextPedalLastMeasure.staffEntries[nextPedalLastMeasure.staffEntries.length - 1];
+
+              //If the end measure's staffline is the ending staffline, this endMeasure is the end of the pedal
+              if (endMeasure.ParentStaffLine === nextPedalStaffline) {
+                nextPedalLastMeasure = endMeasure;
+                lastNote = endStaffEntry;
+              }
+              if(!nextPedal.setStartNote(firstNote)){
+                break;
+              }
+              nextPedal.setEndNote(lastNote);
+              graphicalPedal.setEndMeasure(endMeasure);
+              nextPedalStaffline.Pedals.push(nextPedal);
+              nextPedal.CalculateBoundingBox();
+              this.calculatePedalSkyBottomLine(nextPedal.startVfVoiceEntry, nextPedal.endVfVoiceEntry, nextPedal, nextPedalStaffline);
+            }
+          }
+          graphicalPedal.CalculateBoundingBox();
+          this.calculatePedalSkyBottomLine(graphicalPedal.startVfVoiceEntry, graphicalPedal.endVfVoiceEntry, graphicalPedal, startStaffLine);
+        }
+      } else {
+        graphicalPedal.setEndNote(endStaffEntry);
+        graphicalPedal.setEndMeasure(endMeasure);
+        graphicalPedal.CalculateBoundingBox();
+        this.calculatePedalSkyBottomLine(graphicalPedal.startVfVoiceEntry, graphicalPedal.endVfVoiceEntry, graphicalPedal, startStaffLine);
+      }
+      startStaffLine.Pedals.push(graphicalPedal);
+    } else {
+      log.warn("End measure or staffLines for pedal are undefined! This should not happen!");
+    }
+  }
+
+  private calculatePedalSkyBottomLine(startVfVoiceEntry: VexFlowVoiceEntry, endVfVoiceEntry: VexFlowVoiceEntry,
+    vfPedal: VexFlowPedal, parentStaffline: StaffLine): void {
+      let endBbox: BoundingBox = endVfVoiceEntry?.PositionAndShape;
+      if (!endBbox) {
+        endBbox = vfPedal.endMeasure.PositionAndShape;
+      }
+      //Just for shorthand. Easier readability below
+      const PEDAL_STYLES_ENUM: any = Vex.Flow.PedalMarking.Styles;
+      const pedalMarking: any = vfPedal.getPedalMarking();
+      //VF adds 3 lines to whatever the pedal line is set to.
+      //VF also measures from the bottom line, whereas our bottom line is from the top staff line
+      const yLineForPedalMarking: number = (pedalMarking.line + 3 + (parentStaffline.StaffLines.length - 1));
+      //VF Uses a margin offset for rendering. Take this into account
+      const pedalMarkingMarginXOffset: number = pedalMarking.render_options.text_margin_right / 10;
+      //TODO: Most of this should be in the bounding box calculation
+      let startX: number = startVfVoiceEntry.PositionAndShape.AbsolutePosition.x - pedalMarkingMarginXOffset;
+
+      if (pedalMarking.style === PEDAL_STYLES_ENUM.MIXED ||
+          pedalMarking.style === PEDAL_STYLES_ENUM.MIXED_OPEN_END ||
+          pedalMarking.style === PEDAL_STYLES_ENUM.TEXT) {
+        //Accomodate the Ped. sign
+        startX -= 1;
+      }
+      let stopX: number = undefined;
+      let footroom: number = (parentStaffline.StaffLines.length - 1);
+      //Find the highest foot room in our staffline
+      for (const otherPedal of parentStaffline.Pedals) {
+        const vfOtherPedal: VexFlowPedal = otherPedal as VexFlowPedal;
+        const otherPedalMarking: any = vfOtherPedal.getPedalMarking();
+        const yLineForOtherPedalMarking: number = (otherPedalMarking.line + 3 + (parentStaffline.StaffLines.length - 1));
+        footroom = Math.max(yLineForOtherPedalMarking, footroom);
+      }
+      //We have the two seperate symbols, with two bounding boxes
+      if (vfPedal.EndSymbolPositionAndShape) {
+        const symbolHalfHeight: number = pedalMarking.render_options.glyph_point_size / 20;
+        //Width of the Ped. symbol
+        stopX = startX + 3.4;
+        const startX2: number = endBbox.AbsolutePosition.x - pedalMarkingMarginXOffset;
+        //Width of * symbol
+        const stopX2: number = startX2 + 1.5;
+
+        footroom = Math.max(parentStaffline.SkyBottomLineCalculator.getBottomLineMaxInRange(startX, stopX), footroom);
+        footroom = Math.max(yLineForPedalMarking + symbolHalfHeight * 2, footroom);
+        const footroom2: number = parentStaffline.SkyBottomLineCalculator.getBottomLineMaxInRange(startX2, stopX2);
+        //If Depress text is set, means we are not rendering the begin label (we are just rendering the end one)
+        if (!vfPedal.DepressText) {
+          footroom = Math.max(footroom, footroom2);
+        }
+        vfPedal.setLine(footroom - 3 - (parentStaffline.StaffLines.length - 1));
+        parentStaffline.SkyBottomLineCalculator.updateBottomLineInRange(startX, stopX, footroom + symbolHalfHeight);
+        parentStaffline.SkyBottomLineCalculator.updateBottomLineInRange(startX2, stopX2, footroom + symbolHalfHeight);
+      } else {
+        const bracketHeight: number = pedalMarking.render_options.bracket_height / 10;
+
+        if(pedalMarking.EndsStave){
+          if(endVfVoiceEntry){
+            stopX = endVfVoiceEntry.parentStaffEntry.parentMeasure.PositionAndShape.AbsolutePosition.x +
+              endVfVoiceEntry.parentStaffEntry.parentMeasure.PositionAndShape.Size.width - pedalMarkingMarginXOffset;
+
+          } else {
+            stopX = endBbox.AbsolutePosition.x + endBbox.Size.width;
+          }
+        } else {
+          switch (pedalMarking.style) {
+            case PEDAL_STYLES_ENUM.BRACKET_OPEN_END:
+            case PEDAL_STYLES_ENUM.BRACKET_OPEN_BOTH:
+            case PEDAL_STYLES_ENUM.MIXED_OPEN_END:
+              stopX = endBbox.AbsolutePosition.x + endBbox.BorderRight - pedalMarkingMarginXOffset;
+            break;
+            default:
+              stopX = endBbox.AbsolutePosition.x + endBbox.BorderLeft - pedalMarkingMarginXOffset;
+            break;
+          }
+        }
+        //Take into account in-staff clefs associated with the staff entry (they modify the bounding box position)
+        const vfClefBefore: Vex.Flow.ClefNote = (endVfVoiceEntry?.parentStaffEntry as VexFlowStaffEntry)?.vfClefBefore;
+        if (vfClefBefore) {
+          const clefWidth: number = vfClefBefore.getWidth() / 10;
+          stopX += clefWidth;
+        }
+
+        footroom = Math.max(parentStaffline.SkyBottomLineCalculator.getBottomLineMaxInRange(startX, stopX), footroom);
+        if (footroom === Infinity) { // will cause Vexflow error
+          return;
+        }
+        //Whatever is currently lower - the set render height of the begin vf stave, the set render height of the end vf stave,
+        //or the bottom line. Use that as the render height of both staves
+        footroom = Math.max(footroom, yLineForPedalMarking + bracketHeight);
+        vfPedal.setLine(footroom - 3 - (parentStaffline.StaffLines.length - 1));
+        if (startX > stopX) { // TODO hotfix for skybottomlinecalculator after pedal no endNote fix
+          const newStart: number = stopX;
+          stopX = startX;
+          startX = newStart;
+        }
+        parentStaffline.SkyBottomLineCalculator.updateBottomLineInRange(startX, stopX, footroom + bracketHeight);
+      }
+      //If our current pedal is below the other pedals in this staffline, set them all to this height
+      for (const otherPedal of parentStaffline.Pedals) {
+        const vfOtherPedal: VexFlowPedal = otherPedal as VexFlowPedal;
+        const otherPedalMarking: any = vfOtherPedal.getPedalMarking();
+        const yLineForOtherPedalMarking: number = (otherPedalMarking.line + 3 + (parentStaffline.StaffLines.length - 1));
+        //Only do these changes if current footroom is higher
+        if(footroom > yLineForOtherPedalMarking) {
+          const otherPedalMarkingMarginXOffset: number = otherPedalMarking.render_options.text_margin_right / 10;
+          let otherPedalStartX: number = vfOtherPedal.startVfVoiceEntry.PositionAndShape.AbsolutePosition.x - otherPedalMarkingMarginXOffset;
+          let otherPedalStopX: number = undefined;
+          vfOtherPedal.setLine(footroom - 3 - (parentStaffline.StaffLines.length - 1));
+          let otherPedalEndBBox: BoundingBox = vfOtherPedal.endVfVoiceEntry?.PositionAndShape;
+          if (!otherPedalEndBBox) {
+            otherPedalEndBBox = vfOtherPedal.endMeasure.PositionAndShape;
+          }
+          if (vfOtherPedal.EndSymbolPositionAndShape) {
+            const otherSymbolHalfHeight: number = pedalMarking.render_options.glyph_point_size / 20;
+            //Width of the Ped. symbol
+            otherPedalStopX = otherPedalStartX + 3.4;
+            const otherPedalStartX2: number = otherPedalEndBBox.AbsolutePosition.x - otherPedalMarkingMarginXOffset;
+            //Width of * symbol
+            const otherPedalStopX2: number = otherPedalStartX2 + 1.5;
+            parentStaffline.SkyBottomLineCalculator.updateBottomLineInRange(otherPedalStartX, otherPedalStopX, footroom + otherSymbolHalfHeight);
+            parentStaffline.SkyBottomLineCalculator.updateBottomLineInRange(otherPedalStartX2, otherPedalStopX2, footroom + otherSymbolHalfHeight);
+          } else {
+            const otherPedalBracketHeight: number = otherPedalMarking.render_options.bracket_height / 10;
+
+            if(otherPedalMarking.EndsStave){
+                otherPedalStopX = otherPedalEndBBox.AbsolutePosition.x + otherPedalEndBBox.Size.width - otherPedalMarkingMarginXOffset;
+            } else {
+              switch (pedalMarking.style) {
+                case PEDAL_STYLES_ENUM.BRACKET_OPEN_END:
+                case PEDAL_STYLES_ENUM.BRACKET_OPEN_BOTH:
+                case PEDAL_STYLES_ENUM.MIXED_OPEN_END:
+                  otherPedalStopX = otherPedalEndBBox.AbsolutePosition.x + otherPedalEndBBox.BorderRight - otherPedalMarkingMarginXOffset;
+                break;
+                default:
+                  otherPedalStopX = otherPedalEndBBox.AbsolutePosition.x + otherPedalEndBBox.BorderLeft - otherPedalMarkingMarginXOffset;
+                break;
+              }
+            }
+            //Take into account in-staff clefs associated with the staff entry (they modify the bounding box position)
+            const vfOtherClefBefore: Vex.Flow.ClefNote = (vfOtherPedal.endVfVoiceEntry?.parentStaffEntry as VexFlowStaffEntry)?.vfClefBefore;
+            if (vfOtherClefBefore) {
+              const otherClefWidth: number = vfOtherClefBefore.getWidth() / 10;
+              otherPedalStopX += otherClefWidth;
+            }
+            if (otherPedalStartX > otherPedalStopX) {
+              // TODO this shouldn't happen, though this fixes the SkyBottomLineCalculator error for now (startIndex needs to be <= endIndex)
+              // switch startX and stopX
+              const otherStartX: number = otherPedalStartX;
+              otherPedalStartX = otherPedalStopX;
+              otherPedalStopX = otherStartX;
+            }
+            parentStaffline.SkyBottomLineCalculator.updateBottomLineInRange(otherPedalStartX, otherPedalStopX, footroom + otherPedalBracketHeight);
+          }
+        }
+      }
   }
 
   private calculateOctaveShiftSkyBottomLine(startStaffEntry: GraphicalStaffEntry, endStaffEntry: GraphicalStaffEntry,

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -29,6 +29,7 @@ import { DrawingParameters } from "../DrawingParameters";
 import { GraphicalMusicPage } from "../GraphicalMusicPage";
 import { GraphicalMusicSheet } from "../GraphicalMusicSheet";
 import { GraphicalUnknownExpression } from "../GraphicalUnknownExpression";
+import { VexFlowPedal } from "./VexFlowPedal";
 
 /**
  * This is a global constant which denotes the height in pixels of the space between two lines of the stave
@@ -365,6 +366,19 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
                 } catch (ex) {
                     log.warn(ex);
                 }
+            }
+        }
+    }
+
+    protected drawPedals(staffLine: StaffLine): void {
+        for (const graphicalPedal of staffLine.Pedals) {
+            if (graphicalPedal) {
+                const vexFlowPedal: VexFlowPedal = graphicalPedal as VexFlowPedal;
+                const ctx: Vex.IRenderContext = this.backend.getContext();
+                const pedalMarking: Vex.Flow.PedalMarking = vexFlowPedal.getPedalMarking();
+                (pedalMarking as any).render_options.color = this.rules.DefaultColorMusic;
+                pedalMarking.setContext(ctx);
+                pedalMarking.draw();
             }
         }
     }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowPedal.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowPedal.ts
@@ -1,0 +1,140 @@
+import Vex from "vexflow";
+import { BoundingBox } from "../BoundingBox";
+import { GraphicalStaffEntry } from "../GraphicalStaffEntry";
+import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
+import { GraphicalPedal } from "../GraphicalPedal";
+import { Pedal } from "../../VoiceData/Expressions/ContinuousExpressions/Pedal";
+import { MusicSymbol } from "../MusicSymbol";
+import { GraphicalMeasure } from "../GraphicalMeasure";
+import { VexFlowMeasure } from "./VexFlowMeasure";
+/**
+ * The vexflow adaptation of a pedal marking
+ */
+export class VexFlowPedal extends GraphicalPedal {
+    /** Defines the note where the pedal starts */
+    public startNote: Vex.Flow.StemmableNote;
+    /** Defines the note where the pedal ends */
+    public endNote: Vex.Flow.StemmableNote;
+    private vfStyle: Vex.Flow.PedalMarking.Styles = Vex.Flow.PedalMarking.Styles.BRACKET;
+    public DepressText: string;
+    public ReleaseText: string;
+    public startVfVoiceEntry: VexFlowVoiceEntry;
+    public endVfVoiceEntry: VexFlowVoiceEntry;
+    public endMeasure: GraphicalMeasure;
+    public ChangeBegin: boolean = false;
+    public ChangeEnd: boolean = false;
+    private line: number = -3;
+
+    public EndSymbolPositionAndShape: BoundingBox = undefined;
+    /**
+     * Create a new vexflow pedal marking
+     * @param pedal the object read by the ExpressionReader
+     * @param parent the bounding box of the parent
+     */
+    constructor(pedal: Pedal, parent: BoundingBox, openBegin: boolean = false, openEnd: boolean = false) {
+        super(pedal, parent);
+        this.ChangeBegin = pedal.ChangeBegin;
+        this.ChangeEnd = pedal.ChangeEnd;
+        switch (this.pedalSymbol) {
+            case MusicSymbol.PEDAL_SYMBOL:
+                //This renders the pedal symbols in VF.
+                this.vfStyle = Vex.Flow.PedalMarking.Styles.TEXT;
+                this.EndSymbolPositionAndShape = new BoundingBox(this, parent);
+            break;
+            case MusicSymbol.PEDAL_MIXED:
+                if (openBegin && openEnd) {
+                    this.vfStyle = (Vex.Flow.PedalMarking.Styles as any).BRACKET_OPEN_BOTH;
+                } else if (openBegin) {
+                    this.vfStyle = (Vex.Flow.PedalMarking.Styles as any).BRACKET_OPEN_BEGIN;
+                } else if (openEnd) {
+                    this.vfStyle = (Vex.Flow.PedalMarking.Styles as any).MIXED_OPEN_END;
+                } else {
+                    this.vfStyle = Vex.Flow.PedalMarking.Styles.MIXED;
+                }
+            break;
+            case MusicSymbol.PEDAL_BRACKET:
+            default:
+                if (openBegin && openEnd) {
+                    this.vfStyle = (Vex.Flow.PedalMarking.Styles as any).BRACKET_OPEN_BOTH;
+                } else if (openBegin) {
+                    this.vfStyle = (Vex.Flow.PedalMarking.Styles as any).BRACKET_OPEN_BEGIN;
+                } else if (openEnd) {
+                    this.vfStyle = (Vex.Flow.PedalMarking.Styles as any).BRACKET_OPEN_END;
+                } else {
+                    this.vfStyle = Vex.Flow.PedalMarking.Styles.BRACKET;
+                }
+            break;
+        }
+    }
+
+    /**
+     * Set a start note using a staff entry
+     * @param graphicalStaffEntry the staff entry that holds the start note
+     */
+    public setStartNote(graphicalStaffEntry: GraphicalStaffEntry): boolean {
+        if(!graphicalStaffEntry){
+            return false;
+        }
+        for (const gve of graphicalStaffEntry.graphicalVoiceEntries) {
+            const vve: VexFlowVoiceEntry = (gve as VexFlowVoiceEntry);
+            if (vve?.vfStaveNote) {
+                this.startNote = vve.vfStaveNote;
+                this.startVfVoiceEntry = vve;
+                return true;
+            }
+        }
+        return false; // couldn't find a startNote
+    }
+
+    /**
+     * Set an end note using a staff entry
+     * @param graphicalStaffEntry the staff entry that holds the end note
+     */
+    public setEndNote(graphicalStaffEntry: GraphicalStaffEntry): boolean {
+        // this is duplicate code from setStartNote, but if we make one general method, we add a lot of branching.
+        if (!graphicalStaffEntry) {
+            return false;
+        }
+        for (const gve of graphicalStaffEntry.graphicalVoiceEntries) {
+            const vve: VexFlowVoiceEntry = (gve as VexFlowVoiceEntry);
+            if (vve?.vfStaveNote) {
+                this.endNote = vve.vfStaveNote;
+                this.endVfVoiceEntry = vve;
+                return true;
+            }
+        }
+        return false; // couldn't find an endNote
+    }
+
+    public setEndMeasure(graphicalMeasure: GraphicalMeasure): void {
+        this.endMeasure = graphicalMeasure;
+    }
+
+    public CalculateBoundingBox(): void {
+        //TODO?
+    }
+
+    public setLine(line: number): void {
+        this.line = line;
+    }
+    /**
+     * Get the actual vexflow Pedal Marking used for drawing
+     */
+    public getPedalMarking(): Vex.Flow.PedalMarking {
+        const pedalMarking: Vex.Flow.PedalMarking = new Vex.Flow.PedalMarking([this.startNote, this.endNote]);
+        if (this.endMeasure) {
+            (pedalMarking as any).setEndStave((this.endMeasure as VexFlowMeasure).getVFStave());
+        }
+        pedalMarking.setStyle(this.vfStyle);
+        pedalMarking.setLine(this.line);
+        pedalMarking.setCustomText(this.DepressText, this.ReleaseText);
+        //If our end note is at the end of a stave, set that value
+        if(this.endVfVoiceEntry?.parentStaffEntry === this.endVfVoiceEntry?.parentStaffEntry?.parentMeasure?.staffEntries.last() ||
+        !this.endVfVoiceEntry){
+                (pedalMarking as any).EndsStave = true;
+        }
+        (pedalMarking as any).ChangeBegin = this.ChangeBegin;
+        (pedalMarking as any).ChangeEnd = this.ChangeEnd;
+        return pedalMarking;
+    }
+}

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -538,6 +538,12 @@ export class InstrumentReader {
                );
                expressionReader.addOctaveShift(xmlNode, this.currentMeasure, previousFraction.clone());
              }
+             if (directionTypeNode.element("pedal")) {
+              expressionReader.readExpressionParameters(
+                xmlNode, this.instrument, this.divisions, currentFraction, previousFraction, this.currentMeasure.MeasureNumber, true
+              );
+              expressionReader.addPedalMarking(xmlNode, this.currentMeasure, previousFraction.clone());
+             }
              expressionReader.readExpressionParameters(
                xmlNode, this.instrument, this.divisions, currentFraction, previousFraction, this.currentMeasure.MeasureNumber, false
              );

--- a/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/Pedal.ts
+++ b/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/Pedal.ts
@@ -1,0 +1,23 @@
+import { MultiExpression } from "../MultiExpression";
+
+export class Pedal {
+    constructor(line: boolean = false, sign: boolean = true) {
+        this.line = line;
+        this.sign = sign;
+    }
+
+    private line: boolean;
+    private sign: boolean;
+    public StaffNumber: number;
+    public ParentStartMultiExpression: MultiExpression;
+    public ParentEndMultiExpression: MultiExpression;
+    public ChangeEnd: boolean = false;
+    public ChangeBegin: boolean = false;
+
+    public get IsLine(): boolean {
+        return this.line;
+    }
+    public get IsSign(): boolean {
+        return this.sign;
+    }
+}

--- a/src/MusicalScore/VoiceData/Expressions/MultiExpression.ts
+++ b/src/MusicalScore/VoiceData/Expressions/MultiExpression.ts
@@ -8,6 +8,7 @@ import {UnknownExpression} from "./UnknownExpression";
 import {AbstractExpression} from "./AbstractExpression";
 import {PlacementEnum} from "./AbstractExpression";
 import { FontStyles } from "../../../Common/Enums/FontStyles";
+import { Pedal } from "./ContinuousExpressions/Pedal";
 
 export class MultiExpression {
 
@@ -30,6 +31,8 @@ export class MultiExpression {
     private combinedExpressionsText: string;
     private octaveShiftStart: OctaveShift;
     private octaveShiftEnd: OctaveShift;
+    public PedalStart: Pedal;
+    public PedalEnd: Pedal;
 
     public get SourceMeasureParent(): SourceMeasure {
         return this.sourceMeasure;

--- a/src/VexFlowPatch/readme.txt
+++ b/src/VexFlowPatch/readme.txt
@@ -32,6 +32,9 @@ check for gracenotegroup.spacing set, to allow e.g. spacing = 0 by default.
 keysignature.js (merged vexflow 4):
 open group to get SVG group+class for key signature
 
+pedalmarking.js (custom addition):
+Add rendering options for pedals that break across systems.
+
 renderer.js (vexflow4: need to check if possible):
 CanvasContext: getContext(): use willReadFrequently option for marginal performance potential,
 and for preventing chrome warning (#1242)

--- a/src/VexFlowPatch/src/pedalmarking.js
+++ b/src/VexFlowPatch/src/pedalmarking.js
@@ -1,0 +1,367 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+//
+// ## Description
+//
+// This file implements different types of pedal markings. These notation
+// elements indicate to the performer when to depress and release the a pedal.
+//
+// In order to create "Sostenuto", and "una corda" markings, you must set
+// custom text for the release/depress pedal markings.
+
+import { Vex } from './vex';
+import { Element } from './element';
+import { Glyph } from './glyph';
+import { StaveModifier } from './stavemodifier';
+
+// To enable logging for this class. Set `Vex.Flow.PedalMarking.DEBUG` to `true`.
+function L(...args) { if (PedalMarking.DEBUG) Vex.L('Vex.Flow.PedalMarking', args); }
+
+// Draws a pedal glyph with the provided `name` on a rendering `context`
+// at the coordinates `x` and `y. Takes into account the glyph data
+// coordinate shifts.
+function drawPedalGlyph(name, context, x, y, point) {
+  const glyph_data = PedalMarking.GLYPHS[name];
+  const glyph = new Glyph(glyph_data.code, point);
+  glyph.render(context, x + glyph_data.x_shift, y + glyph_data.y_shift);
+}
+
+export class PedalMarking extends Element {
+  // Glyph data
+  static get GLYPHS() {
+    return {
+      'pedal_depress': {
+        code: 'v36',
+        x_shift: -10,
+        y_shift: 0,
+      },
+      'pedal_release': {
+        code: 'v5d',
+        x_shift: -2,
+        y_shift: 3,
+      },
+    };
+  }
+
+  static get Styles() {
+    return {
+      TEXT: 1,
+      BRACKET: 2,
+      MIXED: 3,
+      MIXED_OPEN_END: 4, // VexFlowPatch: additions from here on
+      BRACKET_OPEN_BEGIN: 5,
+      BRACKET_OPEN_END: 6,
+      BRACKET_OPEN_BOTH: 7
+    };
+  }
+
+  static get StylesString() {
+    return {
+      text: PedalMarking.Styles.TEXT,
+      bracket: PedalMarking.Styles.BRACKET,
+      mixed: PedalMarking.Styles.MIXED,
+      mixed_open_end: PedalMarking.Styles.MIXED_OPEN_END,
+      bracket_open_begin: PedalMarking.Styles.BRACKET_OPEN_BEGIN,
+      bracket_open_end: PedalMarking.Styles.BRACKET_OPEN_END,
+      bracket_open_both: PedalMarking.Styles.BRACKET_OPEN_BOTH
+    };
+  }
+
+  // Create a sustain pedal marking. Returns the defaults PedalMarking.
+  // Which uses the traditional "Ped" and "*"" markings.
+  static createSustain(notes) {
+    const pedal = new PedalMarking(notes);
+    return pedal;
+  }
+
+  // Create a sostenuto pedal marking
+  static createSostenuto(notes) {
+    const pedal = new PedalMarking(notes);
+    pedal.setStyle(PedalMarking.Styles.MIXED);
+    pedal.setCustomText('Sost. Ped.');
+    return pedal;
+  }
+
+  // Create an una corda pedal marking
+  static createUnaCorda(notes) {
+    const pedal = new PedalMarking(notes);
+    pedal.setStyle(PedalMarking.Styles.TEXT);
+    pedal.setCustomText('una corda', 'tre corda');
+    return pedal;
+  }
+
+  // ## Prototype Methods
+  constructor(notes) {
+    super();
+    this.setAttribute('type', 'PedalMarking');
+    this.EndsStave = false; // VexFlowPatch
+    this.ChangeBegin = false;
+    this.ChangeEnd = false;
+    this.notes = notes;
+    this.style = PedalMarking.TEXT;
+    this.line = 0;
+
+    // Custom text for the release/depress markings
+    this.custom_depress_text = '';
+    this.custom_release_text = '';
+
+    this.font = {
+      family: 'Times New Roman',
+      size: 12,
+      weight: 'italic bold',
+    };
+
+    this.render_options = {
+      bracket_height: 10,
+      text_margin_right: 6,
+      bracket_line_width: 1,
+      glyph_point_size: 40,
+      color: 'black',
+    };
+  }
+
+  setEndStave(stave) { // VexFlowPatch addition
+    this.endStave = stave;
+    this.endStaveAddedWidth = 0;
+    this.startMargin = 0;
+    this.endMargin = 0;
+    if(Array.isArray(this.endStave.modifiers)){
+      for(let i = 0; i < this.endStave.modifiers.length; i++){
+        let nextMod = this.endStave.modifiers[i];
+        if(nextMod && nextMod.position === StaveModifier.Position.END && nextMod.width){
+          this.endStaveAddedWidth += nextMod.width;
+        }
+      }
+    }
+  }
+
+  // Set custom text for the `depress`/`release` pedal markings. No text is
+  // set if the parameter is falsy.
+  setCustomText(depress, release) {
+    this.custom_depress_text = depress || '';
+    this.custom_release_text = release || '';
+    return this;
+  }
+
+  // Set the pedal marking style
+  setStyle(style) {
+    if (style < 1 && style > 3)  {
+      throw new Vex.RERR('InvalidParameter', 'The style must be one found in PedalMarking.Styles');
+    }
+
+    this.style = style;
+    return this;
+  }
+
+  // Set the staff line to render the markings on
+  setLine(line) { this.line = line; return this; }
+
+  // Draw the bracket based pedal markings
+  drawBracketed() {
+    const ctx = this.context;
+    let is_pedal_depressed = false;
+    let prev_x;
+    let prev_y;
+    const pedal = this;
+    // Iterate through each note
+    this.notes.forEach((note, index, notes) => {
+      // Each note triggers the opposite pedal action
+      is_pedal_depressed = !is_pedal_depressed;
+      // Get the initial coordinates for the note
+      let x = 0; // VexFlowPatch (further smaller diffs below)
+      if (note) {
+        //default to note head begin
+        x = note.getNoteHeadBeginX();
+      } else {
+        x = this.endStave.end_x + this.endStaveAddedWidth;
+      }
+
+      //If this pedal doesn't end a stave...
+      if(!this.EndsStave){
+        if(note){
+          //pedal across a single note or just the end note
+          if(!is_pedal_depressed){
+            switch(pedal.style) {
+              case PedalMarking.Styles.BRACKET_OPEN_END:
+              case PedalMarking.Styles.BRACKET_OPEN_BOTH:
+              case PedalMarking.Styles.MIXED_OPEN_END:
+                x = note.getNoteHeadEndX();
+              break;
+              default:
+                if(this.ChangeEnd){
+                  //Start in the middle of the note
+                  x = note.getAbsoluteX();
+                } else {
+                  x = note.getNoteHeadBeginX() - pedal.render_options.text_margin_right;
+                  this.startMargin = -pedal.render_options.text_margin_right;
+                }
+              break;
+            }
+          } else if(this.ChangeBegin){
+            x = note.getAbsoluteX();
+          }
+        }
+      } else {
+        //Ends stave and we are at the end...
+        if(!is_pedal_depressed){
+          //IF we are the end, set the end to the stave end
+          if(note){
+            if(this.ChangeEnd){
+              //Start in the middle of the note
+              x = note.getAbsoluteX();
+            }  else {
+              x = note.getStave().end_x + this.endStaveAddedWidth - pedal.render_options.text_margin_right;
+            }
+          } else {
+            x = this.endStave.end_x + this.endStaveAddedWidth - pedal.render_options.text_margin_right;
+          }
+          
+          this.endMargin = -pedal.render_options.text_margin_right;
+        } else if (this.ChangeBegin){
+          x = note.getAbsoluteX();
+        }
+      }
+
+      let stave = this.endStave; // if !note
+      if (note) {
+        stave = note.getStave();
+      }
+      let y = stave.getYForBottomText(pedal.line + 3);
+      if (prev_y) { // compiler complains if we shorten this
+        if (prev_y > y) { // don't slope pedal marking upwards (nonstandard)
+          y = prev_y;
+        }
+      }
+
+      // Throw if current note is positioned before the previous note
+      if (x < prev_x) {
+        // TODO this unnecessarily throws for missing endNote fix
+        // throw new Vex.RERR(
+        //   'InvalidConfiguration', 'The notes provided must be in order of ascending x positions'
+        // );
+      }
+
+      // Determine if the previous or next note are the same
+      // as the current note. We need to keep track of this for
+      // when adjustments are made for the release+depress action
+      const next_is_same = notes[index + 1] === note;
+      const prev_is_same = notes[index - 1] === note;
+
+      let x_shift = 0;
+      if (is_pedal_depressed) {
+        // Adjustment for release+depress
+        x_shift =  prev_is_same ? 5 : 0;
+
+        if ((pedal.style === PedalMarking.Styles.MIXED || pedal.style === PedalMarking.Styles.MIXED_OPEN_END) && !prev_is_same) {
+          // For MIXED style, start with text instead of bracket
+          if (pedal.custom_depress_text) {
+            // If we have custom text, use instead of the default "Ped" glyph
+            const text_width = ctx.measureText(pedal.custom_depress_text).width;
+            ctx.fillText(pedal.custom_depress_text, x - (text_width / 2), y);
+            x_shift = (text_width / 2) + pedal.render_options.text_margin_right;
+          } else {
+            // Render the Ped glyph in position
+            drawPedalGlyph('pedal_depress', ctx, x, y, pedal.render_options.glyph_point_size);
+            x_shift = 20 + pedal.render_options.text_margin_right;
+          }
+        } else {
+          // Draw start bracket
+          ctx.beginPath();
+          if (pedal.style === PedalMarking.Styles.BRACKET_OPEN_BEGIN || pedal.style === PedalMarking.Styles.BRACKET_OPEN_BOTH) {
+            ctx.moveTo(x + x_shift, y);
+          } else {
+            if(this.ChangeBegin){
+              x += 5;
+            }
+            ctx.moveTo(x, y - pedal.render_options.bracket_height);
+            if(this.ChangeBegin){
+              x += 5;
+            }
+            ctx.lineTo(x + x_shift, y);
+          }
+          ctx.stroke();
+          ctx.closePath();
+        }
+      } else {
+        // Adjustment for release+depress
+        x_shift = next_is_same && !this.EndsStave ? -5 : 0;
+
+        // Draw end bracket
+        ctx.beginPath();
+        ctx.moveTo(prev_x, prev_y);
+        ctx.lineTo(x + x_shift, y);
+        if (pedal.style !== PedalMarking.Styles.BRACKET_OPEN_END && pedal.style !== PedalMarking.Styles.MIXED_OPEN_END &&
+            pedal.style !== PedalMarking.Styles.BRACKET_OPEN_BOTH) {
+            if(this.ChangeEnd){
+              x += 5;
+            }
+            ctx.lineTo(x, y - pedal.render_options.bracket_height);
+        }
+        ctx.stroke();
+        ctx.closePath();
+      }
+
+      // Store previous coordinates
+      prev_x = x + x_shift;
+      prev_y = y;
+    });
+  }
+
+  // Draw the text based pedal markings. This defaults to the traditional
+  // "Ped" and "*"" symbols if no custom text has been provided.
+  drawText() {
+    const ctx = this.context;
+    let is_pedal_depressed = false;
+    const pedal = this;
+
+    // The glyph point size
+    const point = pedal.render_options.glyph_point_size;
+
+    // Iterate through each note, placing glyphs or custom text accordingly
+    this.notes.forEach(note => {
+      is_pedal_depressed = !is_pedal_depressed;
+      const stave = note.getStave();
+      const x = note.getAbsoluteX();
+      const y = stave.getYForBottomText(pedal.line + 3);
+
+      let text_width = 0;
+      if (is_pedal_depressed) {
+        if (pedal.custom_depress_text) {
+          text_width = ctx.measureText(pedal.custom_depress_text).width;
+          ctx.fillText(pedal.custom_depress_text, x - (text_width / 2), y);
+        } else {
+          drawPedalGlyph('pedal_depress', ctx, x, y, point);
+        }
+      } else {
+        if (pedal.custom_release_text) {
+          text_width = ctx.measureText(pedal.custom_release_text).width;
+          ctx.fillText(pedal.custom_release_text, x - (text_width / 2), y);
+        } else {
+          drawPedalGlyph('pedal_release', ctx, x, y, point);
+        }
+      }
+    });
+  }
+
+  // Render the pedal marking in position on the rendering context
+  draw() {
+    const ctx = this.checkContext();
+    this.setRendered();
+
+    ctx.save();
+    ctx.setStrokeStyle(this.render_options.color);
+    ctx.setFillStyle(this.render_options.color);
+    ctx.setFont(this.font.family, this.font.size, this.font.weight);
+
+    L('Rendering Pedal Marking');
+
+    if (this.style === PedalMarking.Styles.BRACKET || this.style === PedalMarking.Styles.MIXED || this.style === PedalMarking.Styles.MIXED_OPEN_END ||
+        this.style === PedalMarking.Styles.BRACKET_OPEN_BEGIN || this.style === PedalMarking.Styles.BRACKET_OPEN_END || this.style === PedalMarking.Styles.BRACKET_OPEN_BOTH) {
+      ctx.setLineWidth(this.render_options.bracket_line_width);
+      this.drawBracketed();
+    } else if (this.style === PedalMarking.Styles.TEXT) {
+      this.drawText();
+    }
+
+    ctx.restore();
+  }
+}

--- a/test/data/OSMD_Function_Test_Pedals.musicxml
+++ b/test/data/OSMD_Function_Test_Pedals.musicxml
@@ -1,0 +1,860 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>OSMD Function Test: Pedals</work-title>
+    </work>
+  <identification>
+    <creator type="composer">OSMD</creator>
+    <encoding>
+      <software>MuseScore 3.6.2</software>
+      <encoding-date>2021-05-25</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935" default-y="1511.09" justify="center" valign="top" font-size="22">Title</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1148.14" default-y="1411.09" justify="right" valign="top">Composer</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="298.65">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" sign="yes" default-y="-65.00"/>
+          </direction-type>
+        </direction>
+      <note default-x="73.72" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="129.50" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="185.28" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="241.07" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="237.92">
+      <note default-x="13.00" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="68.78" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="124.56" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="180.34" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="3" width="237.92">
+      <note default-x="13.00" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="68.78" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="124.56" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="180.34" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="4" width="237.92">
+      <note default-x="13.00" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="68.78" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="124.56" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="180.34" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="5" width="318.18">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>-0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <system-distance>150.00</system-distance>
+          </system-layout>
+        </print>
+      <note default-x="62.09" default-y="-55.00">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="62.09" default-y="-40.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="125.66" default-y="-55.00">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="125.66" default-y="-30.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="189.23" default-y="-70.00">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="189.23" default-y="-35.00">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="252.80" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="6" width="248.08">
+      <note default-x="13.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="71.32" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="129.64" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="187.96" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="7" width="248.08">
+      <note default-x="13.00" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="71.32" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="129.64" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="187.96" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="8" width="248.08">
+      <note default-x="13.00" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes"/>
+          </direction-type>
+        </direction>
+      <note default-x="129.64" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="187.96" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="187.96" default-y="0.00">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="9" width="299.80">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>-0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <system-distance>150.00</system-distance>
+          </system-layout>
+        </print>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" line="yes" sign="yes" default-y="-65.00"/>
+          </direction-type>
+        </direction>
+      <note default-x="58.59" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="58.59" default-y="-10.00">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="118.45" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="178.30" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="238.15" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="10" width="254.21">
+      <note default-x="13.00" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="72.85" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="change" line="yes"/>
+          </direction-type>
+        </direction>
+      <note default-x="132.70" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="192.55" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="11" width="254.21">
+      <note default-x="13.00" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="72.85" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes"/>
+          </direction-type>
+        </direction>
+      <note default-x="132.70" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" line="yes" default-y="-65.00"/>
+          </direction-type>
+        </direction>
+      <note default-x="192.55" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="12" width="254.21">
+      <note default-x="13.00" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="72.85" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="132.70" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="192.55" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="13" width="381.59">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>-0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <system-distance>150.00</system-distance>
+          </system-layout>
+        </print>
+      <note default-x="58.59" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="58.59" default-y="-20.00">
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="138.89" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="219.19" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="219.19" default-y="-20.00">
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="299.49" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="14" width="335.99">
+      <note default-x="13.00" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="93.30" default-y="5.00">
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="173.60" default-y="0.00">
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="253.89" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="15" width="344.84">
+      <note default-x="13.00" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="93.30" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes"/>
+          </direction-type>
+        </direction>
+      <note default-x="173.60" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="253.89" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test/data/test_pedal_signs.musicxml
+++ b/test/data/test_pedal_signs.musicxml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>test - pedal signs</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.6.2</software>
+      <encoding-date>2022-12-12</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935" default-y="1511.05" justify="center" valign="top" font-size="22">test - pedal signs</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="394.83">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50.00</left-margin>
+            <right-margin>583.88</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="below">
+        <direction-type>
+          <pedal default-y="-96" line="no" relative-x="-9" type="start"/>
+        </direction-type>
+        <staff>2</staff>
+        <sound damper-pedal="yes"/>
+      </direction>
+      <note default-x="80.72" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal default-y="-95" line="no" type="stop"/>
+        </direction-type>
+        <offset sound="yes">32</offset>
+        <staff>2</staff>
+        <sound damper-pedal="no"/>
+      </direction>
+      <note default-x="232.45" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
closes #347

<img width="373" alt="image" src="https://user-images.githubusercontent.com/33069673/207153689-43e1e5cb-af1a-4ce3-b2cc-bed0cde4b386.png">

<img width="833" alt="image" src="https://user-images.githubusercontent.com/33069673/207153766-535036db-0618-4e00-a490-bc55cdd30c66.png">

code mostly by @fredmeister77 - thanks a lot!

merged from the sponsor early access repository (which also has the audio player and trill / wavy line support).

---

visual regressions:
just added pedals:
Beethoven_AnDieFerneGeliebte.xml_1 0.878868
Dichterliebe01.xml_1 0.0807329
OSMD_function_test_color.musicxml_1 0.0562739
Beethoven_AnDieFerneGeliebte.xml_skybottomline_1 21.9512
Beethoven_AnDieFerneGeliebte.xml_bboxVexFlowGraphicalNote_1 1.38185

[diff_pedal_osmdpublic.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/10212059/diff_pedal_osmdpublic.zip)