### PR TITLE
Fix ledger rest moving downwards on re-render

### DIFF
--- a/src/VexFlowPatch/src/notehead.js
+++ b/src/VexFlowPatch/src/notehead.js
@@ -98,14 +98,15 @@ export class NoteHead extends Note {
     this.x_shift = head_options.x_shift || 0;
     // Swap out the glyph with ledger lines
     if (this.glyph.rest && (this.line > 5 || this.line < 0)) {
+      this.isLedgerLinedRest = true;
       if (this.duration === 'h') {
         head_options.custom_glyph_code = 'rhl';
         this.x_shift_ledger_rest -= 4;
-        this.y_shift_ledger_rest = -5; // was too far down
+        // this.y_shift_ledger_rest = 5; // was too far up
       } else if (this.duration === 'w') {
         head_options.custom_glyph_code = 'rwl';
         this.x_shift_ledger_rest -= 4;
-        this.y_shift_ledger_rest = 5; // was too far up
+        this.y_shift_ledger_rest = -5; // was too far down
       }
     }
     if (head_options.custom_glyph_code) {

--- a/test/data/test_ledger_line_rest.musicxml
+++ b/test/data/test_ledger_line_rest.musicxml
@@ -7,7 +7,7 @@
   <identification>
     <encoding>
       <software>MuseScore 3.6.2</software>
-      <encoding-date>2023-10-04</encoding-date>
+      <encoding-date>2024-01-08</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>
       <supports element="print" attribute="new-page" type="yes" value="yes"/>
@@ -111,7 +111,7 @@
         </backup>
       <note>
         <rest>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
           <display-octave>6</display-octave>
           </rest>
         <duration>4</duration>
@@ -145,7 +145,7 @@
         </backup>
       <note>
         <rest>
-          <display-step>D</display-step>
+          <display-step>C</display-step>
           <display-octave>3</display-octave>
           </rest>
         <duration>2</duration>
@@ -154,7 +154,7 @@
         </note>
       <note>
         <rest>
-          <display-step>D</display-step>
+          <display-step>C</display-step>
           <display-octave>3</display-octave>
           </rest>
         <duration>2</duration>


### PR DESCRIPTION
Related to #1142

visual regression diffs:
[diff_ledger-move.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/13872416/diff_ledger-move.zip)
