### PR TITLE
add support for color display for MoodExpression, UnknownExpression and ContinuousDynamicExpression

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -798,6 +798,10 @@ export abstract class MusicSheetCalculator {
                                                                 multiExpression.getFontstyleOfFirstEntry(),
                                                                 placement,
                                                                 fontHeight);
+        const colorXML: string = multiExpression.getColorXMLOfFirstEntry();
+        if (this.rules.ExpressionsUseXMLColor && colorXML) {
+            graphLabel.ColorXML = colorXML;
+        }
         if (this.rules.PlaceWordsInsideStafflineFromXml) {
             if (defaultYXml < 0 && defaultYXml > -50) { // within staffline
                 let newY: number = defaultYXml / 10; // OSMD units

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowContinuousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowContinuousDynamicExpression.ts
@@ -25,6 +25,10 @@ export class VexFlowContinuousDynamicExpression extends GraphicalContinuousDynam
             this.label.Label.fontStyle = FontStyles.Italic;
             this.label.setLabelPositionAndShapeBorders();
             this.PositionAndShape.calculateBoundingBox();
+
+            if (continuousDynamic.ColorXML && this.rules.ExpressionsUseXMLColor) {
+                this.label.ColorXML = continuousDynamic.ColorXML;
+            }
         }
     }
 }

--- a/src/MusicalScore/VoiceData/Expressions/MultiExpression.ts
+++ b/src/MusicalScore/VoiceData/Expressions/MultiExpression.ts
@@ -131,6 +131,14 @@ export class MultiExpression {
        }
        return fontStyle;
     }
+
+    public getColorXMLOfFirstEntry(): string {
+        let colorXML: string;
+        if (this.expressions.length) {
+            colorXML = this.expressions[0].expression.ColorXML;
+        }
+        return colorXML;
+     }
     //public getFirstEntry(staffLine: StaffLine, graphLabel: GraphicalLabel): AbstractGraphicalExpression {
     //    let indexOfFirstNotInstDynExpr: number = 0;
     //    if (this.expressions[0].expression instanceof InstantaneousDynamicExpression)

--- a/test/data/test_direction_color.musicxml
+++ b/test/data/test_direction_color.musicxml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
-<score-partwise version="3.1">
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
   <work>
     <work-title>test_direction_color</work-title>
     </work>
   <identification>
     <encoding>
-      <software>MuseScore 3.6.2</software>
-      <encoding-date>2024-01-09</encoding-date>
+      <software>MuseScore 4.5.2</software>
+      <encoding-date>2025-07-09</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>
       <supports element="print" attribute="new-page" type="yes" value="yes"/>
@@ -17,31 +17,56 @@
     </identification>
   <defaults>
     <scaling>
-      <millimeters>6.99911</millimeters>
+      <millimeters>6.99912</millimeters>
       <tenths>40</tenths>
       </scaling>
     <page-layout>
       <page-height>1596.77</page-height>
       <page-width>1233.87</page-width>
       <page-margins type="even">
-        <left-margin>85.7252</left-margin>
-        <right-margin>85.7252</right-margin>
-        <top-margin>85.7252</top-margin>
-        <bottom-margin>85.7252</bottom-margin>
+        <left-margin>85.725</left-margin>
+        <right-margin>85.725</right-margin>
+        <top-margin>85.725</top-margin>
+        <bottom-margin>85.725</bottom-margin>
         </page-margins>
       <page-margins type="odd">
-        <left-margin>85.7252</left-margin>
-        <right-margin>85.7252</right-margin>
-        <top-margin>85.7252</top-margin>
-        <bottom-margin>85.7252</bottom-margin>
+        <left-margin>85.725</left-margin>
+        <right-margin>85.725</right-margin>
+        <top-margin>85.725</top-margin>
+        <bottom-margin>85.725</bottom-margin>
         </page-margins>
       </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
     <word-font font-family="Edwin" font-size="10"/>
     <lyric-font font-family="Edwin" font-size="10"/>
     </defaults>
   <credit page="1">
     <credit-type>title</credit-type>
-    <credit-words default-x="616.935" default-y="1511.05" justify="center" valign="top" font-size="22">test_direction_color</credit-words>
+    <credit-words default-x="616.933975" default-y="1511.141929" justify="center" valign="top" font-size="22">test_direction_color</credit-words>
     </credit>
   <part-list>
     <score-part id="P1">
@@ -49,6 +74,7 @@
       <part-abbreviation>Pno.</part-abbreviation>
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
         </score-instrument>
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
@@ -60,18 +86,18 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="306.47">
+    <measure number="1" width="146.75">
       <print>
         <system-layout>
           <system-margins>
-            <left-margin>50.00</left-margin>
-            <right-margin>672.23</right-margin>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
             </system-margins>
-          <top-system-distance>170.00</top-system-distance>
+          <top-system-distance>170</top-system-distance>
           </system-layout>
         </print>
       <attributes>
-        <divisions>1</divisions>
+        <divisions>2</divisions>
         <key>
           <fifths>0</fifths>
           </key>
@@ -86,17 +112,40 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <words color="#0000FF" relative-x="-10.20" relative-y="11.70">Allegro</words>
+          <words color="#0000FF" relative-x="-75" relative-y="40">Allegro</words>
           </direction-type>
         </direction>
-      <note default-x="80.72" default-y="-30.00">
+      <direction placement="above">
+        <direction-type>
+          <words color="#FF0000" relative-x="-75" relative-y="20">affettuoso</words>
+          </direction-type>
+        </direction>
+      <note default-x="79.25" default-y="-30">
         <pitch>
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>4</duration>
+        <duration>8</duration>
         <voice>1</voice>
         <type>whole</type>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <words color="#00FF00" default-y="-40" relative-y="-20">crescendo</words>
+          </direction-type>
+        <offset>-6</offset>
+        </direction>
+      </measure>
+    <measure number="2" width="84.23">
+      <direction placement="above">
+        <direction-type>
+          <words color="#FF00FF" relative-y="5">unknown</words>
+          </direction-type>
+        </direction>
+      <note default-x="30.12" default-y="-10">
+        <rest measure="yes"/>
+        <duration>8</duration>
+        <voice>1</voice>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
PR [#1498](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/pull/1498) have add support for the font color for InstantaneousTempoExpression. The font color for some other expressions still do not take effect. 

The current PR adds support for MoodExpression, UnknownExpression and ContinuousDynamicExpression. 

Before:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/fb95407c-a718-4599-8a8a-95a1aca151e9" />

After:
<img width="575" alt="image" src="https://github.com/user-attachments/assets/c71f5ac7-2df9-43d6-aece-4b8520495dcf" />

(I tried to add support for other expression like InstantaneousDynamicExpression as well but did not succeed).