### PR TITLE
SVG error fix for renderCurve()

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -190,6 +190,18 @@ export class SvgVexFlowBackend extends VexFlowBackend {
     }
 
     public renderCurve(points: PointF2D[]): Node {
+
+        //Here we want to make sure all points are numbers. If not, we will use the previous point.
+        //This avoids the "<path> attribute d: Expeced number." SVG error.
+        for (let i: number = 0; i < points.length; i++) {
+            if (isNaN(points[i].x)) {
+                points[i].x = points[i - 1].x;
+            }
+            if (isNaN(points[i].y)) {
+                points[i].y = points[i - 1].y;
+            }
+        }
+
         const node: Node = this.ctx.openGroup("curve");
         this.ctx.beginPath();
         this.ctx.moveTo(points[0].x, points[0].y);


### PR DESCRIPTION
Added check to renderCurve() function to make sure all numbers are used to avoid SVG path error: "<path> attribute d: Expected number." That may happen when there are slurs starting and ending on the same note (often slures not connected to any note in the original source score).

I am attaching the XML file that causes the error, note the last slur definition, that's causing it. It'd be nice if OSMD could show that slur in some way going towards the end of the bar as shown in the original source score below:

![slurOSMD](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/10005316/22778cee-9821-41d0-b923-404c9917509e)

[testSlurOSMD.musicxml.zip](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/files/14299039/testSlurOSMD.musicxml.zip)

