### PR TITLE
Fix: Tuplet multi-voice alignment in VexFlow rendering

### DIFF
--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_TupletAlignment_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_TupletAlignment_Test.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import {GraphicalMusicSheet} from "../../../../src/MusicalScore/Graphical/GraphicalMusicSheet";
+import {IXmlElement} from "../../../../src/Common/FileIO/Xml";
+import {MusicSheet} from "../../../../src/MusicalScore/MusicSheet";
+import {MusicSheetReader} from "../../../../src/MusicalScore/ScoreIO/MusicSheetReader";
+import {VexFlowMusicSheetCalculator} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator";
+import {TestUtils} from "../../../Util/TestUtils";
+import {VexFlowMeasure} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowMeasure";
+import {VexFlowVoiceEntry} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry";
+import {Note} from "../../../../src/MusicalScore/VoiceData/Note";
+import {Fraction} from "../../../../src/Common/DataObjects/Fraction";
+import Vex from "vexflow";
+import VF = Vex.Flow;
+
+describe("VexFlow Measure - Tuplet Voice Alignment", () => {
+
+   it("Should normalize tick denominators for tuplet notes", (done: Mocha.Done) => {
+      const path: string = "test_tuplet_multivoice_alignment.musicxml";
+      const score: Document = TestUtils.getScore(path);
+      chai.expect(score).to.not.be.undefined;
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      chai.expect(partwise).to.not.be.undefined;
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+
+      // Get the first measure
+      chai.expect(gms.MeasureList.length).to.be.greaterThan(0);
+      chai.expect(gms.MeasureList[0].length).to.be.greaterThan(0);
+      const measure: VexFlowMeasure = gms.MeasureList[0][0] as VexFlowMeasure;
+
+      // Verify that all notes have their tick denominators normalized to 1
+      for (const staffEntry of measure.staffEntries) {
+         for (const gve of staffEntry.graphicalVoiceEntries) {
+            const vfVoiceEntry: VexFlowVoiceEntry = gve as VexFlowVoiceEntry;
+            if (vfVoiceEntry.vfStaveNote) {
+               const ticks: VF.Fraction = vfVoiceEntry.vfStaveNote.getTicks();
+               chai.expect(ticks.denominator).to.equal(1,
+                  "All tick denominators should be normalized to 1");
+            }
+         }
+      }
+
+      done();
+   });
+
+   it("Should calculate correct tick values for tuplet notes based on graphical length", (done: Mocha.Done) => {
+      const path: string = "test_tuplet_multivoice_alignment.musicxml";
+      const score: Document = TestUtils.getScore(path);
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+
+      const measure: VexFlowMeasure = gms.MeasureList[0][0] as VexFlowMeasure;
+
+      // Get voices from the VexFlow measure
+      const vfVoices: { [voiceID: number]: VF.Voice } = measure.vfVoices;
+      const voiceIds: string[] = Object.keys(vfVoices);
+
+      chai.expect(voiceIds.length).to.be.greaterThan(1, "Should have multiple voices");
+
+      // Voice 1 should have 6 tuplet eighth notes, each with the same tick value
+      const voice1: VF.Voice = vfVoices[voiceIds[0]];
+      const voice1Tickables: VF.Tickable[] = voice1.getTickables();
+
+      // All voice 1 notes should have identical tick values (tuplet eighths)
+      const firstNoteTicks: number = voice1Tickables[0].getTicks().value();
+      for (let i: number = 1; i < voice1Tickables.length; i++) {
+         const tickValue: number = voice1Tickables[i].getTicks().value();
+         chai.expect(tickValue).to.equal(firstNoteTicks,
+            "All tuplet eighths in voice 1 should have the same tick value");
+      }
+
+      done();
+   });
+
+   it("Should align notes at same timestamp in different voices", (done: Mocha.Done) => {
+      const path: string = "test_tuplet_multivoice_alignment.musicxml";
+      const score: Document = TestUtils.getScore(path);
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+
+      const measure: VexFlowMeasure = gms.MeasureList[0][0] as VexFlowMeasure;
+      const vfVoices: { [voiceID: number]: VF.Voice } = measure.vfVoices;
+      const voiceIds: string[] = Object.keys(vfVoices);
+
+      // Get tickables from both voices
+      const voice1Tickables: VF.Note[] = vfVoices[voiceIds[0]].getTickables();
+      const voice2Tickables: VF.Note[] = vfVoices[voiceIds[1]].getTickables();
+
+      // Calculate cumulative positions
+      let voice1Pos: number = 0;
+      const voice1Positions: number[] = [];
+      for (const tickable of voice1Tickables) {
+         voice1Positions.push(voice1Pos);
+         voice1Pos += tickable.getTicks().value();
+      }
+
+      let voice2Pos: number = 0;
+      const voice2Positions: number[] = [];
+      for (const tickable of voice2Tickables) {
+         voice2Positions.push(voice2Pos);
+         voice2Pos += tickable.getTicks().value();
+      }
+
+      // Voice 2's first quarter note (at position voice2Positions[1])
+      // should align with Voice 1's second eighth note (at position voice1Positions[1])
+      // Both should be at the same cumulative tick position
+      const voice1SecondNotePos: number = voice1Positions[1];
+      const voice2QuarterNotePos: number = voice2Positions[1];
+
+      chai.expect(voice2QuarterNotePos).to.equal(voice1SecondNotePos,
+         "Notes at the same timestamp in different voices should have the same cumulative tick position");
+
+      done();
+   });
+
+   it("Should handle tuplets with different normal-type values correctly", (done: Mocha.Done) => {
+      const path: string = "test_tuplet_multivoice_alignment.musicxml";
+      const score: Document = TestUtils.getScore(path);
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+
+      const measure: VexFlowMeasure = gms.MeasureList[0][0] as VexFlowMeasure;
+
+      // Verify that tuplet notes with different normal-type (16th, 32nd)
+      // are still calculated correctly based on their graphical length
+      for (const staffEntry of measure.staffEntries) {
+         for (const gve of staffEntry.graphicalVoiceEntries) {
+            const vfVoiceEntry: VexFlowVoiceEntry = gve as VexFlowVoiceEntry;
+            if (vfVoiceEntry.notes.length > 0 && vfVoiceEntry.notes[0].sourceNote) {
+               const sourceNote: Note = vfVoiceEntry.notes[0].sourceNote;
+               if (sourceNote.NoteTuplet && vfVoiceEntry.vfStaveNote) {
+                  const ticks: VF.Fraction = vfVoiceEntry.vfStaveNote.getTicks();
+                  const graphicalLength: Fraction = vfVoiceEntry.notes[0].graphicalNoteLength;
+                  const expectedTicks: number = Math.round(graphicalLength.RealValue * VF.RESOLUTION);
+
+                  chai.expect(ticks.numerator).to.equal(expectedTicks,
+                     "Tuplet note tick value should match its graphical length");
+                  chai.expect(ticks.denominator).to.equal(1,
+                     "Tuplet note tick denominator should be 1");
+               }
+            }
+         }
+      }
+
+      done();
+   });
+
+});

--- a/test/data/test_tuplet_multivoice_alignment.musicxml
+++ b/test/data/test_tuplet_multivoice_alignment.musicxml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Tuplet Multi-Voice Alignment Test</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>OSMD Test</software>
+      <encoding-date>2025-12-17</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>28</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>9</beats>
+          <beat-type>8</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <!-- Voice 1: 6-tuplet eighth notes (6 in the space of 9 eighths) -->
+      <note>
+        <rest/>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <notations>
+          <tuplet type="start" bracket="yes"/>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+      </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+        </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+        </notations>
+      </note>
+      <backup>
+        <duration>126</duration>
+      </backup>
+      <!-- Voice 2: Also 6:9 tuplet, but with different note durations
+           This quarter note should align with Voice 1's second eighth note -->
+      <note print-object="no">
+        <rest/>
+        <duration>21</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+          <normal-type>16th</normal-type>
+        </time-modification>
+        <notations>
+          <tuplet type="start" bracket="yes"/>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>42</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+          <normal-type>16th</normal-type>
+        </time-modification>
+        <stem>down</stem>
+        <notations>
+          <tuplet type="stop"/>
+        </notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>42</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+          <normal-type>16th</normal-type>
+        </time-modification>
+        <stem>down</stem>
+      </note>
+      <forward>
+        <duration>21</duration>
+      </forward>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>42</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+          <normal-type>32nd</normal-type>
+        </time-modification>
+        <stem>down</stem>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          <tuplet type="stop"/>
+        </notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>42</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>6</actual-notes>
+          <normal-notes>9</normal-notes>
+          <normal-type>32nd</normal-type>
+        </time-modification>
+        <stem>down</stem>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
# Problem

Notes in different voices that should be aligned at the same timestamp were being rendered at different horizontal positions when tuplets were involved. This was particularly noticeable in complex pieces like Debussy's "Clair de Lune" where multiple voices have tuplet notes with different durations (e.g., eighth notes in one voice, quarter notes in another) but the same tuplet ratio.

## Root Cause:
  1. VexFlow was using tick fractions with different denominators for tuplet notes (e.g., 3072/6) vs non-tuplet notes (2048/1), preventing proper alignment
  2. More critically, VexFlow calculated tick values based on note type (eighth = 2048 ticks) rather than the actual duration from MusicXML, causing misalignment when different voices had tuplet notes with the same start timestamp but different visual durations

# Solution

## Modified /src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts (lines 1405-1427) to:

1. Normalize tick denominators: Convert all tick fractions to denominator of 1 (e.g., 3072/6 → 3072/1)
2. Recalculate tuplet note ticks: For notes that are part of a tuplet, calculate tick values based on their actual graphical note length from MusicXML using VF.RESOLUTION rather than relying on VexFlow's default tick calculation

```typescript
// Calculate ticks from the actual graphical note length
// graphicalLength.RealValue is the note length as a fraction of a whole note (e.g., 0.5 for half note)
// VF.RESOLUTION is the number of ticks for a whole note
const graphicalLength: Fraction = voiceEntry.notes[0].graphicalNoteLength;
const noteTicks: number = Math.round(graphicalLength.RealValue * VF.RESOLUTION);
ticks.numerator = noteTicks;
ticks.denominator = 1;
```
This ensures that all notes at the same timestamp have their x-positions correctly aligned by VexFlow's formatter, regardless of whether they're in different voices or have different durations.

## Testing

Added comprehensive test suite in /test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_TupletAlignment_Test.ts with 4 tests:

- ✅ Tick denominator normalization for tuplet notes
- ✅ Correct tick calculation based on graphical length
- ✅ Voice alignment at same timestamps
- ✅ Handling of different normal-type values (16th, 32nd)

Also created test MusicXML file: /test/data/test_tuplet_multivoice_alignment.musicxml

All tests pass, including existing regression tests.

## Visual Comparison

### Before
<img width="271" height="543" alt="Screenshot 2025-12-19 at 21 46 32" src="https://github.com/user-attachments/assets/143e30fc-57b7-45e1-97d5-265006b21b8f" />

> Before: Notes that should be vertically aligned appear at different horizontal positions

### After
<img width="350" height="818" alt="Screenshot 2025-12-19 at 21 45 16" src="https://github.com/user-attachments/assets/21e6f798-7ffe-4d7e-9e3a-980966115cf8" />

> After: Notes at the same timestamp are properly aligned across all voices

## Files Changed

- src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts - Core fix
- test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_TupletAlignment_Test.ts - Test suite (new)
- test/data/test_tuplet_multivoice_alignment.musicxml - Test data (new)