### PR TITLE
ColorOptions improvement, and New color mode: ColorByInstrument

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -461,6 +461,15 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             coloringEnabled: true,
             // defaultColorNotehead: "#CC0055", // try setting a default color. default is black (undefined)
             // defaultColorStem: "#BB0099",
+            coloringMode: 1,
+            coloringSetCustom: ["#ff0000", "#ffa500", "#abad00", "#008000", "#0000ff", "#4b0082", "#ee82ee", "#9e8299"],        
+            colorOptions: { // colorOptions allows for toggling color inheritance for specific graphic object classes
+                stems: false,
+                beams: false,
+                flags: false,
+                rests: false,
+                slurs: false,
+            },
 
             autoBeam: false, // try true, OSMD Function Test AutoBeam sample
             autoBeamOptions: {

--- a/demo/index.js
+++ b/demo/index.js
@@ -461,14 +461,14 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             coloringEnabled: true,
             // defaultColorNotehead: "#CC0055", // try setting a default color. default is black (undefined)
             // defaultColorStem: "#BB0099",
-            coloringMode: 1,
+            coloringMode: 3,
             coloringSetCustom: ["#ff0000", "#ffa500", "#abad00", "#008000", "#0000ff", "#4b0082", "#ee82ee", "#9e8299"],        
             colorOptions: { // colorOptions allows for toggling color inheritance for specific graphic object classes
-                stems: false,
-                beams: false,
-                flags: false,
+                stems: true,
+                beams: true,
+                flags: true,
                 rests: false,
-                slurs: false,
+                slurs: true
             },
 
             autoBeam: false, // try true, OSMD Function Test AutoBeam sample

--- a/demo/index.js
+++ b/demo/index.js
@@ -461,15 +461,6 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             coloringEnabled: true,
             // defaultColorNotehead: "#CC0055", // try setting a default color. default is black (undefined)
             // defaultColorStem: "#BB0099",
-            coloringMode: 3,
-            coloringSetCustom: ["#ff0000", "#ffa500", "#abad00", "#008000", "#0000ff", "#4b0082", "#ee82ee", "#9e8299"],        
-            colorOptions: { // colorOptions allows for toggling color inheritance for specific graphic object classes
-                stems: true,
-                beams: true,
-                flags: true,
-                rests: false,
-                slurs: true
-            },
 
             autoBeam: false, // try true, OSMD Function Test AutoBeam sample
             autoBeamOptions: {

--- a/src/MusicalScore/Graphical/DrawingParameters.ts
+++ b/src/MusicalScore/Graphical/DrawingParameters.ts
@@ -4,7 +4,8 @@ import { PlacementEnum } from "../VoiceData/Expressions/AbstractExpression";
 export enum ColoringModes {
     XML = 0,
     AutoColoring = 1,
-    CustomColorSet = 2
+    CustomColorSet = 2,
+    ColorByInstrument = 3
 }
 
 export enum DrawingParametersEnum {

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -6,6 +6,7 @@ import { PlacementEnum } from "../VoiceData/Expressions/AbstractExpression";
 import {
     AutoBeamOptions,
     AlignRestOption,
+    ColorOptions,
     FillEmptyMeasuresWithWholeRests,
     SkyBottomLineBatchCalculatorBackendType
 } from "../../OpenSheetMusicDisplay/OSMDOptions";
@@ -308,9 +309,7 @@ export class EngravingRules {
     public RenderGlissandi: boolean;
     public ColoringMode: ColoringMode;
     public ColoringEnabled: boolean;
-    public ColorStemsLikeNoteheads: boolean;
-    public ColorFlags: boolean;
-    public ColorBeams: boolean;
+    public ColorOptions: ColorOptions;
     public ColoringSetCurrent: Dictionary<NoteEnum|number, string>;
     /** Default color for all musical elements including key signature etc. Default undefined. */
     public DefaultColorMusic: string;
@@ -713,9 +712,13 @@ export class EngravingRules {
         this.RenderGlissandi = true;
         this.ColoringMode = ColoringMode.XML;
         this.ColoringEnabled = true;
-        this.ColorStemsLikeNoteheads = false;
-        this.ColorBeams = true;
-        this.ColorFlags = true;
+        this.ColorOptions = { // toggle color for graphic objects by type, inherits from notehead (ColorMode 1 and 2) or instrument (ColorMode 3)
+            stems: false,
+            beams: false,
+            flags: false,
+            rests: false,
+            slurs: false
+        };
         this.applyDefaultColorMusic("#000000"); // black. undefined is only black if a note's color hasn't been changed before.
         this.DefaultColorCursor = "#33e02f"; // green
         this.DefaultFontFamily = "Times New Roman"; // what OSMD was initially optimized for

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -505,7 +505,7 @@ export class VexFlowConverter {
             if (stemColor) {
                 //gve.parentVoiceEntry.StemColor = stemColor; // this shouldn't be set by DefaultColorStem
                 vfnote.setStemStyle(stemStyle);
-                if (vfnote.flag && rules.ColorFlags) {
+                if (vfnote.flag && rules.ColorOptions.flags) {
                     vfnote.setFlagStyle(stemStyle);
                 }
             }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -930,7 +930,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
                             (<any>vfBeam).render_options.beam_width = 3;
                             (<any>vfBeam).render_options.partial_beam_length = 4;
                         }
-                        if (stemColors.length >= 2 && this.rules.ColorBeams) {
+                        if (stemColors.length >= 2 && this.rules.ColorOptions.beams) {
                             beamColor = stemColors[0];
                             for (const stemColor of stemColors) {
                                 if (stemColor !== beamColor) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -117,8 +117,8 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         super.drawStaffLine(staffLine);
         const absolutePos: PointF2D = staffLine.PositionAndShape.AbsolutePosition;
         if (this.rules.RenderSlurs) {
-            const ctx: Vex.IRenderContext = this.backend.getContext();
             if (this.rules.ColorOptions.slurs) {
+                const ctx: Vex.IRenderContext = this.backend.getContext();
                 ctx.setFillStyle(staffLine.ParentStaff.ParentInstrument.Color);
                 this.drawSlurs(staffLine as VexFlowStaffLine, absolutePos);
                 ctx.setFillStyle(this.rules.DefaultColorMusic);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -117,7 +117,15 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         super.drawStaffLine(staffLine);
         const absolutePos: PointF2D = staffLine.PositionAndShape.AbsolutePosition;
         if (this.rules.RenderSlurs) {
-            this.drawSlurs(staffLine as VexFlowStaffLine, absolutePos);
+            const ctx: Vex.IRenderContext = this.backend.getContext();
+            if (this.rules.ColorOptions.slurs) {
+                ctx.setFillStyle(staffLine.ParentStaff.ParentInstrument.Color);
+                this.drawSlurs(staffLine as VexFlowStaffLine, absolutePos);
+                ctx.setFillStyle(this.rules.DefaultColorMusic);
+            }
+            else {
+                this.drawSlurs(staffLine as VexFlowStaffLine, absolutePos);
+            }
         }
         if (this.rules.RenderGlissandi) {
             this.drawGlissandi(staffLine as VexFlowStaffLine, absolutePos);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry.ts
@@ -58,23 +58,31 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
 
             sourceNoteNoteheadColor = note.sourceNote.NoteheadColor;
             noteheadColor = sourceNoteNoteheadColor;
-            // Switch between XML colors and automatic coloring
-            if (this.rules.ColoringMode === ColoringModes.AutoColoring ||
-                this.rules.ColoringMode === ColoringModes.CustomColorSet) {
+            // Switch between color modes
+            if (this.rules.ColoringMode === ColoringModes.AutoColoring) {
                 if (note.sourceNote.isRest()) {
+                    noteheadColor = defaultColorRest;
+                } else {
+                    const fundamentalNote: NoteEnum = note.sourceNote.Pitch.FundamentalNote;
+                    noteheadColor = this.rules.ColoringSetCurrent.getValue(fundamentalNote);
+                }
+            }
+            else if (this.rules.ColoringMode === ColoringModes.CustomColorSet) {
+                if (this.rules.ColorOptions.rests && note.sourceNote.isRest()) {
                     noteheadColor = this.rules.ColoringSetCurrent.getValue(-1);
                 } else {
                     const fundamentalNote: NoteEnum = note.sourceNote.Pitch.FundamentalNote;
                     noteheadColor = this.rules.ColoringSetCurrent.getValue(fundamentalNote);
                 }
             }
-            if (!note.sourceNote.PrintObject) {
-                noteheadColor = transparentColor; // transparent
-            } else if (!noteheadColor // revert transparency after PrintObject was set to false, then true again
-                || noteheadColor === "#000000" // questionable, because you might want to set specific notes to black,
-                                               // but unfortunately some programs export everything explicitly as black
-                ) {
-                noteheadColor = this.rules.DefaultColorNotehead;
+            else if (this.rules.ColoringMode === ColoringModes.ColorByInstrument){
+                const instrumentIndex: number = this.parentVoiceEntry.ParentSourceStaffEntry.ParentStaff.ParentInstrument.Id;
+                const colorIndex: number = instrumentIndex % this.rules.ColoringSetCurrent.size();
+                if (!this.rules.ColorOptions.rests && note.sourceNote.isRest()) {
+                    noteheadColor = defaultColorRest;
+                } else {
+                    noteheadColor = this.rules.ColoringSetCurrent.getValue(colorIndex);
+                }
             }
 
             // DEBUG runtime coloring test
@@ -93,14 +101,22 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                     noteheadColor = defaultColorRest;
                 }
             }
-            if (noteheadColor && note.sourceNote.PrintObject) {
+            if (!note.sourceNote.PrintObject) {
+                noteheadColor = transparentColor; // transparent
+            } else if (!noteheadColor // revert transparency after PrintObject was set to false, then true again
+                || noteheadColor === "#000000" // questionable, because you might want to set specific notes to black,
+                                               // but unfortunately some programs export everything explicitly as black
+                ) {
+                noteheadColor = this.rules.DefaultColorNotehead;
+            }
+            if (noteheadColor) {
                 note.sourceNote.NoteheadColorCurrentlyRendered = noteheadColor;
             } else if (!noteheadColor) {
                 continue;
             }
 
             // color notebeam if all noteheads have same color and stem coloring enabled
-            if (this.rules.ColoringEnabled && note.sourceNote.NoteBeam && this.rules.ColorBeams) {
+            if (this.rules.ColoringEnabled && note.sourceNote.NoteBeam && this.rules.ColorOptions.beams) {
                 const beamNotes: Note[] = note.sourceNote.NoteBeam.Notes;
                 let colorBeam: boolean = true;
                 for (let j: number = 0; j < beamNotes.length; j++) {
@@ -149,7 +165,7 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                 || stemColor === "#000000") { // see above, noteheadColor === "#000000"
                 stemColor = defaultColorStem;
             }
-            if (this.rules.ColorStemsLikeNoteheads && noteheadColor) {
+            if (this.rules.ColorOptions.stems && noteheadColor) {
                 // condition could be even more fine-grained by only recoloring if there was no custom StemColor set. will be more complex though
                 stemColor = noteheadColor;
                 setVoiceEntryStemColor = true;
@@ -172,7 +188,7 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                 this.parentVoiceEntry.StemColor = stemColor; // this shouldn't be set by DefaultColorStem
             }
             vfStaveNote.setStemStyle(stemStyle);
-            if (vfStaveNote.flag && vfStaveNote.setFlagStyle && this.rules.ColorFlags) {
+            if (vfStaveNote.flag && vfStaveNote.setFlagStyle && this.rules.ColorOptions.flags) {
                 vfStaveNote.setFlagStyle(stemStyle);
             }
         }

--- a/src/MusicalScore/Instrument.ts
+++ b/src/MusicalScore/Instrument.ts
@@ -28,6 +28,7 @@ export class Instrument extends InstrumentalGroup {
     private nameLabel: Label;
     private idString: string;
     private id: number;
+    private color: string;
     private hasLyrics: boolean = false;
     private hasChordSymbols: boolean = false;
     private playbackTranspose: number;
@@ -71,6 +72,12 @@ export class Instrument extends InstrumentalGroup {
     }
     public get IdString(): string {
         return this.idString;
+    }
+    public get Color(): string {
+        return this.color;
+    }
+    public set Color(value: string) {
+        this.color = value;
     }
     public get Id(): number {
         return this.id;

--- a/src/MusicalScore/ScoreIO/MusicSheetReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSheetReader.ts
@@ -24,6 +24,7 @@ import {RepetitionCalculator} from "./MusicSymbolModules/RepetitionCalculator";
 import {EngravingRules} from "../Graphical/EngravingRules";
 import { ReaderPluginManager } from "./ReaderPluginManager";
 import { TextAlignmentEnum } from "../../Common/Enums/TextAlignment";
+import { ColoringModes } from "../Graphical/DrawingParameters";
 
 export class MusicSheetReader /*implements IMusicSheetReader*/ {
 
@@ -231,6 +232,10 @@ export class MusicSheetReader /*implements IMusicSheetReader*/ {
 
                 currentInstrument.createStaves(instrumentNumberOfStaves);
                 instrumentReaders.push(new InstrumentReader(this.pluginManager, this.repetitionInstructionReader, xmlMeasureList, currentInstrument));
+                if (this.rules.ColoringMode === ColoringModes.ColorByInstrument){
+                    const colorArray: Array<string> = Array.from(this.rules.ColoringSetCurrent.values());
+                    currentInstrument.Color = colorArray[instrumentReaders.length-1];
+                }
                 if (this.repetitionInstructionReader) {
                     this.repetitionInstructionReader.xmlMeasureList[counter] = xmlMeasureList;
                 }

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -37,16 +37,16 @@ export interface IOSMDOptions {
     autoResize?: boolean;
     /** Render Backend, will be SVG if given undefined, "SVG" or "svg", otherwise Canvas. */
     backend?: string;
-    /** Defines the mode that is used for coloring: XML (0), Boomwhacker(1), CustomColorSet (2). Default XML.
-     *  If coloringMode.CustomColorSet (2) is chosen, a coloringSetCustom parameter must be added.
+    /** Defines the mode that is used for coloring: XML (0), Boomwhacker (1), CustomColorSet (2), ColorByInstrument (3). Default XML.
+     *  If CustomColorSet (2) or ColorByInstrument (3) is chosen, a coloringSetCustom parameter must be added.
      */
     coloringMode?: ColoringModes;
     /** Set of 8 colors for automatic coloring of 7 notes from C to B + rest note in HTML form (e.g. "#00ff00" for green).  */
     coloringSetCustom?: string[];
+    /** Options for color inheritance based on graphic object class type (stems, rests, slurs, ties, dynamics). */
+    colorOptions?: ColorOptions;
     /** Whether to enable coloring noteheads and stems, depending on coloringMode. */
     coloringEnabled?: boolean;
-    /** Whether to color the stems of notes the same as their noteheads. Default false. */
-    colorStemsLikeNoteheads?: boolean;
     /** Dark mode (black background, white notes). Simply sets defaultColorMusic and EngravingRules.PageBackgroundColor. */
     darkMode?: boolean;
     /** Default color for all musical elements including key signature etc. Can be used for dark mode etc. Default undefined. */
@@ -312,6 +312,20 @@ export class OSMDOptions {
             return BackendType.SVG;
         }
     }
+}
+
+/** Whether to color the graphic objects, inheriting from parent notehead or instrument color. */
+export interface ColorOptions {
+    /** Whether to color the stems of notes the same as their noteheads. Default false. */
+    stems?: boolean;
+    /** Whether to color the beams. Default false. */
+    beams?: boolean;
+    /** Whether to color the flags of notes the same as their noteheads. Default false. */
+    flags?: boolean;
+    /** Whether to color the rests. Default false. */
+    rests?: boolean;
+    /** Whether to color the slurs. Default false. */
+    slurs?: boolean;
 }
 
 export interface AutoBeamOptions {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -685,8 +685,8 @@ export class OpenSheetMusicDisplay {
             for (let i: number = 0; i < noteIndices.length; i++) {
                 coloringSetCurrent.setValue(noteIndices[i], colorSetString[i]);
             }
+            coloringSetCurrent.setValue(-1, colorSetString.last()); // index 7. Unfortunately -1 is not a NoteEnum value, so we can't put it into noteIndices
         }
-        coloringSetCurrent.setValue(-1, colorSetString.last()); // index 7. Unfortunately -1 is not a NoteEnum value, so we can't put it into noteIndices
         this.rules.ColoringSetCurrent = coloringSetCurrent;
         this.rules.ColoringMode = options.coloringMode;
     }

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -13,7 +13,7 @@ import { MXLHelper } from "../Common/FileIO/Mxl";
 import { AJAX } from "./AJAX";
 import log from "loglevel";
 import { DrawingParametersEnum, DrawingParameters, ColoringModes } from "../MusicalScore/Graphical/DrawingParameters";
-import { IOSMDOptions, OSMDOptions, AutoBeamOptions, BackendType, CursorOptions } from "./OSMDOptions";
+import { IOSMDOptions, OSMDOptions, AutoBeamOptions, BackendType, CursorOptions, ColorOptions } from "./OSMDOptions";
 import { EngravingRules, PageFormat } from "../MusicalScore/Graphical/EngravingRules";
 import { AbstractExpression } from "../MusicalScore/VoiceData/Expressions/AbstractExpression";
 import { Dictionary } from "typescript-collections";
@@ -437,8 +437,26 @@ export class OpenSheetMusicDisplay {
         if (options.coloringEnabled !== undefined) {
             this.rules.ColoringEnabled = options.coloringEnabled;
         }
-        if (options.colorStemsLikeNoteheads !== undefined) {
-            this.rules.ColorStemsLikeNoteheads = options.colorStemsLikeNoteheads;
+        const colorOptions: ColorOptions = options.colorOptions;
+        if (colorOptions){
+            if (colorOptions.stems !== undefined) {
+                this.rules.ColorOptions.stems = colorOptions.stems;
+            }
+            if (colorOptions.beams !== undefined) {
+                this.rules.ColorOptions.beams = colorOptions.beams;
+            }
+            if (colorOptions.flags !== undefined) {
+                this.rules.ColorOptions.flags = colorOptions.flags;
+            }
+            if (colorOptions.rests !== undefined) {
+                this.rules.ColorOptions.rests = colorOptions.rests;
+            }
+            if (colorOptions.slurs !== undefined) {
+                this.rules.ColorOptions.slurs = colorOptions.slurs;
+            }
+            if (colorOptions.flags !== undefined) {
+                this.rules.ColorOptions.flags = colorOptions.flags;
+            }
         }
         if (options.disableCursor) {
             this.drawingParameters.drawCursors = false;
@@ -626,14 +644,16 @@ export class OpenSheetMusicDisplay {
             this.rules.ColoringMode = ColoringModes.XML;
             return;
         }
-        const noteIndices: NoteEnum[] = [NoteEnum.C, NoteEnum.D, NoteEnum.E, NoteEnum.F, NoteEnum.G, NoteEnum.A, NoteEnum.B];
-        let colorSetString: string[];
-        if (options.coloringMode === ColoringModes.CustomColorSet) {
-            if (!options.coloringSetCustom || options.coloringSetCustom.length !== 8) {
+        // validate coloringSetCustom array
+        if (options.coloringMode === ColoringModes.CustomColorSet || options.coloringMode === ColoringModes.ColorByInstrument) {
+            if (options.coloringMode === ColoringModes.CustomColorSet && (!options.coloringSetCustom || options.coloringSetCustom.length !== 8)) {
                 throw new Error("Invalid amount of colors: With coloringModes.customColorSet, " +
                     "you have to provide a coloringSetCustom parameter (array) with 8 strings (C to B, rest note).");
             }
-            // validate strings input
+            if (options.coloringMode === ColoringModes.ColorByInstrument && (!options.coloringSetCustom || !options.coloringSetCustom.length)) {
+                throw new Error("Invalid coloringSetCustom: With coloringModes.colorByInstrument, " +
+                    "you have to provide a coloringSetCustom parameter (array) with at least one color.");
+            }
             for (const colorString of options.coloringSetCustom) {
                 const regExp: RegExp = /^\#[0-9a-fA-F]{6}$/;
                 if (!regExp.test(colorString)) {
@@ -641,17 +661,30 @@ export class OpenSheetMusicDisplay {
                         "One of the color strings in options.coloringSetCustom was not a valid HTML Hex color:\n" + colorString);
                 }
             }
-            colorSetString = options.coloringSetCustom;
-        } else if (options.coloringMode === ColoringModes.AutoColoring) {
+        }
+        const coloringSetCurrent: Dictionary<NoteEnum | number, string> = new Dictionary<NoteEnum | number, string>();
+        const noteIndices: NoteEnum[] = [NoteEnum.C, NoteEnum.D, NoteEnum.E, NoteEnum.F, NoteEnum.G, NoteEnum.A, NoteEnum.B];
+        let colorSetString: string[] = options.coloringSetCustom;
+        if (options.coloringMode === ColoringModes.ColorByInstrument) {
+            for (let i: number = 0; i < colorSetString.length; i++) {
+                coloringSetCurrent.setValue(i, colorSetString[i]);
+            }
+        }
+        else if (options.coloringMode === ColoringModes.CustomColorSet) {
+            for (let i: number = 0; i < noteIndices.length; i++) {
+                coloringSetCurrent.setValue(noteIndices[i], colorSetString[i]);
+            }
+            coloringSetCurrent.setValue(-1, colorSetString.last());
+        }
+        else if (options.coloringMode === ColoringModes.AutoColoring) {
             colorSetString = [];
             const keys: string[] = Object.keys(AutoColorSet);
             for (let i: number = 0; i < keys.length; i++) {
                 colorSetString.push(AutoColorSet[keys[i]]);
             }
-        } // for both cases:
-        const coloringSetCurrent: Dictionary<NoteEnum | number, string> = new Dictionary<NoteEnum | number, string>();
-        for (let i: number = 0; i < noteIndices.length; i++) {
-            coloringSetCurrent.setValue(noteIndices[i], colorSetString[i]);
+            for (let i: number = 0; i < noteIndices.length; i++) {
+                coloringSetCurrent.setValue(noteIndices[i], colorSetString[i]);
+            }
         }
         coloringSetCurrent.setValue(-1, colorSetString.last()); // index 7. Unfortunately -1 is not a NoteEnum value, so we can't put it into noteIndices
         this.rules.ColoringSetCurrent = coloringSetCurrent;

--- a/test/Util/generateImages_browserless.mjs
+++ b/test/Util/generateImages_browserless.mjs
@@ -332,7 +332,9 @@ async function generateSampleImage (sampleFilename, directory, osmdInstance, osm
             coloringMode: isFunctionTestAutoColoring ? 2 : 0,
             // eslint-disable-next-line max-len
             coloringSetCustom: isFunctionTestAutoColoring ? ["#d82c6b", "#F89D15", "#FFE21A", "#4dbd5c", "#009D96", "#43469d", "#76429c", "#ff0000"] : undefined,
-            colorStemsLikeNoteheads: isFunctionTestAutoColoring,
+            colorOptions: {
+                stems: isFunctionTestAutoColoring
+            },
             drawingParameters: defaultOrCompactTightMode, // note: default resets all EngravingRules. could be solved differently
             drawFromMeasureNumber: isFunctionTestDrawingRange ? 9 : 1,
             drawUpToMeasureNumber: isFunctionTestDrawingRange ? 12 : Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
I have added a new color mode `ColorByInstrument`, which allows each instrument to be it's own color. 
```js
openSheetMusicDisplay.setOptions({
    coloringMode: 3,
    coloringSetCustom: ["#ff0000", "#ffa500", "#abad00", "#008000", "#0000ff", "#4b0082", "#ee82ee", "#9e8299"],
    colorOptions: {
        stems: true,
        beams: true,
        flags: true,
        rests: false,
        slurs: true
    }
});
```
 Colors are determined by `coloringSetCustom` and will simply repeat colors if there are more instruments than colors in `coloringSetCustom` array.

![Screenshot 2023-05-20 172918](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/40344766/4d76d03e-9b7e-4fd0-b55f-f2f108a498b9)

# 
The new `ColorOptions` consolidates some of the color options into a single interface.

This allows for toggling color inheritance for specific graphic object classes.  In other words, you can toggle various graphic elements (`stems`, `beams`, `flags`, `rests`, `slurs`) to inherit the color from the notehead or instrument.

This means `ColorStemsLikeNoteheads`, `ColorFlags`, and `ColorBeams` are now consolidated into the `ColorOptions`  and can be referenced as `ColorOptions.stems`, `ColorOptions.flags`,  `ColorOptions.beams`.

If this system proves useful, we could add other options here such as `ties`, `dynamics`, or `lyrics` to inherit as well in the future.

# 

I'm hoping this new system can be adopted, It opens up possibilities in the future for other ColoringModes such as `ColorByPart`, `ColorByVoice`, or `ColorByKey` (could be like `AutoColor`, but shifted by key so red is not always C and the color center can modulate with the key center).

These are just some ideas, but I think the changes in this PR are a core improvement to the color system. At the very least, I find useful and hope others do too. Feel free to chime in. Thanks 🤘