### PR TITLE
Fix (decrescendo) wedge startX in multi-instrument scores (further)

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1406,10 +1406,10 @@ export abstract class MusicSheetCalculator {
         const startCollideBox: BoundingBox =
             this.dynamicExpressionMap.get(graphicalContinuousDynamic.ContinuousDynamic.StartMultiExpression.AbsoluteTimestamp.RealValue);
         if (startCollideBox) {
-            startPosInStaffline.x = startCollideBox.RelativePosition.x + this.rules.WedgeHorizontalMargin;
             if ((startCollideBox.DataObject as any).ParentStaffLine === staffLine) {
                 // TODO the dynamicExpressionMap doesn't distinguish between staffLines, so we may react to a different staffline otherwise
                 //   so the more fundamental solution would be to fix dynamicExpressionMap mapping across stafflines.
+                startPosInStaffline.x = startCollideBox.RelativePosition.x + this.rules.WedgeHorizontalMargin;
                 startPosInStaffline.x += startCollideBox.BorderMarginRight;
             }
         }

--- a/test/data/test_wedge_cresc_dim_simultaneous_quartet.musicxml
+++ b/test/data/test_wedge_cresc_dim_simultaneous_quartet.musicxml
@@ -2,7 +2,7 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
   <work>
-    <work-title>test_cresc_dim_simultaneous_quartet</work-title>
+    <work-title>test_wedge_cresc_dim_simultaneous_quartet</work-title>
     </work>
   <identification>
     <encoding>
@@ -41,7 +41,7 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">test_cresc_dim_simultaneous_quartet</credit-words>
+    <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">test_wedge_cresc_dim_simultaneous_quartet</credit-words>
     </credit>
   <part-list>
     <part-group type="start" number="1">

--- a/test/data/test_wedge_crescendo_multi-instrument.musicxml
+++ b/test/data/test_wedge_crescendo_multi-instrument.musicxml
@@ -2,7 +2,7 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
   <work>
-    <work-title>test_crescendo_multi-instrument</work-title>
+    <work-title>test_wedge_crescendo_multi-instrument</work-title>
     </work>
   <identification>
     <encoding>
@@ -35,7 +35,7 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="646" default-y="1735.69" justify="center" valign="top" font-family="ZapfChancery Light" font-size="29.94">test_crescendo_multi-instrument</credit-words>
+    <credit-words default-x="646" default-y="1735.69" justify="center" valign="top" font-family="ZapfChancery Light" font-size="29.94">test_wedge_crescendo_multi-instrument</credit-words>
     </credit>
   <part-list>
     <part-group type="start" number="1">

--- a/test/data/test_wedge_decrescendo_crescendo_stop_start.musicxml
+++ b/test/data/test_wedge_decrescendo_crescendo_stop_start.musicxml
@@ -2,7 +2,7 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.1">
   <work>
-    <work-title>test_decrescendo_crescendo_stop_start</work-title>
+    <work-title>test_wedge_decrescendo_crescendo_stop_start</work-title>
     </work>
   <identification>
     <encoding>
@@ -35,7 +35,7 @@
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="646" default-y="1749.85" justify="center" valign="top" font-family="Edwin" font-size="22">test_decrescendo_crescendo_stop_start</credit-words>
+    <credit-words default-x="646" default-y="1749.85" justify="center" valign="top" font-family="Edwin" font-size="22">test_wedge_decrescendo_crescendo_stop_start</credit-words>
     </credit>
   <part-list>
     <score-part id="P1">

--- a/test/data/test_wedge_decrescendo_multi-instrument_startX.musicxml
+++ b/test/data/test_wedge_decrescendo_multi-instrument_startX.musicxml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <movement-title>test_wedge_decrescendo_multi-instrument_startX</movement-title>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.6.2</software>
+      <encoding-date>2024-01-30</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1697</page-height>
+      <page-width>1200</page-width>
+      <page-margins type="both">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="Edwin" font-size="11"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Violin</part-name>
+      <part-abbreviation>Vln.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Violin (solo)</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>41</midi-program>
+        <volume>78.7402</volume>
+        <pan>-46</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Cello</part-name>
+      <part-abbreviation>Vlc.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Violoncello</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>43</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="393.21">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>71.69</left-margin>
+            <right-margin>563.68</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>2</fifths>
+          <mode>major</mode>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="diminuendo" number="1" default-y="-63.64"/>
+          </direction-type>
+        </direction>
+      <note default-x="113.25" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <fermata type="upright" relative-y="5.00"/>
+          </notations>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="stop" number="1"/>
+          </direction-type>
+        </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1" width="393.21">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>2</fifths>
+          <mode>major</mode>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="diminuendo" number="1" default-y="-60.00"/>
+          </direction-type>
+        </direction>
+      <note default-x="113.25" default-y="-125.00">
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <fermata type="upright" relative-y="5.00"/>
+          </notations>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="stop" number="1"/>
+          </direction-type>
+        </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Additional fix for #1480, that fixes a similar problem in a new sample that we weren't aware of before.

Before:
<img width="227" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/a33527f5-eb6d-4d74-bedb-d12d7c26ba57">

After:
<img width="215" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/80702cb1-9b0e-4cc2-aa6d-d3fa22d6a1e4">

Basically no visual regressions, except in `test_wedge_crescendo_multi-instrument` the wedges are now better vertically aligned.
visual regressions:
[diff_wedge_startx-fix.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/14102274/diff_wedge_startx-fix.zip)

(had to rename a few images in the blessed sample, since the sample name changed)

Added new sample `test_wedge_decrescendo_multi-instrument_startX.musicxml`

Thanks to boblete for the report and sample!