### PR TITLE
fix svg export: tabnote not clearing/painting white rectangle around number

### DIFF
--- a/src/VexFlowPatch/src/tabnote.js
+++ b/src/VexFlowPatch/src/tabnote.js
@@ -435,7 +435,8 @@ export class TabNote extends StemmableNote {
       const glyph = this.glyphs[i];
 
       let currentGlyphWidth = glyph.getWidth();
-      if (currentGlyphWidth === 0 && glyph.text?.toString()?.length) {
+      if (currentGlyphWidth === 0 && glyph.text && glyph.text.toString() && glyph.text.toString().length) {
+        // above: glyph.text?.toString()?.length would be shorter, but fails appveyor build
         // VexflowPatch: workaround for generateImages script -> SVG export
         currentGlyphWidth = glyph.text.toString().length * 7;
       }

--- a/src/VexFlowPatch/src/tabnote.js
+++ b/src/VexFlowPatch/src/tabnote.js
@@ -434,12 +434,18 @@ export class TabNote extends StemmableNote {
       const y = ys[i] + this.render_options.y_shift;
       const glyph = this.glyphs[i];
 
+      let currentGlyphWidth = glyph.getWidth();
+      if (currentGlyphWidth === 0 && glyph.text?.toString()?.length) {
+        // workaround for generateImages script -> SVG export
+        currentGlyphWidth = glyph.text.toString().length * 7;
+      }
+      //console.log("currentGlyphWidth: " + currentGlyphWidth);
       // Center the fret text beneath the notation note head
       const note_glyph_width = this.glyph.getWidth();
-      const tab_x = x + (note_glyph_width / 2) - (glyph.getWidth() / 2);
+      const tab_x = x + (note_glyph_width / 2) - (currentGlyphWidth / 2);
 
       // FIXME: Magic numbers.
-      ctx.clearRect(tab_x - 2, y - 3, glyph.getWidth() + 4, 6);
+      ctx.clearRect(tab_x - 2, y - 3, currentGlyphWidth + 4, 6);
 
       if (glyph.code) {
         Glyph.renderGlyph(ctx, tab_x, y,

--- a/src/VexFlowPatch/src/tabnote.js
+++ b/src/VexFlowPatch/src/tabnote.js
@@ -436,12 +436,15 @@ export class TabNote extends StemmableNote {
 
       let currentGlyphWidth = glyph.getWidth();
       if (currentGlyphWidth === 0 && glyph.text?.toString()?.length) {
-        // workaround for generateImages script -> SVG export
+        // VexflowPatch: workaround for generateImages script -> SVG export
         currentGlyphWidth = glyph.text.toString().length * 7;
       }
-      //console.log("currentGlyphWidth: " + currentGlyphWidth);
       // Center the fret text beneath the notation note head
-      const note_glyph_width = this.glyph.getWidth();
+      let note_glyph_width = this.glyph.getWidth();
+      if (note_glyph_width === 0) {
+        // VexflowPatch: correct positioning after VexflowPatch change above
+        note_glyph_width = currentGlyphWidth;
+      }
       const tab_x = x + (note_glyph_width / 2) - (currentGlyphWidth / 2);
 
       // FIXME: Magic numbers.


### PR DESCRIPTION
before:
<img width="144" alt="image" src="https://user-images.githubusercontent.com/33069673/217652104-41076cc5-e0ad-4c25-ae1c-88d8d5611791.png">

after:
<img width="141" alt="image" src="https://user-images.githubusercontent.com/33069673/217652152-9f6fb92c-bc37-48fb-9841-4619a55fbd70.png">

sample: `OSMD_Function_Test_Tablature_Vibrato.musicxml`

Positioning of the numbers was fixed in the second commit (from a new shift introduced in the first commit),
see `OSMD_Function_Test_Tabulature_hayden_study_1.mxl`

no visual regressions spotted (other than this improvement) in the SVGs (we don't yet have automatic visual regression tests for SVG export)