### PR TITLE
Fixed a problem where if slur and tie stops are in separate notations…

### DIFF
--- a/src/Common/FileIO/Xml.ts
+++ b/src/Common/FileIO/Xml.ts
@@ -104,7 +104,6 @@ export class IXmlElement {
         return ret;
     }
 
-
     /**
      * Get the first child element with the given node name
      * with all the children of consequent child elements with the same node name.
@@ -114,12 +113,12 @@ export class IXmlElement {
      */
     public combinedElement(elementName: string): IXmlElement {
         const nodes: NodeList = this.elem.childNodes;
-        if(nodes.length > 0) {
+        if (nodes.length > 0) {
             let firstNode: Node;
             for (let i: number = 0, length: number = nodes.length; i < length; i += 1) {
                 const otherNode: Node = nodes[i];
                 if (otherNode.nodeType === Node.ELEMENT_NODE && otherNode.nodeName.toLowerCase() === elementName) {
-                    if(firstNode){
+                    if (firstNode) {
                         const childNodes: NodeList = otherNode.childNodes;
                         for (let j: number = 0, numChildNodes: number = childNodes.length; j < numChildNodes; j += 1) {
                             const childNode: Node = childNodes[j];
@@ -130,7 +129,7 @@ export class IXmlElement {
                     }
                 }
             }
-            if(firstNode){
+            if (firstNode) {
                 return new IXmlElement(firstNode as Element);
             }
         }

--- a/src/Common/FileIO/Xml.ts
+++ b/src/Common/FileIO/Xml.ts
@@ -103,4 +103,36 @@ export class IXmlElement {
         }
         return ret;
     }
+
+
+    /**
+     * Get the first child element with the given node name
+     * with all the children of consequent child elements with the same node name.
+     * for example two <notations> tags will be combined for better processing
+     * @param elementName
+     * @returns {IXmlElement}
+     */
+    public combinedElement(elementName: string): IXmlElement {
+        const nodes: NodeList = this.elem.childNodes;
+        if(nodes.length > 0) {
+            let firstNode: Node;
+            for (let i: number = 0, length: number = nodes.length; i < length; i += 1) {
+                const otherNode: Node = nodes[i];
+                if (otherNode.nodeType === Node.ELEMENT_NODE && otherNode.nodeName.toLowerCase() === elementName) {
+                    if(firstNode){
+                        const childNodes: NodeList = otherNode.childNodes;
+                        for (let j: number = 0, numChildNodes: number = childNodes.length; j < numChildNodes; j += 1) {
+                            const childNode: Node = childNodes[j];
+                            firstNode.appendChild(childNode.cloneNode(true));
+                        }
+                    }else{
+                        firstNode = otherNode;
+                    }
+                }
+            }
+            if(firstNode){
+                return new IXmlElement(firstNode as Element);
+            }
+        }
+    }
 }

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -247,7 +247,6 @@ export class InstrumentReader {
               graceSlur = true;
               // grace slurs could be non-binary, but VexFlow.GraceNoteGroup modifier system is currently only boolean for slurs.
             }
-
           }
 
           // check for cue note

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -225,7 +225,7 @@ export class InstrumentReader {
           const restNote: boolean = xmlNode.element("rest") !== undefined;
           //log.info("New note found!", noteDivisions, noteDuration.toString(), restNote);
 
-          const notationsNode: IXmlElement = xmlNode.element("notations"); // used for multiple checks further on
+          const notationsNode: IXmlElement = xmlNode.combinedElement("notations"); // select all notation nodes
 
           const isGraceNote: boolean = xmlNode.element("grace") !== undefined || noteDivisions === 0 || isChord && lastNoteWasGrace;
           let graceNoteSlash: boolean = false;
@@ -243,13 +243,11 @@ export class InstrumentReader {
 
             noteDuration = this.getNoteDurationFromTypeNode(xmlNode);
 
-            const notationNode: IXmlElement = xmlNode.element("notations");
-            if (notationNode) {
-              if (notationNode.element("slur")) {
-                graceSlur = true;
-                // grace slurs could be non-binary, but VexFlow.GraceNoteGroup modifier system is currently only boolean for slurs.
-              }
+            if (notationsNode && notationsNode.element("slur")) {
+              graceSlur = true;
+              // grace slurs could be non-binary, but VexFlow.GraceNoteGroup modifier system is currently only boolean for slurs.
             }
+
           }
 
           // check for cue note


### PR DESCRIPTION
… tags, the slur end would be missed, resulting in endless slurs on notes with both a slur end and a tie stop. According to the musicxml specs multiple notations tags are allowed, so they should be dealt with.
[Say Something SSAB - Full score - 01 0 tutti Pentatonix - Say Something SSAB.musicxml.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/10928500/Say.Something.SSAB.-.Full.score.-.01.0.tutti.Pentatonix.-.Say.Something.SSAB.musicxml.zip)

In this example file, look at the bottom staff. Every 4 measures there should be a slur. In version 1.7.4, when a note has a tie end and a slur end, the slur end is ignored, which the
<img width="1412" alt="Schermafbeelding 2023-03-09 om 07 40 12" src="https://user-images.githubusercontent.com/83608208/223941082-432bfcef-3527-43e4-b6d4-046100364a4d.png">
 slur longer until another note has a slur end that is recognized.


Below is an image of the new situation.
<img width="1389" alt="Schermafbeelding 2023-03-09 om 07 41 03" src="https://user-images.githubusercontent.com/83608208/223941225-cd5bb06a-43e2-4175-ad42-c3280b76e723.png">
