### PR TITLE
Fix grace note fingering positioning

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1632,6 +1632,9 @@ export class VexFlowMeasure extends GraphicalMeasure {
             }
             let offsetX: number = this.rules.FingeringOffsetX;
             let modifierPosition: number; // VF.Stavemodifier.Position
+            // baseFingeringXOffset is now calculated per voice entry for grace notes
+            // (in VexFlowStaffEntry.setModifierXOffsets), so it correctly handles
+            // collision avoidance within each chord without cross-chord interference.
             switch (fingeringPosition) {
                 default:
                 case PlacementEnum.Left:

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1632,9 +1632,6 @@ export class VexFlowMeasure extends GraphicalMeasure {
             }
             let offsetX: number = this.rules.FingeringOffsetX;
             let modifierPosition: number; // VF.Stavemodifier.Position
-            // baseFingeringXOffset is now calculated per voice entry for grace notes
-            // (in VexFlowStaffEntry.setModifierXOffsets), so it correctly handles
-            // collision avoidance within each chord without cross-chord interference.
             switch (fingeringPosition) {
                 default:
                 case PlacementEnum.Left:

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -106,17 +106,37 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
 
     // should be called after VexFlowConverter.StaveNote
     public setModifierXOffsets(): void {
-        let notes: GraphicalNote[] = [];
+        // Grace notes are at different horizontal positions than other notes,
+        // so we calculate collision offsets separately for each grace note voice entry.
+        // Non-grace notes at the same timestamp share the same X position, so they're grouped together.
+        const nonGraceNotes: GraphicalNote[] = [];
+
         for (const gve of this.graphicalVoiceEntries) {
-            notes = notes.concat(gve.notes);
+            const isGrace: boolean = gve.parentVoiceEntry?.IsGrace ?? false;
+            if (isGrace) {
+                // Calculate offsets only within this grace note voice entry
+                const graceStaffLines: number[] = gve.notes.map(n => n.staffLine);
+                const graceStringOffsets: number[] = this.calculateModifierXOffsets(graceStaffLines, 1);
+                const graceFingeringOffsets: number[] = this.calculateModifierXOffsets(graceStaffLines, 0.5);
+                gve.notes.forEach((note, i) => {
+                    note.baseFingeringXOffset = graceFingeringOffsets[i];
+                    note.baseStringNumberXOffset = graceStringOffsets[i];
+                });
+            } else {
+                nonGraceNotes.push(...gve.notes);
+            }
         }
-        const staffLines: number[] = notes.map(n => n.staffLine);
-        const stringNumberOffsets: number[] = this.calculateModifierXOffsets(staffLines, 1);
-        const fingeringOffsets: number[] = this.calculateModifierXOffsets(staffLines, 0.5);
-        notes.forEach((note, i) => {
-            note.baseFingeringXOffset = fingeringOffsets[i];
-            note.baseStringNumberXOffset = stringNumberOffsets[i];
-        });
+
+        // Calculate offsets for all non-grace notes together (they share the same X position)
+        if (nonGraceNotes.length > 0) {
+            const staffLines: number[] = nonGraceNotes.map(n => n.staffLine);
+            const stringNumberOffsets: number[] = this.calculateModifierXOffsets(staffLines, 1);
+            const fingeringOffsets: number[] = this.calculateModifierXOffsets(staffLines, 0.5);
+            nonGraceNotes.forEach((note, i) => {
+                note.baseFingeringXOffset = fingeringOffsets[i];
+                note.baseStringNumberXOffset = stringNumberOffsets[i];
+            });
+        }
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowStaffEntry.ts
@@ -114,29 +114,26 @@ export class VexFlowStaffEntry extends GraphicalStaffEntry {
         for (const gve of this.graphicalVoiceEntries) {
             const isGrace: boolean = gve.parentVoiceEntry?.IsGrace ?? false;
             if (isGrace) {
-                // Calculate offsets only within this grace note voice entry
-                const graceStaffLines: number[] = gve.notes.map(n => n.staffLine);
-                const graceStringOffsets: number[] = this.calculateModifierXOffsets(graceStaffLines, 1);
-                const graceFingeringOffsets: number[] = this.calculateModifierXOffsets(graceStaffLines, 0.5);
-                gve.notes.forEach((note, i) => {
-                    note.baseFingeringXOffset = graceFingeringOffsets[i];
-                    note.baseStringNumberXOffset = graceStringOffsets[i];
-                });
+                this.applyModifierOffsets(gve.notes);
             } else {
                 nonGraceNotes.push(...gve.notes);
             }
         }
 
-        // Calculate offsets for all non-grace notes together (they share the same X position)
-        if (nonGraceNotes.length > 0) {
-            const staffLines: number[] = nonGraceNotes.map(n => n.staffLine);
-            const stringNumberOffsets: number[] = this.calculateModifierXOffsets(staffLines, 1);
-            const fingeringOffsets: number[] = this.calculateModifierXOffsets(staffLines, 0.5);
-            nonGraceNotes.forEach((note, i) => {
-                note.baseFingeringXOffset = fingeringOffsets[i];
-                note.baseStringNumberXOffset = stringNumberOffsets[i];
-            });
+        this.applyModifierOffsets(nonGraceNotes);
+    }
+
+    private applyModifierOffsets(notes: GraphicalNote[]): void {
+        if (notes.length === 0) {
+            return;
         }
+        const staffLines: number[] = notes.map(n => n.staffLine);
+        const fingeringOffsets: number[] = this.calculateModifierXOffsets(staffLines, 0.5);
+        const stringNumberOffsets: number[] = this.calculateModifierXOffsets(staffLines, 1);
+        notes.forEach((note, i) => {
+            note.baseFingeringXOffset = fingeringOffsets[i];
+            note.baseStringNumberXOffset = stringNumberOffsets[i];
+        });
     }
 
     /**

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -11,6 +11,11 @@ import {MusicSheetCalculator} from "../../../../src/MusicalScore/Graphical/Music
 import {EngravingRules} from "../../../../src/MusicalScore/Graphical/EngravingRules";
 import { Staff } from "../../../../src/MusicalScore/VoiceData/Staff";
 import { Instrument } from "../../../../src/MusicalScore/Instrument";
+import { OpenSheetMusicDisplay } from "../../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
+import { VexFlowVoiceEntry } from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry";
+import { GraphicalMeasure } from "../../../../src/MusicalScore/Graphical/GraphicalMeasure";
+import { GraphicalStaffEntry } from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
+import { GraphicalVoiceEntry } from "../../../../src/MusicalScore/Graphical/GraphicalVoiceEntry";
 
 describe("VexFlow Measure", () => {
 
@@ -42,6 +47,63 @@ describe("VexFlow Measure", () => {
       chai.expect(gms.MeasureList[0].length).to.equal(1);
       chai.expect(gms.MeasureList[0][0].staffEntries.length).to.equal(0);
       done();
+   });
+
+   // Non-regression test for grace note fingering positioning
+   // Before fix: fingerings on grace notes were incorrectly shifted due to chord collision offset
+   // being applied, causing e.g. the second grace note's fingering to appear above the first grace note.
+   // The fix skips applying baseFingeringXOffset for grace notes since they're already horizontally separated.
+   it("Grace note fingerings should render correctly without chord collision offset", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("test_grace_note_fingerings_position.musicxml");
+      const div: HTMLElement = TestUtils.getDivElement(document);
+      const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
+
+      osmd.load(score).then(
+         (_: {}) => {
+            osmd.render();
+
+            // Get the first measure
+            const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, 0);
+            chai.expect(gm).to.not.be.undefined;
+
+            // Get the first staff entry which should contain grace notes
+            const staffEntry: GraphicalStaffEntry = gm.staffEntries[0];
+            chai.expect(staffEntry).to.not.be.undefined;
+
+            // Check that we have grace voice entries with fingerings
+            const graceVoiceEntries: GraphicalVoiceEntry[] = staffEntry.graphicalVoiceEntries.filter(
+               (gve: VexFlowVoiceEntry) => gve.parentVoiceEntry?.IsGrace
+            );
+            chai.expect(graceVoiceEntries.length).to.equal(2);
+
+            // Verify each grace note has a fingering defined in the source
+            let fingeringsFound: number = 0;
+            for (const gve of graceVoiceEntries) {
+               for (const note of gve.notes) {
+                  if (note.sourceNote.Fingering) {
+                     fingeringsFound++;
+                  }
+               }
+            }
+            chai.expect(fingeringsFound).to.equal(2);
+
+            // Verify the vfStaveNote modifiers contain the fingerings
+            // This ensures the fingerings were actually added to the VexFlow notes
+            for (const gve of graceVoiceEntries as VexFlowVoiceEntry[]) {
+               // eslint-disable-next-line @typescript-eslint/no-explicit-any
+               const modifiers: any[] = (gve.vfStaveNote as any).getModifiers();
+               // eslint-disable-next-line @typescript-eslint/no-explicit-any
+               const fingeringModifiers: any[] = modifiers.filter(
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (m: any) => m.getCategory() === "frethandfinger"
+               );
+               chai.expect(fingeringModifiers.length).to.be.greaterThan(0);
+            }
+
+            done();
+         },
+         done
+      );
    });
 
 });

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -50,10 +50,10 @@ describe("VexFlow Measure", () => {
    });
 
    // Non-regression test for grace note fingering positioning
-   // Before fix: fingerings on grace notes were incorrectly shifted due to chord collision offset
-   // being applied, causing e.g. the second grace note's fingering to appear above the first grace note.
-   // The fix skips applying baseFingeringXOffset for grace notes since they're already horizontally separated.
-   it("Grace note fingerings should render correctly without chord collision offset", (done: Mocha.Done) => {
+   // Before fix: baseFingeringXOffset was calculated across all notes in the staff entry,
+   // causing grace notes to have incorrect offsets based on collision with other grace notes
+   // at different horizontal positions. The fix calculates offsets per voice entry for grace notes.
+   it("Grace notes should have baseFingeringXOffset calculated per voice entry", (done: Mocha.Done) => {
       const score: Document = TestUtils.getScore("test_grace_note_fingerings_position.musicxml");
       const div: HTMLElement = TestUtils.getDivElement(document);
       const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
@@ -62,42 +62,24 @@ describe("VexFlow Measure", () => {
          (_: {}) => {
             osmd.render();
 
-            // Get the first measure
+            // Get the first measure and staff entry
             const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, 0);
-            chai.expect(gm).to.not.be.undefined;
-
-            // Get the first staff entry which should contain grace notes
             const staffEntry: GraphicalStaffEntry = gm.staffEntries[0];
-            chai.expect(staffEntry).to.not.be.undefined;
 
-            // Check that we have grace voice entries with fingerings
+            // Get grace voice entries (each containing a single grace note)
             const graceVoiceEntries: GraphicalVoiceEntry[] = staffEntry.graphicalVoiceEntries.filter(
                (gve: VexFlowVoiceEntry) => gve.parentVoiceEntry?.IsGrace
             );
             chai.expect(graceVoiceEntries.length).to.equal(2);
 
-            // Verify each grace note has a fingering defined in the source
-            let fingeringsFound: number = 0;
+            // Each grace note is alone in its voice entry, so baseFingeringXOffset should be 0.
+            // Before the fix, the second grace note had offset=1 due to collision detection
+            // with the first grace note (which is at a different horizontal position).
             for (const gve of graceVoiceEntries) {
                for (const note of gve.notes) {
-                  if (note.sourceNote.Fingering) {
-                     fingeringsFound++;
-                  }
+                  chai.expect(note.baseFingeringXOffset).to.equal(0,
+                     "Single grace notes should have baseFingeringXOffset=0");
                }
-            }
-            chai.expect(fingeringsFound).to.equal(2);
-
-            // Verify the vfStaveNote modifiers contain the fingerings
-            // This ensures the fingerings were actually added to the VexFlow notes
-            for (const gve of graceVoiceEntries as VexFlowVoiceEntry[]) {
-               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-               const modifiers: any[] = (gve.vfStaveNote as any).getModifiers();
-               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-               const fingeringModifiers: any[] = modifiers.filter(
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (m: any) => m.getCategory() === "frethandfinger"
-               );
-               chai.expect(fingeringModifiers.length).to.be.greaterThan(0);
             }
 
             done();

--- a/test/data/test_grace_note_fingerings_position.musicxml
+++ b/test/data/test_grace_note_fingerings_position.musicxml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Test - Grace Note Fingerings Position</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>OSMD Test</software>
+      <encoding-date>2024-01-01</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <!-- Grace note 1 with fingering 2 -->
+      <note>
+        <grace/>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <technical><fingering>2</fingering></technical>
+        </notations>
+      </note>
+      <!-- Grace note 2 with fingering 3 -->
+      <note>
+        <grace/>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <technical><fingering>3</fingering></technical>
+        </notations>
+      </note>
+      <!-- Main note -->
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Hi! This is my first contribution to OSMD. Thank you for making this library available — it's been very helpful for my piano training project.

---

## Summary

- Fix incorrect fingering positions on grace notes
- Grace notes now have collision offsets calculated per voice entry instead of across all notes in the staff entry

## Problem

Fingerings on grace notes were incorrectly shifted because the collision detection (`baseFingeringXOffset`) included all notes in the staff entry, without considering that grace notes are at different horizontal positions.

This caused issues like:
- Second grace note's fingering appearing above the first grace note
- Sequential grace note chords having fingerings shifted incorrectly

## Screenshots

### Before (develop)
<img width="169" height="96" alt="Screenshot 2026-02-01 at 14 01 22" src="https://github.com/user-attachments/assets/8cc5572e-3bdb-4f45-a63a-6d44dfa147f4" />


### After (this PR)
<img width="158" height="117" alt="Screenshot 2026-02-01 at 14 02 04" src="https://github.com/user-attachments/assets/178dc731-a695-4913-ab3b-988e188af1b6" />



## Solution

Calculate fingering collision offsets separately for each grace note voice entry (chord), since they are rendered at different X positions. Non-grace notes continue to have offsets calculated together as before.

## Test plan

- [x] Added test MusicXML file `test_grace_note_fingerings_position.musicxml`
- [x] Added unit test verifying `baseFingeringXOffset === 0` for single grace notes
- [x] All 194 existing tests pass
- [x] Tested with sequential grace notes with fingerings
- [x] Tested with sequential grace note chords with fingerings

## Question for maintainers

I added a unit test that verifies `baseFingeringXOffset === 0` for single grace notes. However, this tests an implementation detail rather than the visual output.

Since the MusicXML test file is included in `test/data/`, it will be part of visual regression testing. **Would you prefer:**
1. **Keep the unit test** - runs automatically in CI, catches regressions quickly
2. **Remove the unit test** - rely only on visual regression testing with the MusicXML file

Happy to adjust based on your preference.

---
🤖 Generated with [Claude Code](https://claude.ai/code)