### PR TITLE
feat(MeasureNumbers): Add CSS class 'measure-number' to measure number labels

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -355,6 +355,7 @@ export abstract class MusicSheetDrawer {
         if (!this.leadSheet) {
             for (const measureNumberLabel of musicSystem.MeasureNumberLabels) {
                 measureNumberLabel.SVGNode = this.drawLabel(measureNumberLabel, <number>GraphicalLayers.Notes);
+                (measureNumberLabel.SVGNode as SVGGElement)?.classList?.add("measure-number");
             }
         }
         for (const staffLine of musicSystem.StaffLines) {


### PR DESCRIPTION
## Summary

Adds a `measure-number` CSS class to measure number labels, allowing users to style them via CSS.

## Motivation

Measure numbers and fingering annotations can look visually similar in rendered scores, which can be confusing for users. Since measure numbers are typically less important than fingerings for musicians reading a score, users may want to de-emphasize them visually (e.g., by making them gray or smaller).

This follows the existing pattern used for other elements like lyrics (`.lyrics`), staff lines (`.staffline`), and dashes (`.dash`).

## Usage example

```css
svg g.measure-number text {
  fill: #999999;
}
```

## Test plan

- [x] Load a score with measure numbers displayed
- [x] Verify the SVG elements have the `measure-number` class
- [x] Apply custom CSS styling and confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)