### PR TITLE
Fix cursor type 3 when first measure(s) invisible

### DIFF
--- a/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
+++ b/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
@@ -219,8 +219,10 @@ export class GraphicalMusicSheet {
     }
 
     public findGraphicalMeasure(measureIndex: number, staffIndex: number): GraphicalMeasure {
+        // note the cursor calls this with measureIndex 1 (measure 2) when advancing beyond the end of a 1-measure piece
         for (let i: number = measureIndex; i >= 0; i--) {
-            const gMeasure: GraphicalMeasure = this.measureList[i][staffIndex];
+            const verticalMeasures: GraphicalMeasure[] = this.measureList[i];
+            const gMeasure: GraphicalMeasure = verticalMeasures?.[staffIndex];
             if (gMeasure) {
                 return gMeasure;
             }

--- a/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
+++ b/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
@@ -221,8 +221,7 @@ export class GraphicalMusicSheet {
     public findGraphicalMeasure(measureIndex: number, staffIndex: number): GraphicalMeasure {
         // note the cursor calls this with measureIndex 1 (measure 2) when advancing beyond the end of a 1-measure piece
         for (let i: number = measureIndex; i >= 0; i--) {
-            const verticalMeasures: GraphicalMeasure[] = this.measureList[i];
-            const gMeasure: GraphicalMeasure = verticalMeasures?.[staffIndex];
+            const gMeasure: GraphicalMeasure = this.measureList[i]?.[staffIndex];
             if (gMeasure) {
                 return gMeasure;
             }

--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -216,7 +216,11 @@ export class Cursor {
     height = endY - y;
 
     // Update the graphical cursor
-    const measurePositionAndShape: BoundingBox = this.graphic.findGraphicalMeasure(currentMeasureIndex, 0).PositionAndShape;
+    const visibleMeasure: GraphicalMeasure = this.findVisibleGraphicalMeasure(currentMeasureIndex);
+    if (!visibleMeasure) {
+      return;
+    }
+    const measurePositionAndShape: BoundingBox = visibleMeasure.PositionAndShape;
     this.updateWidthAndStyle(measurePositionAndShape, x, y, height);
 
     if (this.openSheetMusicDisplay.FollowCursor && this.cursorOptions.follow) {


### PR DESCRIPTION
after:
<img width="611" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/8a529485-cc9e-4708-8640-b0d15234cc7e">

before:
<img width="598" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/6c867066-9ac2-49d7-aa6d-7ef318e7b4d7">

after:
<img width="334" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/48b9abde-5bca-400a-a2a6-6dc6fc33ff28">

before:
<img width="301" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/75ff5598-8816-42c6-b7b1-9dd0f3ae8abe">

```js
osmd.Sheet.Instruments[0].Visible = false;
osmd.cursor.cursorOptions.type = 3
```