### PR TITLE
Fix MusicPartManagerIterator.CurrentVisibleVoiceEntries() not filtering by instrument correctly.

### DIFF
--- a/src/MusicalScore/MusicParts/MusicPartManagerIterator.ts
+++ b/src/MusicalScore/MusicParts/MusicPartManagerIterator.ts
@@ -168,13 +168,12 @@ export class MusicPartManagerIterator {
             for (const entry of this.currentVoiceEntries) {
                 if (entry.ParentVoice.Parent.IdString === instrument.IdString) {
                     this.getVisibleEntries(entry, voiceEntries);
-                    return voiceEntries;
                 }
             }
-        } else {
-            for (const entry of this.currentVoiceEntries) {
-                this.getVisibleEntries(entry, voiceEntries);
-            }
+            return voiceEntries;
+        }
+        for (const entry of this.currentVoiceEntries) {
+            this.getVisibleEntries(entry, voiceEntries);
         }
         return voiceEntries;
     }


### PR DESCRIPTION
Function returns before checking other voice entries for the same `instrument.idString`.  

repro:

Choose any score with instruments having more than one voice, e.g. _An die Ferne Geliebete_ and compare the results of
`osmd.cursor.VoicesUnderCursor().filter(voice => voice.parentVoice.parent.idString === osmd.sheet.instruments[1].idString)` 
against
`osmd.cursor.VoicesUnderCursor(osmd.sheet.instruments[1])`.

Before change:
![image](https://github.com/user-attachments/assets/282eecbb-1ef5-4e20-a710-8ed2beca6797)

After change:
![image](https://github.com/user-attachments/assets/15818fe9-890b-4aec-912a-56e993ba2b25)

