### PR TITLE
Fix tab errors for faulty xml files

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -867,7 +867,7 @@ export class VexFlowConverter {
             const tabNote: TabNote = note.sourceNote as TabNote;
             let tabPosition: {str: number, fret: number} = {str: tabNote.StringNumberTab, fret: tabNote.FretNumber};
             if (!(note.sourceNote instanceof TabNote)) {
-                log.info(`not a valid tab note: ${note.sourceNote.Pitch.ToString()} in measure ${gve.parentStaffEntry.parentMeasure.MeasureNumber}` +
+                log.info(`invalid tab note: ${note.sourceNote.Pitch.ToString()} in measure ${gve.parentStaffEntry.parentMeasure.MeasureNumber}` +
                     ", likely missing XML string+fret number.");
                 tabPosition = {str: 5, fret: 0};
             }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -866,7 +866,7 @@ export class VexFlowConverter {
         for (const note of gve.notes) {
             const tabNote: TabNote = note.sourceNote as TabNote;
             let tabPosition: {str: number, fret: number} = {str: tabNote.StringNumberTab, fret: tabNote.FretNumber};
-            if (!(note instanceof TabNote)) {
+            if (!(note.sourceNote instanceof TabNote)) {
                 log.info(`not a valid tab note: ${note.sourceNote.Pitch.ToString()} in measure ${gve.parentStaffEntry.parentMeasure.MeasureNumber}` +
                     ", likely missing XML string+fret number.");
                 tabPosition = {str: 5, fret: 0};

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -865,7 +865,12 @@ export class VexFlowConverter {
         let tabVibrato: boolean = false;
         for (const note of gve.notes) {
             const tabNote: TabNote = note.sourceNote as TabNote;
-            const tabPosition: {str: number, fret: number} = {str: tabNote.StringNumberTab, fret: tabNote.FretNumber};
+            let tabPosition: {str: number, fret: number} = {str: tabNote.StringNumberTab, fret: tabNote.FretNumber};
+            if (!(note instanceof TabNote)) {
+                log.info(`not a valid tab note: ${note.sourceNote.Pitch.ToString()} in measure ${gve.parentStaffEntry.parentMeasure.MeasureNumber}` +
+                    ", likely missing XML string+fret number.");
+                tabPosition = {str: 5, fret: 0};
+            }
             tabPositions.push(tabPosition);
             if (tabNote.BendArray) {
                 tabNote.BendArray.forEach( function( bend: {bendalter: number, direction: string} ): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -869,7 +869,7 @@ export class VexFlowConverter {
             if (!(note.sourceNote instanceof TabNote)) {
                 log.info(`invalid tab note: ${note.sourceNote.Pitch.ToString()} in measure ${gve.parentStaffEntry.parentMeasure.MeasureNumber}` +
                     ", likely missing XML string+fret number.");
-                tabPosition = {str: 5, fret: 0};
+                tabPosition = {str: 1, fret: 0}; // random safe values, otherwise it's both undefined for invalid notes
             }
             tabPositions.push(tabPosition);
             if (tabNote.BendArray) {

--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -460,7 +460,7 @@ export class VoiceGenerator {
     const pitch: Pitch = new Pitch(noteStep, noteOctave, noteAccidental, accidentalValue);
     const noteLength: Fraction = Fraction.createFromFraction(noteDuration);
     let note: Note = undefined;
-    let stringNumber: number = -1; //5 to always recognize as valid tab note
+    let stringNumber: number = -1; //1 to always recognize as valid tab note
     let fretNumber: number = -1; //0 to always recognize as valid tab note
     const bends: {bendalter: number, direction: string}[] = [];
     // check for guitar tabs:

--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -460,8 +460,8 @@ export class VoiceGenerator {
     const pitch: Pitch = new Pitch(noteStep, noteOctave, noteAccidental, accidentalValue);
     const noteLength: Fraction = Fraction.createFromFraction(noteDuration);
     let note: Note = undefined;
-    let stringNumber: number = -1;
-    let fretNumber: number = -1;
+    let stringNumber: number = -1; //5 to always recognize as valid tab note
+    let fretNumber: number = -1; //0 to always recognize as valid tab note
     const bends: {bendalter: number, direction: string}[] = [];
     // check for guitar tabs:
     const notationNode: IXmlElement = node.element("notations");

--- a/src/VexFlowPatch/readme.txt
+++ b/src/VexFlowPatch/readme.txt
@@ -21,9 +21,11 @@ able to add svg node id+class to beam (not yet in vexflow 4)
 clef.js (merged vexflow 4):
 open group to get SVG group+class for clef
 
-formatter.js (custom addition, unnecessary in vexflow 4):
+formatter.js:
 comment out unnecessary error thrown, which prevents the fix to
-layouting improvements with whole measure rests and e.g. 12/8 rhythm in #1187.
+  layouting improvements with whole measure rests and e.g. 12/8 rhythm in #1187.
+  (custom addition, unnecessary in vexflow 4)
+fix x set to NaN when totalTicks = 0 (bugfix for some tab scores, not sure if fixed in vexflow 4)
 
 gracenotegroup.js (custom addition, needs check if necessary in vexflow 4):
 check for gracenotegroup.spacing set, to allow e.g. spacing = 0 by default.

--- a/src/VexFlowPatch/src/formatter.js
+++ b/src/VexFlowPatch/src/formatter.js
@@ -484,7 +484,7 @@ export class Formatter {
     let totalTicks = this.totalTicks.value();
     if (totalTicks === 0) {
       totalTicks = 1;
-      // VexFlowPatch: this is not supposed to happen, but needs to be fixed if it does,
+      // VexFlowPatch: this is not supposed to happen, but does for faulty tab scores, needs fixing,
       //   so that leftoverPxPerTick doesn't become Infinity, and then x is set to NaN (via setX())
     }
     const leftoverPxPerTick = remainingX / (totalTicks * resolutionMultiplier);

--- a/src/VexFlowPatch/src/formatter.js
+++ b/src/VexFlowPatch/src/formatter.js
@@ -481,7 +481,13 @@ export class Formatter {
     // Pass 2: Take leftover width, and distribute it to proportionately to
     // all notes.
     const remainingX = justifyWidth - this.minTotalWidth;
-    const leftoverPxPerTick = remainingX / (this.totalTicks.value() * resolutionMultiplier);
+    let totalTicks = this.totalTicks.value();
+    if (totalTicks === 0) {
+      totalTicks = 1;
+      // VexFlowPatch: this is not supposed to happen, but needs to be fixed if it does,
+      //   so that leftoverPxPerTick doesn't become Infinity, and then x is set to NaN (via setX())
+    }
+    const leftoverPxPerTick = remainingX / (totalTicks * resolutionMultiplier);
     let spaceAccum = 0;
 
     contextList.forEach((tick, index) => {


### PR DESCRIPTION
* Fix error because x is NaN due to some faults in specific tab MusicXML files
* Fix error when string number and fret number are not provided in a MusicXML file, even though they always should be for non-rest notes. Report/log that these are missing instead.

reported by mimimix on Discord in the sponsor-dev channel
(sample `BORN_UNDER_A_BAD_SIGN_2.musicxml`)