### PR TITLE
Fix short lyrics not looking vertically centered below notes. Fix dash overlap in short intervals

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -189,6 +189,12 @@ export class EngravingRules {
     public LyricsHeight: number;
     public LyricsYOffsetToStaffHeight: number;
     public LyricsYMarginToBottomLine: number;
+    /** Extra x-shift (to the right) for short lyrics to be better vertically aligned.
+     * Also see ChordSymbolExtraXShiftForShortChordSymbols, same principle, same default value.
+     */
+    public LyricsExtraXShiftForShortLyrics: number;
+    /** Threshold of the lyric entry's width below which the x-shift is applied. Default 1.4. */
+    public LyricsExtraXShiftForShortLyricsWidthThreshold: number;
     /** Whether to enable x padding (to the right) for short notes, see LyricsXPaddingFactorForLongLyrics for the degree. */
     public LyricsUseXPaddingForShortNotes: boolean;
     /** How much spacing/padding should be added after notes with long lyrics on short notes
@@ -566,7 +572,7 @@ export class EngravingRules {
         this.ChordSymbolTextHeight = 2.0;
         this.ChordSymbolTextAlignment = TextAlignmentEnum.LeftBottom;
         this.ChordSymbolRelativeXOffset = -1.0;
-        this.ChordSymbolExtraXShiftForShortChordSymbols = 0.3;
+        this.ChordSymbolExtraXShiftForShortChordSymbols = 0.3; // also see LyricsExtraXShiftForShortLyrics, same principle
         this.ChordSymbolExtraXShiftWidthThreshold = 2.0;
         this.ChordSymbolXSpacing = 1.0;
         this.ChordOverlapAllowedIntoNextMeasure = 0;
@@ -653,6 +659,8 @@ export class EngravingRules {
         this.LyricsHeight = 2.0; // actually size of lyrics
         this.LyricsYOffsetToStaffHeight = 0.0; // distance between lyrics and staff. could partly be even lower/dynamic
         this.LyricsYMarginToBottomLine = 0.2;
+        this.LyricsExtraXShiftForShortLyrics = 0.5; // also see ChordSymbolExtraXShiftForShortChordSymbols, same principle
+        this.LyricsExtraXShiftForShortLyricsWidthThreshold = 1.4; // width of '+': 1.12, 'II': 1.33 (benefits from x-shift), 'III': 1.99 (doesn't benefit)
         this.LyricsUseXPaddingForShortNotes = true;
         this.LyricsXPaddingFactorForLongLyrics = 0.8;
         this.LyricsXPaddingWidthThreshold = 3.3;

--- a/src/MusicalScore/Graphical/GraphicalLabel.ts
+++ b/src/MusicalScore/Graphical/GraphicalLabel.ts
@@ -17,6 +17,8 @@ export class GraphicalLabel extends Clickable {
      *  For the Canvas backend, this is unfortunately not possible.
      */
     public SVGNode: Node;
+    /** Read-only informational variable only set once by lyrics centering algorithm. */
+    public CenteringXShift: number = 0;
 
     /**
      * Creates a new GraphicalLabel from a Label

--- a/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
@@ -41,6 +41,7 @@ export class GraphicalLyricEntry {
         this.graphicalLabel.setLabelPositionAndShapeBorders(); // needed to have Size.width
         if (this.graphicalLabel.PositionAndShape.Size.width < rules.LyricsExtraXShiftForShortLyricsWidthThreshold) {
             this.graphicalLabel.PositionAndShape.RelativePosition.x += rules.LyricsExtraXShiftForShortLyrics;
+            this.graphicalLabel.CenteringXShift = rules.LyricsExtraXShiftForShortLyrics;
         }
         if (lyricsTextAlignment === TextAlignmentEnum.LeftBottom) {
             this.graphicalLabel.PositionAndShape.RelativePosition.x -= 1; // make lyrics optically left-aligned

--- a/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
+++ b/src/MusicalScore/Graphical/GraphicalLyricEntry.ts
@@ -38,6 +38,10 @@ export class GraphicalLyricEntry {
         );
         this.graphicalLabel.Label.colorDefault = rules.DefaultColorLyrics; // if undefined, no change. saves an if check
         this.graphicalLabel.PositionAndShape.RelativePosition = new PointF2D(0, staffHeight);
+        this.graphicalLabel.setLabelPositionAndShapeBorders(); // needed to have Size.width
+        if (this.graphicalLabel.PositionAndShape.Size.width < rules.LyricsExtraXShiftForShortLyricsWidthThreshold) {
+            this.graphicalLabel.PositionAndShape.RelativePosition.x += rules.LyricsExtraXShiftForShortLyrics;
+        }
         if (lyricsTextAlignment === TextAlignmentEnum.LeftBottom) {
             this.graphicalLabel.PositionAndShape.RelativePosition.x -= 1; // make lyrics optically left-aligned
         }

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3097,7 +3097,8 @@ export abstract class MusicSheetCalculator {
             const startX: number = startStaffEntry.parentMeasure.PositionAndShape.RelativePosition.x +
                 startStaffEntry.PositionAndShape.RelativePosition.x +
                 lyricEntry.GraphicalLabel.PositionAndShape.RelativePosition.x +
-                lyricEntry.GraphicalLabel.PositionAndShape.BorderMarginRight;
+                lyricEntry.GraphicalLabel.PositionAndShape.BorderMarginRight -
+                lyricEntry.GraphicalLabel.CenteringXShift; // TODO not sure why this is necessary, see Christbaum measure 9+11, Land der Berge 11-12
 
             const endX: number = endStaffentry.parentMeasure.PositionAndShape.RelativePosition.x +
                 endStaffentry.PositionAndShape.RelativePosition.x +
@@ -3194,10 +3195,10 @@ export abstract class MusicSheetCalculator {
         const label: Label = new Label("-");
         label.colorDefault = this.rules.DefaultColorLyrics; // if undefined, no change. saves an if check
         let textHeight: number = this.rules.LyricsHeight;
-        let xShift: number = 0;
         if (endX - startX < 0.8) {
             textHeight *= 0.8;
-            xShift = -0.2;
+            y -= 0.15 * textHeight; // dash moves downwards when textHeight is reduced. counter-act that.
+            //xShift = -0.1;
             // dashes in short/narrow intervals are slightly right-leaning and tend to overlap with right lyricsentry
             //   see Cornelius - Christbaum, measure 9 and 11 ("li-che", "li-ger")
         }
@@ -3209,7 +3210,7 @@ export abstract class MusicSheetCalculator {
             this.staffLinesWithLyricWords.push(staffLine);
         }
         dash.PositionAndShape.Parent = staffLine.PositionAndShape;
-        const relative: PointF2D = new PointF2D(startX + (endX - startX) / 2 + xShift, y);
+        const relative: PointF2D = new PointF2D(startX + (endX - startX) / 2, y);
         dash.PositionAndShape.RelativePosition = relative;
     }
 

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3199,8 +3199,11 @@ export abstract class MusicSheetCalculator {
             textHeight *= 0.8;
             y -= 0.1 * textHeight; // dash moves downwards when textHeight is reduced. counter-act that.
             //xShift = -0.1;
-            // dashes in short/narrow intervals are slightly right-leaning and tend to overlap with right lyricsentry
-            //   see Cornelius - Christbaum, measure 9 and 11 ("li-che", "li-ger")
+            // x-position is situational, sometimes it's slightly right-leaning and tends to overlap with the right LyricsEntry
+            //   (see Cornelius - Christbaum, measure 9 and 11 ("li-che", "li-ger"), due to centering x-shift = GraphicalLabel.CenteringXShift)
+            // sometimes the x-position is perfect and the interval is extremely narrow
+            //   (see Mozart/Holzer Land der Berge measure 11-12)
+            // or even slightly too far left (Beethoven Geliebte measure 4, due to centering x-shift = GraphicalLabel.CenteringXShift)
         }
         const dash: GraphicalLabel = new GraphicalLabel(
             label, textHeight, TextAlignmentEnum.CenterBottom, this.rules);

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3193,15 +3193,23 @@ export abstract class MusicSheetCalculator {
     private calculateSingleDashForLyricWord(staffLine: StaffLine, startX: number, endX: number, y: number): void {
         const label: Label = new Label("-");
         label.colorDefault = this.rules.DefaultColorLyrics; // if undefined, no change. saves an if check
+        let textHeight: number = this.rules.LyricsHeight;
+        let xShift: number = 0;
+        if (endX - startX < 0.7) {
+            textHeight *= 0.9;
+            xShift = -0.2;
+            // dashes in short/narrow intervals are slightly right-leaning and tend to overlap with right lyricsentry
+            //   see Cornelius - Christbaum, measure 9 ("li-che")
+        }
         const dash: GraphicalLabel = new GraphicalLabel(
-            label, this.rules.LyricsHeight, TextAlignmentEnum.CenterBottom, this.rules);
+            label, textHeight, TextAlignmentEnum.CenterBottom, this.rules);
         dash.setLabelPositionAndShapeBorders();
         staffLine.LyricsDashes.push(dash);
         if (this.staffLinesWithLyricWords.indexOf(staffLine) === -1) {
             this.staffLinesWithLyricWords.push(staffLine);
         }
         dash.PositionAndShape.Parent = staffLine.PositionAndShape;
-        const relative: PointF2D = new PointF2D(startX + (endX - startX) / 2, y);
+        const relative: PointF2D = new PointF2D(startX + (endX - startX) / 2 + xShift, y);
         dash.PositionAndShape.RelativePosition = relative;
     }
 

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3197,7 +3197,7 @@ export abstract class MusicSheetCalculator {
         let textHeight: number = this.rules.LyricsHeight;
         if (endX - startX < 0.8) {
             textHeight *= 0.8;
-            y -= 0.15 * textHeight; // dash moves downwards when textHeight is reduced. counter-act that.
+            y -= 0.1 * textHeight; // dash moves downwards when textHeight is reduced. counter-act that.
             //xShift = -0.1;
             // dashes in short/narrow intervals are slightly right-leaning and tend to overlap with right lyricsentry
             //   see Cornelius - Christbaum, measure 9 and 11 ("li-che", "li-ger")

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3197,7 +3197,7 @@ export abstract class MusicSheetCalculator {
         let textHeight: number = this.rules.LyricsHeight;
         if (endX - startX < 0.8) {
             textHeight *= 0.8;
-            y -= 0.1 * textHeight; // dash moves downwards when textHeight is reduced. counter-act that.
+            y -= 0.1 * textHeight; // dash moves downwards when textHeight is reduced. counteract that.
             //xShift = -0.1;
             // x-position is situational, sometimes it's slightly right-leaning and tends to overlap with the right LyricsEntry
             //   (see Cornelius - Christbaum, measure 9 and 11 ("li-che", "li-ger"), due to centering x-shift = GraphicalLabel.CenteringXShift)

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3195,11 +3195,11 @@ export abstract class MusicSheetCalculator {
         label.colorDefault = this.rules.DefaultColorLyrics; // if undefined, no change. saves an if check
         let textHeight: number = this.rules.LyricsHeight;
         let xShift: number = 0;
-        if (endX - startX < 0.7) {
-            textHeight *= 0.9;
+        if (endX - startX < 0.8) {
+            textHeight *= 0.8;
             xShift = -0.2;
             // dashes in short/narrow intervals are slightly right-leaning and tend to overlap with right lyricsentry
-            //   see Cornelius - Christbaum, measure 9 ("li-che")
+            //   see Cornelius - Christbaum, measure 9 and 11 ("li-che", "li-ger")
         }
         const dash: GraphicalLabel = new GraphicalLabel(
             label, textHeight, TextAlignmentEnum.CenterBottom, this.rules);

--- a/test/data/test_lyrics_centering.musicxml
+++ b/test/data/test_lyrics_centering.musicxml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>test_lyrics_centering</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.6.2</software>
+      <encoding-date>2023-06-20</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935" default-y="1511.05" justify="center" valign="top" font-size="22">test_lyrics_centering</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="501.56">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="80.72" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>1</text>
+          </lyric>
+        </note>
+      <note default-x="185.48" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>and</text>
+          </lyric>
+        </note>
+      <note default-x="290.24" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>2</text>
+          </lyric>
+        </note>
+      <note default-x="395.00" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>+</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="2" width="477.14">
+      <note default-x="13.00" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>3</text>
+          </lyric>
+        </note>
+      <note default-x="123.87" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>II</text>
+          </lyric>
+        </note>
+      <note default-x="234.75" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental>sharp</accidental>
+        <stem>down</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>4</text>
+          </lyric>
+        </note>
+      <attributes>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          <clef-octave-change>1</clef-octave-change>
+          </clef>
+        </attributes>
+      <note default-x="355.62" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="6.50" default-y="-42.57" relative-y="-30.00">
+          <syllabic>single</syllabic>
+          <text>+</text>
+          </lyric>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Fixes #1407