### PR TITLE
Fix consecutive tuplet label number disabling not respecting note length

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1151,12 +1151,6 @@ export abstract class MusicSheetCalculator {
                         if (consecutiveTupletCount <= this.rules.TupletNumberMaxConsecutiveRepetitions) {
                             firstNote.NoteTuplet.RenderTupletNumber = true; // need to re-activate after re-render when it was set to false
                         }
-                        if (consecutiveTupletCount === this.rules.TupletNumberMaxConsecutiveRepetitions && this.rules.TupletNumberAlwaysDisableAfterFirstMax) {
-                            if (!disabledPerVoice[voice.VoiceId][currentTupletNumber]) {
-                                disabledPerVoice[voice.VoiceId][currentTupletNumber] = {};
-                            }
-                            disabledPerVoice[voice.VoiceId][currentTupletNumber][typeLength.RealValue] = true;
-                        }
                         if (consecutiveTupletCount > this.rules.TupletNumberMaxConsecutiveRepetitions) {
                             firstNote.NoteTuplet.RenderTupletNumber = false;
                             if (this.rules.TupletNumberAlwaysDisableAfterFirstMax) {

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1102,6 +1102,7 @@ export abstract class MusicSheetCalculator {
             return;
         }
         let currentTupletNumber: number = -1;
+        let currentTypeLength: Fraction = undefined;
         let consecutiveTupletCount: number = 0;
         let currentTuplet: Tuplet = undefined;
         let skipTuplet: Tuplet = undefined; // if set, ignore (further) handling of this tuplet
@@ -1117,6 +1118,7 @@ export abstract class MusicSheetCalculator {
                             currentTupletNumber = -1;
                             consecutiveTupletCount = 0;
                             currentTuplet = undefined;
+                            currentTypeLength = undefined;
                             continue;
                         }
                         if (firstNote.NoteTuplet === skipTuplet) {
@@ -1138,8 +1140,10 @@ export abstract class MusicSheetCalculator {
                                 }
                             }
                         }
-                        if (firstNote.NoteTuplet.TupletLabelNumber !== currentTupletNumber) {
+                        if (firstNote.NoteTuplet.TupletLabelNumber !== currentTupletNumber ||
+                            !typeLength.Equals(currentTypeLength)) {
                             currentTupletNumber = firstNote.NoteTuplet.TupletLabelNumber;
+                            currentTypeLength = typeLength;
                             consecutiveTupletCount = 0;
                         }
                         currentTuplet = firstNote.NoteTuplet;

--- a/test/data/test_tuplet_consecutive_respect_notelength.musicxml
+++ b/test/data/test_tuplet_consecutive_respect_notelength.musicxml
@@ -2,7 +2,7 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
   <work>
-    <work-title>test_tuplet_consecutive_simple_alwaysdisable</work-title>
+    <work-title>test_tuplet_consecutive_respect_notelength</work-title>
     </work>
   <identification>
     <encoding>
@@ -41,9 +41,12 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="600" default-y="1611.86" justify="center" valign="top" font-size="22">tuplet_consecutive_test_simple</credit-words>
+    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">test_tuplet_consecutive_respect_notelength</credit-words>
     </credit>
   <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>brace</group-symbol>
+      </part-group>
     <score-part id="P1">
       <part-name>Piano</part-name>
       <part-abbreviation>Pno.</part-abbreviation>
@@ -60,18 +63,15 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="547.15">
+    <measure number="1" width="385.63">
       <print>
         <system-layout>
           <system-margins>
-            <left-margin>64.90</left-margin>
+            <left-margin>50.00</left-margin>
             <right-margin>0.00</right-margin>
             </system-margins>
           <top-system-distance>170.00</top-system-distance>
           </system-layout>
-        <staff-layout number="2">
-          <staff-distance>65.00</staff-distance>
-          </staff-layout>
         </print>
       <attributes>
         <divisions>3</divisions>
@@ -82,285 +82,366 @@
           <beats>3</beats>
           <beat-type>4</beat-type>
           </time>
-        <staves>2</staves>
-        <clef number="1">
+        <clef>
           <sign>G</sign>
           <line>2</line>
           </clef>
-        <clef number="2">
-          <sign>F</sign>
-          <line>4</line>
-          </clef>
         </attributes>
-      <note default-x="83.49" default-y="-30.00">
+      <note default-x="80.72" default-y="-30.00">
         <pitch>
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>9</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <dot/>
-        <stem>up</stem>
-        <staff>1</staff>
-        </note>
-      <backup>
-        <duration>9</duration>
-        </backup>
-      <note default-x="83.49" default-y="-130.00">
-        <pitch>
-          <step>C</step>
-          <octave>3</octave>
-          </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>up</stem>
-        <staff>2</staff>
         <beam number="1">begin</beam>
         <notations>
           <tuplet type="start" bracket="no"/>
           </notations>
         </note>
-      <note default-x="134.81" default-y="-135.00">
+      <note default-x="115.97" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="151.21" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note default-x="186.46" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note default-x="221.70" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="256.95" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note default-x="292.20" default-y="-20.00">
         <pitch>
           <step>B</step>
-          <octave>2</octave>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+          </time-modification>
+        <stem>down</stem>
+        <notations>
+          <tuplet type="start" bracket="yes"/>
+          </notations>
+        </note>
+      <note default-x="348.59" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
           </time-modification>
-        <stem>up</stem>
-        <staff>2</staff>
-        <beam number="1">continue</beam>
+        <stem>down</stem>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
         </note>
-      <note default-x="186.12" default-y="-130.00">
+      </measure>
+    <measure number="2" width="335.16">
+      <note default-x="13.00" default-y="-15.00">
         <pitch>
           <step>C</step>
-          <octave>3</octave>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          </time-modification>
-        <stem>up</stem>
-        <staff>2</staff>
-        <beam number="1">end</beam>
-        <notations>
-          <tuplet type="stop"/>
-          </notations>
-        </note>
-      <note default-x="237.44" default-y="-125.00">
-        <pitch>
-          <step>D</step>
-          <octave>3</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">begin</beam>
         <notations>
           <tuplet type="start" bracket="no"/>
           </notations>
         </note>
-      <note default-x="288.76" default-y="-120.00">
+      <note default-x="48.60" default-y="-15.00">
         <pitch>
-          <step>E</step>
-          <octave>3</octave>
+          <step>C</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="340.08" default-y="-125.00">
+      <note default-x="84.19" default-y="-15.00">
         <pitch>
-          <step>D</step>
-          <octave>3</octave>
+          <step>C</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">end</beam>
         <notations>
           <tuplet type="stop"/>
           </notations>
         </note>
-      <note default-x="391.39" default-y="-120.00">
+      <note default-x="119.79" default-y="-10.00">
         <pitch>
-          <step>E</step>
-          <octave>3</octave>
+          <step>D</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">begin</beam>
         <notations>
           <tuplet type="start" bracket="no"/>
           </notations>
         </note>
-      <note default-x="442.71" default-y="-115.00">
+      <note default-x="155.38" default-y="-10.00">
         <pitch>
-          <step>F</step>
-          <octave>3</octave>
+          <step>D</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="494.03" default-y="-120.00">
+      <note default-x="190.98" default-y="-10.00">
         <pitch>
-          <step>E</step>
-          <octave>3</octave>
+          <step>D</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note default-x="226.57" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note default-x="262.17" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="297.76" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>down</stem>
         <beam number="1">end</beam>
         <notations>
           <tuplet type="stop"/>
           </notations>
         </note>
       </measure>
-    <measure number="2" width="416.52">
-      <note default-x="13.00" default-y="-25.00">
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>9</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <dot/>
-        <stem>up</stem>
-        <staff>1</staff>
-        </note>
-      <backup>
-        <duration>9</duration>
-        </backup>
-      <note default-x="13.00" default-y="-115.00">
+    <measure number="3" width="257.78">
+      <note default-x="13.00" default-y="0.00">
         <pitch>
           <step>F</step>
-          <octave>3</octave>
-          </pitch>
-        <duration>3</duration>
-        <voice>5</voice>
-        <type>quarter</type>
-        <stem>down</stem>
-        <staff>2</staff>
-        </note>
-      <note default-x="124.05" default-y="-110.00">
-        <pitch>
-          <step>G</step>
-          <octave>3</octave>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">begin</beam>
         <notations>
           <tuplet type="start" bracket="no"/>
           </notations>
         </note>
-      <note default-x="180.98" default-y="-105.00">
+      <note default-x="55.18" default-y="0.00">
         <pitch>
-          <step>A</step>
-          <octave>3</octave>
+          <step>F</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">continue</beam>
         </note>
-      <note default-x="237.90" default-y="-110.00">
+      <note default-x="97.36" default-y="0.00">
         <pitch>
-          <step>G</step>
-          <octave>3</octave>
+          <step>F</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>5</voice>
+        <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>3</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
         <stem>down</stem>
-        <staff>2</staff>
         <beam number="1">end</beam>
         <notations>
           <tuplet type="stop"/>
           </notations>
         </note>
-      <note default-x="294.82" default-y="-105.00">
+      <note default-x="139.53" default-y="5.00">
         <pitch>
-          <step>A</step>
-          <octave>3</octave>
+          <step>G</step>
+          <octave>5</octave>
           </pitch>
-        <duration>3</duration>
-        <voice>5</voice>
-        <type>quarter</type>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
         <stem>down</stem>
-        <staff>2</staff>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
See https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/1207#issuecomment-1398816426

This could be expanded to check not only the first note but all notes, but that would complicate the code a bit and should be rarely needed.

Aside from the new sample, the few visual diffs are mostly a matter of taste, and depend on options set.
[diff_tuplet_consecutive_length.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/10469391/diff_tuplet_consecutive_length.zip)