### PR TITLE
Add SourceMeasure.widthFactor, parse osmdWidthFactor attribute from xml

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -318,6 +318,7 @@ export abstract class MusicSheetCalculator {
             // minLength = minimumStaffEntriesWidth * 1.2 + maxInstrNameLabelLength + maxInstructionsLength;
             let maxWidth: number = 0;
             let measures: GraphicalMeasure[];
+            let measureWidthFactor: number = 1;
             for (let i: number = 0; i < this.graphicalMusicSheet.MeasureList.length; i++) {
                 measures = this.graphicalMusicSheet.MeasureList[i];
                 let minimumStaffEntriesWidth: number = this.calculateMeasureXLayout(measures);
@@ -325,6 +326,10 @@ export abstract class MusicSheetCalculator {
                 if (minimumStaffEntriesWidth > maxWidth) {
                     maxWidth = minimumStaffEntriesWidth;
                 }
+                if (measures[i]?.parentSourceMeasure.widthFactor) { // GraphicalMeasure might be undefined (multi-rest)
+                    measureWidthFactor = measures[i].parentSourceMeasure.widthFactor;
+                }
+                minimumStaffEntriesWidth *= measureWidthFactor;
                 //console.log(`min width for measure ${measures[0].MeasureNumber}: ${minimumStaffEntriesWidth}`);
                 MusicSheetCalculator.setMeasuresMinStaffEntriesWidth(measures, minimumStaffEntriesWidth);
                 // minLength = Math.max(minLength, minimumStaffEntriesWidth * 1.2 + maxInstructionsLength);

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -326,8 +326,11 @@ export abstract class MusicSheetCalculator {
                 if (minimumStaffEntriesWidth > maxWidth) {
                     maxWidth = minimumStaffEntriesWidth;
                 }
-                if (measures[i]?.parentSourceMeasure.widthFactor) { // GraphicalMeasure might be undefined (multi-rest)
-                    measureWidthFactor = measures[i].parentSourceMeasure.widthFactor;
+                for (const verticalMeasure of measures) {
+                    if (verticalMeasure?.parentSourceMeasure.widthFactor) { // some of these GraphicalMeasures might be undefined (multi-rest)
+                        measureWidthFactor = verticalMeasure.parentSourceMeasure.widthFactor;
+                        break;
+                    }
                 }
                 minimumStaffEntriesWidth *= measureWidthFactor;
                 //console.log(`min width for measure ${measures[0].MeasureNumber}: ${minimumStaffEntriesWidth}`);

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -137,7 +137,7 @@ export class InstrumentReader {
     let lastNoteWasGrace: boolean = false;
     try {
       const measureNode: IXmlElement = this.xmlMeasureList[this.currentXmlMeasureIndex];
-      const widthFactorAttr: IXmlAttribute = measureNode.attribute("widthFactor"); // custom xml attribute
+      const widthFactorAttr: IXmlAttribute = measureNode.attribute("osmdWidthFactor"); // custom xml attribute
       if (widthFactorAttr) {
         currentMeasure.widthFactor = Number.parseFloat(widthFactorAttr.value);
       }

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -137,6 +137,10 @@ export class InstrumentReader {
     let lastNoteWasGrace: boolean = false;
     try {
       const measureNode: IXmlElement = this.xmlMeasureList[this.currentXmlMeasureIndex];
+      const widthFactorAttr: IXmlAttribute = measureNode.attribute("widthFactor"); // custom xml attribute
+      if (widthFactorAttr) {
+        currentMeasure.widthFactor = Number.parseFloat(widthFactorAttr.value);
+      }
       const xmlMeasureListArr: IXmlElement[] = measureNode.elements();
       if (currentMeasure.Rules.UseXMLMeasureNumbers && !Number.isInteger(currentMeasure.MeasureNumberXML)) {
         const measureNumberXml: number = parseInt(measureNode.attribute("number")?.value, 10);

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -64,8 +64,8 @@ export class SourceMeasure {
      * E.g. factor 0.6 = 60% will make the measure only 60% as long as before.
      * Note that this potentially causes issues by counteracting systems like lyrics overlap prevention,
      * and if you give Vexflow too little width to render it will eventually cause other layout issues too.
-     * This factor is also read by a custom XML attribute widthFactor in the measure node,
-     *   e.g. <measure number="1" widthFactor="0.6">
+     * This factor is also read by a custom XML attribute osmdWidthFactor in the measure node,
+     *   e.g. <measure number="1" osmdWidthFactor="0.6">
      * This will either be multiplicative with a sheet-wide widthFactor or override it, depending on settings.
      *   (TODO sheet-wide widthFactor not yet implemented)
      */

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -60,6 +60,16 @@ export class SourceMeasure {
     /** Whether the MusicXML says to print a new page (page break). See OSMDOptions.newPageFromXML */
     public printNewPageXml: boolean = false;
     public IsSystemStartMeasure: boolean = false;
+    /** The graphical measure width will be multiplied by this factor.
+     * E.g. factor 0.6 = 60% will make the measure only 60% as long as before.
+     * Note that this potentially causes issues by counteracting systems like lyrics overlap prevention,
+     * and if you give Vexflow too little width to render it will eventually cause other layout issues too.
+     * This factor is also read by a custom XML attribute widthFactor in the measure node,
+     *   e.g. <measure number="1" widthFactor="0.6">
+     * This will either be multiplicative with a sheet-wide widthFactor or override it, depending on settings.
+     *   (TODO sheet-wide widthFactor not yet implemented)
+     */
+    public widthFactor: number = 1;
 
     private measureNumber: number;
     public MeasureNumberXML: number;

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -339,16 +339,10 @@ export interface CursorOptions {
      * 4: Current measure to left of current notes
      */
     type: CursorType;
-    /**
-     * Color to draw the cursor
-     */
+    /** Color to draw the cursor */
     color: string;
-    /**
-     * alpha value to be used with color (0.0 transparent, 0.5 medium, 1.0 opaque).
-     */
+    /** alpha value to be used with color (0.0 transparent, 0.5 medium, 1.0 opaque). */
     alpha: number;
-    /**
-     * If true, this cursor will be followed.
-     */
+    /** If true, this cursor will be followed. */
     follow: boolean;
 }

--- a/test/data/Beethoven_AnDieFerneGeliebte.xml
+++ b/test/data/Beethoven_AnDieFerneGeliebte.xml
@@ -103,7 +103,7 @@
   </part-list>
   <!--=========================================================-->
   <part id="P1">
-    <measure number="1" width="324" widthFactor="1.0">
+    <measure number="1" width="324" osmdWidthFactor="1.0">
       <print page-number="1">
         <system-layout>
           <system-margins>

--- a/test/data/Beethoven_AnDieFerneGeliebte.xml
+++ b/test/data/Beethoven_AnDieFerneGeliebte.xml
@@ -103,7 +103,7 @@
   </part-list>
   <!--=========================================================-->
   <part id="P1">
-    <measure number="1" width="324">
+    <measure number="1" width="324" widthFactor="1.0">
       <print page-number="1">
         <system-layout>
           <system-margins>


### PR DESCRIPTION
Adds widthFactor for individual measures (osmdWidthFactor), first part of #1534.
(second part will be global scale factor for all measures)

e.g.:
```xml
<measure number="1" osmdWidthFactor="0.7"/>
```
This will make measure 1 only 70% as wide as OSMD would make it otherwise.
after:
<img width="170" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/66c523f1-892a-4ca8-b1f9-da6eb6a70c1d">

before:
<img width="196" alt="image" src="https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/assets/33069673/ea43aa25-7a26-495b-a2aa-750c7597c601">

You can also set this factor manually in SourceMeasure.widthFactor:
```js
osmd.Sheet.SourceMeasures[0].widthFactor = 0.7;
osmd.render();
```

We will also soon add a similar attribute for a global scale factor `x` that will scale all measure widths by `x`.

Note that if you make the factor too low (shrink measures too much), there might be overlaps and other layout issues, especially with lyrics. So use this with caution and at your own risk ;)