### PR TITLE
Fixed measure width option

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -674,7 +674,7 @@ export class EngravingRules {
         this.MultipleRestMeasureDefaultWidth = 4;
         this.MultipleRestMeasureAddKeySignature = true;
 
-        this.FixedMeasureWidth = true;
+        this.FixedMeasureWidth = false;
         this.FixedMeasureWidthFixedValue = undefined; // only set to a number x if the width should be always x
 
         // Line Widths

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -241,7 +241,16 @@ export class EngravingRules {
     public SystemRepetitionEndingLineWidth: number;
     public SystemDotWidth: number;
     public MultipleRestMeasureDefaultWidth: number;
+    /** Use the same measure width for all measures (experimental).
+     *  Note that this will use the largest width of all measures,
+     *  as Vexflow will mess up the layout with overlays if using less than minimum width.
+     *  See formatter.preCalculateMinTotalWidth()
+     */
     public FixedMeasureWidth: boolean;
+    /** Use a fixed width for all measures (experimental).
+     *  This is mostly for debugging or for when you already know how big the measures
+     *  in the target score are, because using a too low width will cause overlaps in Vexflow.
+     */
     public FixedMeasureWidthFixedValue: number;
     public DistanceBetweenVerticalSystemLines: number;
     public DistanceBetweenDotAndLine: number;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -241,6 +241,8 @@ export class EngravingRules {
     public SystemRepetitionEndingLineWidth: number;
     public SystemDotWidth: number;
     public MultipleRestMeasureDefaultWidth: number;
+    public FixedMeasureWidth: boolean;
+    public FixedMeasureWidthFixedValue: number;
     public DistanceBetweenVerticalSystemLines: number;
     public DistanceBetweenDotAndLine: number;
     public RepeatEndStartPadding: number;
@@ -650,6 +652,8 @@ export class EngravingRules {
         this.GraceLineWidth = this.StaffLineWidth * this.GraceNoteScalingFactor;
 
         this.MultipleRestMeasureDefaultWidth = 4;
+        this.FixedMeasureWidth = true;
+        this.FixedMeasureWidthFixedValue = undefined; // only set to a number x if the width should be always x
 
         // Line Widths
         this.MinimumCrossedBeamDifferenceMargin = 0.0001;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -307,12 +307,31 @@ export abstract class MusicSheetCalculator {
             minimumStaffEntriesWidth = this.calculateMeasureWidthFromStaffEntries(measures, minimumStaffEntriesWidth);
             MusicSheetCalculator.setMeasuresMinStaffEntriesWidth(measures, minimumStaffEntriesWidth);
             // minLength = minimumStaffEntriesWidth * 1.2 + maxInstrNameLabelLength + maxInstructionsLength;
+            let maxWidth: number = 0;
             for (let i: number = 1; i < this.graphicalMusicSheet.MeasureList.length; i++) {
                 measures = this.graphicalMusicSheet.MeasureList[i];
                 minimumStaffEntriesWidth = this.calculateMeasureXLayout(measures);
                 minimumStaffEntriesWidth = this.calculateMeasureWidthFromStaffEntries(measures, minimumStaffEntriesWidth);
+                if (minimumStaffEntriesWidth > maxWidth) {
+                    maxWidth = minimumStaffEntriesWidth;
+                }
+                //console.log(`min width for measure ${measures[0].MeasureNumber}: ${minimumStaffEntriesWidth}`);
                 MusicSheetCalculator.setMeasuresMinStaffEntriesWidth(measures, minimumStaffEntriesWidth);
                 // minLength = Math.max(minLength, minimumStaffEntriesWidth * 1.2 + maxInstructionsLength);
+            }
+            if (this.rules.FixedMeasureWidth) {
+                // experimental: use the same measure width for all measures
+                //   here we take the maximum measure width for now,
+                //   otherwise Vexflow's layout can get completely messed up and place everything on top of each other,
+                //   if it gets less width than it says it needs as a minimum for a measure. (formatter.preCalculateMinTotalWidth)
+                let targetWidth: number = maxWidth;
+                if (this.rules.FixedMeasureWidthFixedValue) {
+                    targetWidth = this.rules.FixedMeasureWidthFixedValue;
+                }
+                for (let i: number = 1; i < this.graphicalMusicSheet.MeasureList.length; i++) {
+                    measures = this.graphicalMusicSheet.MeasureList[i];
+                    MusicSheetCalculator.setMeasuresMinStaffEntriesWidth(measures, targetWidth);
+                }
             }
         }
         // this.graphicalMusicSheet.MinAllowedSystemWidth = minLength; // currently unused

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -169,6 +169,7 @@ export class MusicSystemBuilder {
                 this.finalizeCurrentSystem(this.measureList[this.measureList.length - 1], !this.rules.StretchLastSystemLine, false);
                 return this.musicSystems;
             }
+            // TODO FixedMeasureWidth: last measure will have a different stretch factor, misaligning measures and widths. use previous stretch factor instead
             this.finalizeCurrentAndCreateNewSystem(this.measureList[this.measureList.length - 1], !this.rules.StretchLastSystemLine, false);
         }
         return this.musicSystems;


### PR DESCRIPTION
See #1314.

An experimental option with certain drawbacks, but multiple people have requested it.

Activate option:
`osmd.EngravingRules.FixedMeasureWidth = true`

optional/experimental/debug given width for all measures:
`osmd.EngravingRules.FixedMeasureWidthFixedValue = 5`
(if you set this too low, the Vexflow layout will break, causing overlaps. minimum width depends on score)