### PR TITLE
Fix cursor not respecting repetitions. Fix left repeat barline not respecting instructions like clef. Fix double thin barline after "to coda" etc

### DIFF
--- a/src/Common/DataObjects/PlaybackSettings.ts
+++ b/src/Common/DataObjects/PlaybackSettings.ts
@@ -1,0 +1,86 @@
+import { Fraction } from "./Fraction";
+
+export class PlaybackSettings {
+    private beatsPerMinute: number;
+    private beatLengthInMilliseconds: number;
+    private beatRealValue: number;
+    public rhythm: Fraction;
+
+    /** The denominator of the fraction of the rhythm is 1 beat long
+     * --> By knowing the rhythm and the beatsPerMinute the length of notes can be calculated.
+     */
+    constructor(rhythm: Fraction = new Fraction(), beatsPerMinute: number = 100) {
+        this.rhythm = rhythm;
+        this.beatsPerMinute = beatsPerMinute;
+        // 1 minute in milliseconds/beatsPerMinute
+        this.beatLengthInMilliseconds = 60000.0 / beatsPerMinute;
+        // the denominator in the rhythm is the unit for the beats in a music sheet (it is 1 beat long)
+        this.beatRealValue = 1.0 / 4.0;
+    }
+
+    public static createFrom(from: PlaybackSettings): PlaybackSettings {
+        return new PlaybackSettings(from.Rhythm, from.BeatsPerMinute);
+    }
+
+    public get BeatsPerMinute(): number {
+        return this.beatsPerMinute;
+    }
+    public set BeatsPerMinute(value: number) {
+        this.beatsPerMinute = value;
+        // 1 minute in milliseconds/beatsPerMinute
+        this.beatLengthInMilliseconds = 60000.0 / this.beatsPerMinute;
+    }
+    public get Rhythm(): Fraction {
+        return this.rhythm;
+    }
+    public set Rhythm(value: Fraction) {
+        this.rhythm = value;
+        // TODO: Below is commented out in original C# code, delete here?
+        // the denominator in the rhythm is the unit for the beats in a music sheet (it is 1 beat long)
+        // this.beatRealValue = 1.0 / this.rhythm.Denominator;
+    }
+    public get BeatRealValue(): number {
+        return this.beatRealValue;
+    }
+    public get BeatLengthInMilliseconds(): number {
+        return this.beatLengthInMilliseconds;
+    }
+    // TODO: Following overload is handled below, check if it does what it is supposed to do
+    // public getDurationInMilliseconds(duration: Fraction): number {
+    //     var ret: number = duration.RealValue * this.BeatLengthInMilliseconds / this.beatRealValue;
+    //     return ret;
+    // }
+    // public getDurationInMilliseconds(durationRealValue: number): number {
+    //     var ret: number = durationRealValue * this.BeatLengthInMilliseconds / this.beatRealValue;
+    //     return ret;
+    // }
+    public getDurationInMilliseconds(duration: number | Fraction): number {
+        const value: number = typeof duration === "number" ? duration : duration.RealValue;
+        const ret: number = value * this.BeatLengthInMilliseconds / this.beatRealValue;
+        return ret;
+    }
+    public getDurationAsNoteDuration(milliseconds: number, fractionPrecision: number = 1024): Fraction {
+        // 1 beat can be mapped to 1/denominator of the rhythm.
+        const numBeats: number = milliseconds / (this.BeatLengthInMilliseconds);
+        let numerator: number = <number>Math.floor(numBeats);
+
+        // TODO: Comment in line below from original code, keep it?
+        // here is the problem: this.rhythm.Denominator
+
+        const ret: Fraction = new Fraction(numerator, 4);
+        // TODO: Line below commented out in original code, port to TS?
+        //Console.WriteLine($"milliseconds: {milliseconds}, BeatLengthInMilliseconds: {BeatLengthInMilliseconds}, LINEBREAK for linter
+        //numBeats: {numBeats}, DurationFraction: {ret}");
+        // now approximate as good as possible by using fractionPrecision as smallest fraction
+        const tmp: number = numBeats - numerator;
+        numerator = <number>Math.round(tmp / (1.0 / fractionPrecision) / 4);
+        if (tmp !== 0 && numerator === 0 && milliseconds > 0) {
+            numerator = 1;
+            // tmp !== 0 necessary because otherwise 4/4 turns into e.g. 1.0009 instead of 1
+            //   -> too far in playFromMs() (see extended issue 63). better just to round.
+        }
+        // add the 2 fractions
+        ret.Add(new Fraction(numerator, fractionPrecision));
+        return ret;
+    }
+}

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -548,6 +548,10 @@ export class EngravingRules {
     /** Whether to always set preferred backend (WebGL or Plain) automatically, depending on browser and number of measures. */
     public AlwaysSetPreferredSkyBottomLineBackendAutomatically: boolean;
 
+    // Playback settings
+    /** Currently only used in audio player */
+    public UseInterpolatedTempoForAccelerandoEtc: boolean;
+
     constructor() {
         this.loadDefaultValues();
     }
@@ -974,6 +978,11 @@ export class EngravingRules {
         this.DisableWebGLInFirefox = true;
         this.DisableWebGLInSafariAndIOS = true;
         this.setPreferredSkyBottomLineBackendAutomatically();
+
+        // Playback
+        this.UseInterpolatedTempoForAccelerandoEtc = false; // wait for rit support etc. can also make
+        //   player features like syncing more difficult to implement.
+        //   Also, the end of an accelerando is usually not marked, so this makes it difficult to find an end timestamp.
 
         // this.populateDictionaries(); // these values aren't used currently
         try {

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -825,7 +825,9 @@ export class MusicSystemBuilder {
         /*if (this.measureListIndex === this.measureList.length - 1 || this.measureList[this.measureListIndex][0].parentSourceMeasure.endsPiece) {
             return SystemLinesEnum.ThinBold;
         }*/
-        if (this.nextMeasureHasKeyInstructionChange() || this.thisMeasureEndsWordRepetition() || this.nextMeasureBeginsWordRepetition()) {
+        if (this.nextMeasureHasKeyInstructionChange()) {
+        //if (this.nextMeasureHasKeyInstructionChange() || this.thisMeasureEndsWordRepetition() || this.nextMeasureBeginsWordRepetition()) {
+        //  previously, we forced a double thin barline for places like "to coda" end of measure, even if it there's no double thin barline in the xml
             return SystemLinesEnum.DoubleThin;
         }
         if (!sourceMeasure) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1753,9 +1753,12 @@ export class VexFlowMeasure extends GraphicalMeasure {
      * @param top
      * @param lineType
      */
-    public lineTo(top: VexFlowMeasure, lineType: any): void {
+    public lineTo(top: VexFlowMeasure, lineType: any, xShift: number = 0): void {
         const connector: VF.StaveConnector = new VF.StaveConnector(top.getVFStave(), this.stave);
         connector.setType(lineType);
+        if (xShift !== 0) {
+            connector.setXShift(xShift);
+        }
         this.connectors.push(connector);
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSystem.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSystem.ts
@@ -61,9 +61,25 @@ export class VexFlowMusicSystem extends MusicSystem {
 
         if (bottomMeasure) {
             renderInitialLine = true;
-            // create here the correct lines according to the given lineType.
-            (bottomMeasure as VexFlowMeasure).lineTo(topMeasure as VexFlowMeasure, VexFlowConverter.line(lineType, linePosition));
+            // Set bar types on both staves before creating connectors,
+            // so VexFlow's stave formatting is aware of the REPEAT_BEGIN barline.
             (bottomMeasure as VexFlowMeasure).addMeasureLine(lineType, linePosition);
+            if (vfTopMeasure) {
+                vfTopMeasure.addMeasureLine(lineType, linePosition, renderInitialLine);
+            }
+
+            // For begin repeat barlines on measures with begin instructions (clef, key, time signature),
+            // shift the StaveConnector past the begin instructions so it aligns with the repeat barline
+            // rather than drawing at the stave's leftmost x position.
+            let connectorXShift: number = 0;
+            if (lineType === SystemLinesEnum.BoldThinDots && linePosition === SystemLinePosition.MeasureBegin
+                && topMeasure.beginInstructionsWidth > 0) {
+                connectorXShift = vfTopMeasure.getVFStave().getModifierXShift(0);
+            }
+
+            // create here the correct lines according to the given lineType.
+            (bottomMeasure as VexFlowMeasure).lineTo(
+                topMeasure as VexFlowMeasure, VexFlowConverter.line(lineType, linePosition), connectorXShift);
             //Double repeat. VF doesn't have concept of double repeat. Need to add stave connector to begin of next measure
             if (lineType === SystemLinesEnum.DotsBoldBoldDots) {
                 const nextIndex: number = bottomMeasure.ParentStaffLine.Measures.indexOf(bottomMeasure) + 1;
@@ -74,8 +90,7 @@ export class VexFlowMusicSystem extends MusicSystem {
                     nextBottomMeasure.addMeasureLine(SystemLinesEnum.BoldThinDots, linePosition);
                 }
             }
-        }
-        if (vfTopMeasure) {
+        } else if (vfTopMeasure) {
             vfTopMeasure.addMeasureLine(lineType, linePosition, renderInitialLine);
         }
 

--- a/src/MusicalScore/MusicParts/MusicPartManagerIterator.ts
+++ b/src/MusicalScore/MusicParts/MusicPartManagerIterator.ts
@@ -16,6 +16,8 @@ import {AbstractExpression} from "../VoiceData/Expressions/AbstractExpression";
 import log from "loglevel";
 import { MusicSheet } from "../MusicSheet";
 import { NoteHeadShape } from "../VoiceData/Notehead";
+import { PlaybackSettings } from "../../Common/DataObjects/PlaybackSettings";
+import { Note } from "../VoiceData";
 
 export class MusicPartManagerIterator {
     constructor(musicSheet: MusicSheet, startTimestamp?: Fraction, endTimestamp?: Fraction) {
@@ -28,9 +30,15 @@ export class MusicPartManagerIterator {
             for (const rep of this.musicSheet.Repetitions) {
                 this.setRepetitionIterationCount(rep, 1);
             }
-            this.activeDynamicExpressions = new Array(this.musicSheet.getCompleteNumberOfStaves());
+            for (let i: number = 0; i < musicSheet.getCompleteNumberOfStaves(); i++) {
+                this.ActiveDynamicExpressions.push(undefined);
+            }
+
             this.currentMeasure = this.musicSheet.SourceMeasures[0];
-            if (!startTimestamp) { return; }
+            if (!startTimestamp) {
+                startTimestamp = new Fraction();
+            }
+
             do {
                 this.moveToNext();
             } while ((!this.currentVoiceEntries || this.currentTimeStamp.lt(startTimestamp)) && !this.endReached);
@@ -67,8 +75,8 @@ export class MusicPartManagerIterator {
     private currentDynamicChangingExpressions: DynamicsContainer[] = [];
     private currentTempoChangingExpression: MultiTempoExpression;
     // FIXME: replace these two with a real Dictionary!
-    private repetitionIterationCountDictKeys: Repetition[];
-    private repetitionIterationCountDictValues: number[];
+    private repetitionIterationCountDictKeys: Repetition[] = [];
+    private repetitionIterationCountDictValues: number[] = [];
     private currentRepetition: Repetition = undefined;
     private endReached: boolean = false;
     private frontReached: boolean = false;
@@ -108,6 +116,9 @@ export class MusicPartManagerIterator {
     }
     public get CurrentBpm(): number {
         return this.currentBpm;
+    }
+    public set CurrentBpm(value: number) {
+        this.currentBpm = value;
     }
     public get CurrentVoiceEntries(): VoiceEntry[] {
         return this.currentVoiceEntries;
@@ -181,25 +192,24 @@ export class MusicPartManagerIterator {
     }
 
     /**
-     * Returns the visible voice entries for the provided instrument of the current iterator position.
+     * Returns the audible voice entries for the provided instrument of the current iterator position.
      * @param instrument
      * Returns: A List of voiceEntries. If there are no entries the List has a Count of 0 (it does not return null).
      */
     public CurrentAudibleVoiceEntries(instrument?: Instrument): VoiceEntry[] {
         const voiceEntries: VoiceEntry[] = [];
-        if (!this.currentVoiceEntries) {
-            return voiceEntries;
-        }
-        if (instrument) {
-            for (const entry of this.currentVoiceEntries) {
-                if (entry.ParentVoice.Parent.IdString === instrument.IdString) {
-                    this.getAudibleEntries(entry, voiceEntries);
-                    return voiceEntries;
+        if (this.currentVoiceEntries) {
+            if (instrument) {
+                for (const entry of this.currentVoiceEntries) {
+                    if (entry.ParentVoice.Parent.IdString === instrument.IdString) {
+                        this.getAudibleEntries(entry, voiceEntries);
+                        return voiceEntries;
+                    }
                 }
-            }
-        } else {
-            for (const entry of this.currentVoiceEntries) {
-                this.getAudibleEntries(entry, voiceEntries);
+            } else {
+                for (const entry of this.currentVoiceEntries) {
+                    this.getAudibleEntries(entry, voiceEntries);
+                }
             }
         }
         return voiceEntries;
@@ -238,10 +248,9 @@ export class MusicPartManagerIterator {
         }
         return voiceEntries;
     }
-
-    //public currentPlaybackSettings(): PlaybackSettings {
-    //    return this.manager.MusicSheet.SheetPlaybackSetting;
-    //}
+    public currentPlaybackSettings(): PlaybackSettings {
+       return this.musicSheet.SheetPlaybackSetting;
+    }
 
     // move to previous
     public moveToPrevious(): void {
@@ -263,6 +272,7 @@ export class MusicPartManagerIterator {
             }
         }
     }
+
     public moveToNext(): void {
         this.forwardJumpOccurred = this.backJumpOccurred = false;
         if (this.endReached) { return; }
@@ -271,21 +281,30 @@ export class MusicPartManagerIterator {
             this.currentVoiceEntryIndex = -1;
         }
         if (this.currentVoiceEntries) {
-            this.currentVoiceEntries = [];
+            this.currentVoiceEntries.length = 0;
         }
         this.recursiveMove();
         if (!this.currentMeasure) {
             this.currentTimeStamp = new Fraction(99999, 1);
             this.currentMeasure = this.musicSheet.SourceMeasures.last();
         }
+
         if (this.CurrentTempoChangingExpression !== undefined && !this.musicSheet.IgnoreTempoInstructions) {
-            if (this.CurrentTempoChangingExpression.InstantaneousTempo !== undefined) {
+            if (this.CurrentTempoChangingExpression.ContinuousTempo !== undefined &&
+                this.currentMeasure.Rules.UseInterpolatedTempoForAccelerandoEtc
+            ) {
+                const interpolatedBpm: number = this.CurrentTempoChangingExpression.ContinuousTempo.getInterpolatedTempo(this.CurrentSourceTimestamp);
+                if (interpolatedBpm > 0) {
+                    this.currentBpm = interpolatedBpm;
+                    //console.log("current bpm: " + this.currentBpm);
+                }
+            } else { // Instantaneous Expression
                 // only adapt to new instantaneous exp if it has changed
                 if (!this.musicSheet.IgnoreTempoInstructions) { // e.g. user set fixed tempo via UI
-                    // ToDo QuarterBpm:
-                    const newBpm: number = this.CurrentTempoChangingExpression.InstantaneousTempo.TempoInBpm;
-                    if (newBpm > 0) {
-                        this.currentBpm = newBpm;
+                    if (this.CurrentTempoChangingExpression.InstantaneousTempo?.TempoInBpm) { // TODO can be undefined
+                        // ToDo QuarterBpm:
+                        this.currentBpm = this.CurrentTempoChangingExpression.InstantaneousTempo.TempoInBpm;
+                        //console.log("current bpm: " + this.currentBpm);
                     }
                 }
             }
@@ -393,9 +412,9 @@ export class MusicPartManagerIterator {
             const currentRepetition: Repetition = repetitionInstruction.parentRepetition;
             if (!currentRepetition) { continue; }
             if (currentRepetition.BackwardJumpInstructions.indexOf(repetitionInstruction) > -1) {
-                if (this.getRepetitionIterationCount(currentRepetition) < currentRepetition.UserNumberOfRepetitions) {
+                if (this.getRepetitionIterationCount(currentRepetition) < currentRepetition.UserNumberOfRepetitions &&
+                    !currentRepetition.SkipRepetition) {
                     this.doBackJump(currentRepetition);
-                    this.backJumpOccurred = true;
                     return;
                 }
             }
@@ -404,24 +423,25 @@ export class MusicPartManagerIterator {
                   this.JumpResponsibleRepetition !== undefined
                   && currentRepetition !== this.JumpResponsibleRepetition
                   && currentRepetition.StartIndex >= this.JumpResponsibleRepetition.StartIndex
-                  && currentRepetition.EndIndex <= this.JumpResponsibleRepetition.EndIndex
-                ) {
+                  && currentRepetition.EndIndex <= this.JumpResponsibleRepetition.EndIndex) {
                     this.resetRepetitionIterationCount(currentRepetition);
                 }
 
-                const forwardJumpTargetMeasureIndex: number = currentRepetition.getForwardJumpTargetForIteration(
-                  this.getRepetitionIterationCount(currentRepetition)
-                );
-                if (forwardJumpTargetMeasureIndex >= 0) {
-                    this.currentMeasureIndex = forwardJumpTargetMeasureIndex;
-                    this.currentMeasure = this.musicSheet.SourceMeasures[this.currentMeasureIndex];
-                    this.currentVoiceEntryIndex = -1;
-                    this.jumpResponsibleRepetition = currentRepetition;
-                    this.forwardJumpOccurred = true;
-                    return;
-                }
-                if (forwardJumpTargetMeasureIndex === -2) {
-                    this.endReached = true;
+                if (this.repetitionIterationCountDictKeys.contains(currentRepetition)) {
+                    const forwardJumpTargetMeasureIndex: number = currentRepetition.getForwardJumpTargetForIteration(
+                        this.getRepetitionIterationCount(currentRepetition));
+
+                    if (forwardJumpTargetMeasureIndex >= 0) {
+                        this.currentMeasureIndex = forwardJumpTargetMeasureIndex;
+                        this.currentMeasure = this.musicSheet.SourceMeasures[this.currentMeasureIndex];
+                        this.currentVoiceEntryIndex = -1;
+                        this.jumpResponsibleRepetition = currentRepetition;
+                        this.forwardJumpOccurred = true;
+                        return;
+                    }
+                    if (forwardJumpTargetMeasureIndex === -2) {
+                        this.endReached = true;
+                    }
                 }
             }
         }
@@ -431,11 +451,15 @@ export class MusicPartManagerIterator {
         }
     }
     private doBackJump(currentRepetition: Repetition): void {
+        if (currentRepetition.SkipRepetition) {
+            return;
+        }
         this.currentMeasureIndex = currentRepetition.getBackwardJumpTarget();
         this.currentMeasure = this.musicSheet.SourceMeasures[this.currentMeasureIndex];
         this.currentVoiceEntryIndex = -1;
         this.incrementRepetitionIterationCount(currentRepetition);
         this.jumpResponsibleRepetition = currentRepetition;
+        this.backJumpOccurred = true;
     }
     private activateCurrentRhythmInstructions(): void {
         if (
@@ -647,7 +671,20 @@ export class MusicPartManagerIterator {
         }
     }
     private getAudibleEntries(entry: VoiceEntry, audibleEntries: VoiceEntry[]): void {
-        if (entry.ParentVoice.Audible) {
+        // is it a tied note?
+        if (entry.hasTie()) {
+            // ignore all tied notes that are no start notes:
+            // check on the first note:
+            const note: Note = entry.Notes[0];
+            if (note.NoteTie !== undefined &&
+                note.NoteTie.StartNote !== note) {
+                // ignore the whole voice entry,
+                // as anyway all notes should be tied in a voice:
+                return;
+            }
+        }
+
+        if (entry.ParentVoice.Audible && entry.ParentSourceStaffEntry.ParentStaff.audible) {
             audibleEntries.push(entry);
         }
     }

--- a/src/MusicalScore/MusicSheet.ts
+++ b/src/MusicalScore/MusicSheet.ts
@@ -18,12 +18,9 @@ import {Note} from "./VoiceData/Note";
 import {VoiceEntry} from "./VoiceData/VoiceEntry";
 import log from "loglevel";
 import { TextAlignmentEnum } from "../Common/Enums/TextAlignment";
+import { PlaybackSettings } from "../Common/DataObjects/PlaybackSettings";
 
 // FIXME Andrea: Commented out some unnecessary/not-ported-yet code, have a look at (*)
-
-export class PlaybackSettings {
-    public rhythm: Fraction;
-}
 
 /**
  * This is the representation of a complete piece of sheet music.

--- a/src/MusicalScore/MusicSource/Repetition.ts
+++ b/src/MusicalScore/MusicSource/Repetition.ts
@@ -7,7 +7,7 @@ import {PartListEntry} from "./PartListEntry";
 import log from "loglevel";
 
 export class Repetition extends PartListEntry /*implements IRepetition*/ {
-    constructor(musicSheet: MusicSheet, virtualOverallRepetition: boolean) {
+    constructor(musicSheet: MusicSheet, virtualOverallRepetition: boolean = false) {
         super(musicSheet);
         this.musicSheet2 = musicSheet;
         this.virtualOverallRepetition = virtualOverallRepetition;
@@ -16,11 +16,19 @@ export class Repetition extends PartListEntry /*implements IRepetition*/ {
     public startMarker: RepetitionInstruction;
     public endMarker: RepetitionInstruction;
     public forwardJumpInstruction: RepetitionInstruction;
+    /** If set to true, will skip the repetition during playback.
+     * Note that you need to call PlaybackManager.recalculatePlaybackEntriesAndRepetitions() afterwards to skip repetitions during playback.
+     * Also note that the better method is to set UserNumberOfRepetitions = 1 instead of SkipRepetition, this will also work for voltas.
+     * This can be set or disabled by the user/developer at any time. */
+    public SkipRepetition: boolean = false;
 
+    /** How many times the repetition should be played. Standard for a repetition is 2, so setting it to 1 makes it not repeat.
+     * Note that you need to call PlaybackManager.recalculatePlaybackEntriesAndRepetitions() afterwards to respect this during playback.
+     */
+    private userNumberOfRepetitions: number = 0;
     private backwardJumpInstructions: RepetitionInstruction[] = [];
     private endingParts: RepetitionEndingPart[] = [];
     private endingIndexDict: { [_: number]: RepetitionEndingPart } = {};
-    private userNumberOfRepetitions: number = 0;
     private visibles: boolean[] = [];
     private fromWords: boolean = false;
     private musicSheet2: MusicSheet;
@@ -73,7 +81,7 @@ export class Repetition extends PartListEntry /*implements IRepetition*/ {
     public getBackwardJumpTarget(): number {
         return this.startMarker.measureIndex;
     }
-    public SetEndingStartIndex(endingNumbers: number[], startIndex: number): void {
+    public setEndingsStartIndex(endingNumbers: number[], startIndex: number): void {
         const part: RepetitionEndingPart = new RepetitionEndingPart(new SourceMusicPart(this.musicSheet2, startIndex, startIndex));
         this.endingParts.push(part);
         for (const endingNumber of endingNumbers) {
@@ -86,18 +94,20 @@ export class Repetition extends PartListEntry /*implements IRepetition*/ {
             } catch (err) {
                 log.error("Repetition: Exception.", err);
             }
-
         }
     }
-    //public SetEndingStartIndex(endingNumber: number, startIndex: number): void {
-    //    let part: RepetitionEndingPart = new RepetitionEndingPart(new SourceMusicPart(this.musicSheet2, startIndex, startIndex));
-    //    this.endingParts.push(part);
-    //    this.endingIndexDict[endingNumber] = part;
-    //    part.endingIndices.push(endingNumber);
-    //    if (this.numberOfEndings < endingNumber) {
-    //        this.numberOfEndings = endingNumber;
-    //    }
-    //}
+    public setEndingStartIndex(endingNumber: number, startIndex: number): void {
+        const part: RepetitionEndingPart = new RepetitionEndingPart(new SourceMusicPart(this.musicSheet2, startIndex, startIndex));
+
+        this.EndingIndexDict[endingNumber] = part;
+
+        this.endingParts.push(part);
+        part.endingIndices.push(endingNumber);
+
+        if (this.numberOfEndings < endingNumber) {
+            this.numberOfEndings = endingNumber;
+        }
+    }
     public setEndingEndIndex(endingNumber: number, endIndex: number): void {
         if (this.endingIndexDict[endingNumber]) {
             this.endingIndexDict[endingNumber].part.setEndIndex(endIndex);
@@ -135,13 +145,15 @@ export class Repetition extends PartListEntry /*implements IRepetition*/ {
         for (let measureIndex: number = start; measureIndex <= end; measureIndex++) {
             const sourceMeasure: SourceMeasure = this.musicSheet2.SourceMeasures[measureIndex];
             for (let i: number = 0; i < sourceMeasure.CompleteNumberOfStaves; i++) {
-                for (const sourceStaffEntry of sourceMeasure.VerticalSourceStaffEntryContainers[i].StaffEntries) {
-                    if (sourceStaffEntry) {
-                        let verses: number = 0;
-                        for (const voiceEntry of sourceStaffEntry.VoiceEntries) {
-                            verses += Object.keys(voiceEntry.LyricsEntries).length;
+                if (sourceMeasure.VerticalSourceStaffEntryContainers[i]) {
+                    for (const sourceStaffEntry of sourceMeasure.VerticalSourceStaffEntryContainers[i].StaffEntries) {
+                        if (sourceStaffEntry) {
+                            let verses: number = 0;
+                            for (const voiceEntry of sourceStaffEntry.VoiceEntries) {
+                                verses += voiceEntry.LyricsEntries.keys.length;
+                            }
+                            lyricVerses = Math.max(lyricVerses, verses);
                         }
-                        lyricVerses = Math.max(lyricVerses, verses);
                     }
                 }
             }
@@ -155,6 +167,26 @@ export class Repetition extends PartListEntry /*implements IRepetition*/ {
         return this.getLastSourceMeasure().MeasureNumber;
     }
 
+    public  coversIdenticalMeasures(other: Repetition): boolean {
+        if (this.StartIndex === other.StartIndex &&
+            this.EndIndex === other.EndIndex) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public removeFromRepetitionInstructions(): void {
+        if (this.startMarker !== undefined) {
+            this.startMarker.parentRepetition = undefined;
+        }
+        if (this.endMarker !== undefined) {
+            this.endMarker.parentRepetition = undefined;
+        }
+        for (const backJump of this.BackwardJumpInstructions) {
+            backJump.parentRepetition = undefined;
+        }
+    }
 }
 
 export class RepetitionEndingPart {

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
@@ -3,10 +3,14 @@ import {RepetitionInstruction, RepetitionInstructionEnum, AlignmentType} from ".
 import {RepetitionInstructionComparer} from "../../VoiceData/Instructions/RepetitionInstruction";
 import {ArgumentOutOfRangeException} from "../../Exceptions";
 import {MusicSheet} from "../../MusicSheet";
+import { Repetition } from "../../MusicSource";
+import log from "loglevel";
 
 export class RepetitionCalculator {
   private musicSheet: MusicSheet;
   private repetitionInstructions: RepetitionInstruction[] = [];
+  private openRepetitions: RepetitionBuildingContainer[] = [];
+  private lastRepetitionCommonPartStartIndex: number = 0;
   private currentMeasure: SourceMeasure;
   private currentMeasureIndex: number;
 
@@ -18,14 +22,85 @@ export class RepetitionCalculator {
    * @param repetitionInstructions
    */
   public calculateRepetitions(musicSheet: MusicSheet, repetitionInstructions: RepetitionInstruction[]): void {
-    this.musicSheet = <MusicSheet>musicSheet;
+    this.musicSheet = musicSheet;
     this.repetitionInstructions = repetitionInstructions;
+
+    this.openRepetitions.length = 0;
+    this.lastRepetitionCommonPartStartIndex = 0;
+
     const sourceMeasures: SourceMeasure[] = this.musicSheet.SourceMeasures;
-    for (let idx: number = 0, len: number = this.repetitionInstructions.length; idx < len; ++idx) {
-      const instruction: RepetitionInstruction = this.repetitionInstructions[idx];
+    for (const instruction of this.repetitionInstructions) {
       this.currentMeasureIndex = instruction.measureIndex;
-      this.currentMeasure = sourceMeasures[this.currentMeasureIndex];
-      this.handleRepetitionInstructions(instruction);
+      try {
+        this.currentMeasure = sourceMeasures[this.currentMeasureIndex];
+        this.handleRepetitionInstructions(instruction);
+      } catch (error) {
+        log.error("RepetitionCalculator: calculateRepetitions", error);
+      }
+    }
+
+    while (this.openRepetitions.length > 0) {
+      try {
+          const last: RepetitionBuildingContainer = this.openRepetitions.last();
+          if (last.RepetitonUnderConstruction.FromWords) {
+              if (last.WaitingForCoda) {
+                  let endIndex: number = last.RepetitonUnderConstruction.BackwardJumpInstructions.last().measureIndex + 1;
+                  if (endIndex >= this.musicSheet.SourceMeasures.length) {
+                      endIndex = -1;
+                  }
+                  last.RepetitonUnderConstruction.setEndingStartIndex(2, endIndex);
+              } else {
+                  if (last.RepetitonUnderConstruction.BackwardJumpInstructions.length === 0) {
+                      this.openRepetitions.splice(this.openRepetitions.length - 1, 1);
+                      continue;
+                  }
+              }
+          } else {
+              if (last.RepetitonUnderConstruction.BackwardJumpInstructions.length === 0) {
+                  const lastMeasureIndex: number = sourceMeasures.length - 1;
+                  const backJumpInstruction: RepetitionInstruction = new RepetitionInstruction( lastMeasureIndex,
+                                                                                                RepetitionInstructionEnum.BackJumpLine,
+                                                                                                AlignmentType.End,
+                                                                                                last.RepetitonUnderConstruction);
+                  last.RepetitonUnderConstruction.BackwardJumpInstructions.push(backJumpInstruction);
+                  sourceMeasures[lastMeasureIndex].LastRepetitionInstructions.push(backJumpInstruction);
+              }
+          }
+          this.finalizeRepetition(this.openRepetitions.last());
+      } catch (err) {
+          try {
+              const faultyRep: Repetition = this.openRepetitions.last().RepetitonUnderConstruction;
+              for (const instruction of this.repetitionInstructions) {
+                  if (instruction.parentRepetition === faultyRep) {
+                      instruction.parentRepetition = undefined;
+                  }
+              }
+              this.openRepetitions.splice(this.openRepetitions.length - 1, 1);
+          } catch (error) {
+            log.error("RepetitionCalculator: calculateRepetitions2", error);
+          }
+      }
+    }
+    let overallRepetition: boolean = false;
+    const startMeasureIndex: number = 0;
+    const endMeasureIndex: number = this.musicSheet.SourceMeasures.length - 1;
+    for (const repetition of this.musicSheet.Repetitions) {
+        if (repetition.StartIndex === startMeasureIndex && repetition.EndIndex === endMeasureIndex) {
+            overallRepetition = true;
+            break;
+        }
+    }
+    if (!overallRepetition) {
+        const repetition: Repetition = new Repetition(this.musicSheet, true);
+        repetition.FromWords = true;
+        repetition.startMarker = new RepetitionInstruction(startMeasureIndex, RepetitionInstructionEnum.StartLine);
+        repetition.startMarker.parentRepetition = repetition;
+        this.musicSheet.SourceMeasures[startMeasureIndex].FirstRepetitionInstructions.push(repetition.startMarker);
+        repetition.endMarker = new RepetitionInstruction(endMeasureIndex, RepetitionInstructionEnum.BackJumpLine);
+        repetition.endMarker.parentRepetition = repetition;
+        repetition.BackwardJumpInstructions.push(repetition.endMarker);
+        repetition.UserNumberOfRepetitions = repetition.DefaultNumberOfRepetitions;
+        this.musicSheet.Repetitions.push(repetition);
     }
 
     // if there are more than one instruction at measure begin or end,
@@ -41,62 +116,567 @@ export class RepetitionCalculator {
     }
   }
 
+  // private handleRepetitionInstructions(currentRepetitionInstruction: RepetitionInstruction): boolean {
+  //   if (!this.currentMeasure) {
+  //     return false;
+  //   }
+  //   switch (currentRepetitionInstruction.type) {
+  //     case RepetitionInstructionEnum.StartLine:
+  //       this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.BackJumpLine:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.Ending:
+  //       // set ending start or end
+  //       if (currentRepetitionInstruction.alignment ==== AlignmentType.Begin) {  // ending start
+  //         this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
+  //       } else { // ending end
+  //         for (let idx: number = 0, len: number = currentRepetitionInstruction.endingIndices.length; idx < len; ++idx) {
+  //           this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //         }
+  //       }
+  //       break;
+  //     case RepetitionInstructionEnum.Segno:
+  //       this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.Fine:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.ToCoda:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.Coda:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.DaCapo:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.DalSegno:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.DalSegnoAlFine:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.DaCapoAlFine:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.DalSegnoAlCoda:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.DaCapoAlCoda:
+  //       this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+  //       break;
+  //     case RepetitionInstructionEnum.None:
+  //       break;
+  //     default:
+  //       throw new ArgumentOutOfRangeException("currentRepetitionInstruction");
+  //   }
+  //   return true;
+  // }
+
   private handleRepetitionInstructions(currentRepetitionInstruction: RepetitionInstruction): boolean {
-    if (!this.currentMeasure) {
-      return false;
-    }
+    let currentRepetition: RepetitionBuildingContainer;
     switch (currentRepetitionInstruction.type) {
-      case RepetitionInstructionEnum.StartLine:
-        this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.BackJumpLine:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.Ending:
-        // set ending start or end
-        if (currentRepetitionInstruction.alignment === AlignmentType.Begin) {  // ending start
-          this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
-        } else { // ending end
-          for (let idx: number = 0, len: number = currentRepetitionInstruction.endingIndices.length; idx < len; ++idx) {
+        case RepetitionInstructionEnum.StartLine:
+            currentRepetition = this.createNewRepetition(this.currentMeasureIndex);
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            currentRepetition.RepetitonUnderConstruction.FromWords = false;
+            currentRepetition.RepetitonUnderConstruction.startMarker = currentRepetitionInstruction;
+            this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.BackJumpLine:
+            currentRepetition = this.getOrCreateCurrentRepetition2(false);
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
             this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-          }
-        }
-        break;
-      case RepetitionInstructionEnum.Segno:
-        this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.Fine:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.ToCoda:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.Coda:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.DaCapo:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.DalSegno:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.DalSegnoAlFine:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.DaCapoAlFine:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.DalSegnoAlCoda:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.DaCapoAlCoda:
-        this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
-        break;
-      case RepetitionInstructionEnum.None:
-        break;
-      default:
-        throw new ArgumentOutOfRangeException("currentRepetitionInstruction");
+            if (currentRepetition.RepetitonUnderConstruction.EndingParts.length === 0) {
+                this.finalizeRepetition(currentRepetition);
+            }
+            break;
+        case RepetitionInstructionEnum.Ending:
+            currentRepetition = this.getOrCreateCurrentRepetition();
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            const isFirstEndingStart: boolean = currentRepetitionInstruction.endingIndices.contains(1) &&
+                                                currentRepetitionInstruction.alignment === AlignmentType.Begin;
+            if (isFirstEndingStart) {
+                if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0 ||
+                    currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                    currentRepetition = undefined;
+                    for (let i: number = this.openRepetitions.length - 1; i >= 0; i--) {
+                        const openRep: RepetitionBuildingContainer = this.openRepetitions[i];
+                        if (openRep.RepetitonUnderConstruction.BackwardJumpInstructions.length === 0) {
+                            currentRepetition = openRep;
+                            while (this.openRepetitions.length - 1 > i) {
+                                const repToFinalize: RepetitionBuildingContainer = this.openRepetitions.last();
+                                this.finalizeRepetition(repToFinalize);
+                            }
+                        }
+                    }
+                    if (currentRepetition === undefined) {
+                        currentRepetition = this.createNewRepetition(0);
+                        currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(0, RepetitionInstructionEnum.None);
+                    }
+                }
+                if (currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction === undefined) {
+                    currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                      new RepetitionInstruction(this.currentMeasureIndex - 1, RepetitionInstructionEnum.ForwardJump,
+                                                AlignmentType.End,
+                                                currentRepetition.RepetitonUnderConstruction);
+                    this.musicSheet.SourceMeasures[this.currentMeasureIndex - 1].LastRepetitionInstructions.push(
+                      currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                }
+            }
+            if (currentRepetitionInstruction.alignment === AlignmentType.Begin) {
+                currentRepetition.RepetitonUnderConstruction.setEndingsStartIndex(currentRepetitionInstruction.endingIndices, this.currentMeasureIndex);
+                this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
+            } else {
+                for (let idx: number = 0, len: number = currentRepetitionInstruction.endingIndices.length; idx < len; ++idx) {
+                    const endingIndex: number = currentRepetitionInstruction.endingIndices[idx];
+                    currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(endingIndex, this.currentMeasureIndex);
+                    this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+                }
+            }
+            break;
+        case RepetitionInstructionEnum.Segno:
+            currentRepetition = this.getCurrentRepetition(true);
+            if (currentRepetition !== undefined &&
+                currentRepetition.SegnoFound &&
+                currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0 &&
+                Math.abs((currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.last().measureIndex - this.currentMeasureIndex)) <= 1) {
+                break;
+            }
+            currentRepetition = this.createNewRepetition(this.currentMeasureIndex);
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            currentRepetition.RepetitonUnderConstruction.FromWords = true;
+            currentRepetition.SegnoFound = true;
+            currentRepetition.RepetitonUnderConstruction.startMarker = currentRepetitionInstruction;
+            this.currentMeasure.FirstRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.Fine:
+            if (this.openRepetitions.length === 0) {
+                break;
+            }
+            currentRepetition = this.getCurrentRepetition(true);
+            if (currentRepetition === undefined) {
+                break;
+            }
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            currentRepetition.RepetitonUnderConstruction.FromWords = true;
+            if (currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction === undefined) {
+                currentRepetition.FineFound = true;
+                currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction = currentRepetitionInstruction;
+                currentRepetition.RepetitonUnderConstruction.setEndingStartIndex(2, -2);
+                this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            } else {
+                this.currentMeasure.LastRepetitionInstructions.push(new RepetitionInstruction(this.currentMeasureIndex,
+                                                                                              RepetitionInstructionEnum.Fine, AlignmentType.End, undefined));
+            }
+            break;
+        case RepetitionInstructionEnum.ToCoda:
+            if (this.openRepetitions.length === 0) {
+                break;
+            }
+            currentRepetition = this.getCurrentRepetition(true);
+            if (currentRepetition === undefined) {
+                break;
+            }
+            if (currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction === undefined) {
+                currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+                currentRepetition.RepetitonUnderConstruction.FromWords = true;
+                currentRepetition.ToCodaFound = true;
+                currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction = currentRepetitionInstruction;
+                this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            }
+            break;
+        case RepetitionInstructionEnum.Coda:
+            if (this.openRepetitions.length === 0) {
+                break;
+            }
+            currentRepetition = this.getOrCreateCurrentRepetition2(true);
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            if (currentRepetition.WaitingForCoda) {
+                currentRepetition.CodaFound = true;
+                currentRepetition.RepetitonUnderConstruction.setEndingStartIndex(2, this.currentMeasureIndex);
+                this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+                this.finalizeRepetition(currentRepetition);
+                if (this.currentMeasureIndex > 0) {
+                    this.musicSheet.SourceMeasures[this.currentMeasureIndex - 1].printNewSystemXml = true;
+                }
+            } else if (!currentRepetition.ToCodaFound) {
+                if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length === 0) {
+                    currentRepetition.ToCodaFound = true;
+                    currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                      new RepetitionInstruction(this.currentMeasureIndex,
+                                                RepetitionInstructionEnum.ToCoda,
+                                                AlignmentType.End,
+                                                currentRepetition.RepetitonUnderConstruction);
+                    this.currentMeasure.LastRepetitionInstructions.push(currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                } else {
+                    this.currentMeasure.LastRepetitionInstructions.push(new RepetitionInstruction(this.currentMeasureIndex,
+                                                                                                  RepetitionInstructionEnum.Coda,
+                                                                                                  AlignmentType.Begin, undefined));
+                }
+            }
+            break;
+        case RepetitionInstructionEnum.DaCapo:
+            currentRepetition = this.getOrCreateCurrentRepetition();
+            if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0) {
+                this.finalizeRepetition(currentRepetition);
+            }
+            if (currentRepetition.RepetitonUnderConstruction.StartIndex !== 0) {
+                currentRepetition = this.createNewRepetition(0);
+            }
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            currentRepetition.RepetitonUnderConstruction.FromWords = true;
+            currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(0, RepetitionInstructionEnum.None,
+                                                                                                 AlignmentType.Begin,
+                                                                                                 currentRepetition.RepetitonUnderConstruction);
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
+            this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            if (currentRepetition.RepetitonUnderConstruction.EndingParts.length === 0) {
+                this.finalizeRepetition(currentRepetition);
+            }
+            break;
+        case RepetitionInstructionEnum.DalSegno:
+            currentRepetition = this.getOrCreateCurrentRepetition2(true);
+            if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0) {
+                this.finalizeRepetition(currentRepetition);
+                currentRepetition = this.createNewRepetition(0);
+                currentRepetition.RepetitonUnderConstruction.FromWords = true;
+                currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(0, RepetitionInstructionEnum.None,
+                                                                                                     AlignmentType.Begin,
+                                                                                                     currentRepetition.RepetitonUnderConstruction);
+            }
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            if (!currentRepetition.SegnoFound) {
+                const segnoMeasureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.Segno,
+                                                                                          currentRepetitionInstruction.measureIndex);
+                if (segnoMeasureIndex >= 0) {
+                    currentRepetition.SegnoFound = true;
+                    currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction( segnoMeasureIndex,
+                                                                                                          RepetitionInstructionEnum.Segno,
+                                                                                                          AlignmentType.Begin,
+                                                                                                          currentRepetition.RepetitonUnderConstruction);
+                    this.musicSheet.SourceMeasures[segnoMeasureIndex].FirstRepetitionInstructions.splice(
+                      0, 0, currentRepetition.RepetitonUnderConstruction.startMarker);
+                }
+            }
+            if (currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
+            }
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
+            this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.DalSegnoAlFine:
+            if (this.openRepetitions.length === 0) {
+                break;
+            }
+            currentRepetition = this.getOrCreateCurrentRepetition2(true);
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            if (!currentRepetition.SegnoFound) {
+                const segnoMeasureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.Segno,
+                                                                                          currentRepetitionInstruction.measureIndex);
+                if (segnoMeasureIndex >= 0) {
+                    currentRepetition.SegnoFound = true;
+                    currentRepetition.RepetitonUnderConstruction.startMarker =
+                      new RepetitionInstruction(segnoMeasureIndex, RepetitionInstructionEnum.Segno,
+                                                AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                    this.musicSheet.SourceMeasures[segnoMeasureIndex].FirstRepetitionInstructions.
+                      splice(0, 0, currentRepetition.RepetitonUnderConstruction.startMarker);
+                }
+            }
+            if (!currentRepetition.FineFound) {
+                const fineMeasureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.Fine,
+                                                                                         currentRepetitionInstruction.measureIndex);
+                if (fineMeasureIndex >= 0) {
+                    currentRepetition.FineFound = true;
+                    currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                      new RepetitionInstruction(fineMeasureIndex, RepetitionInstructionEnum.Fine,
+                                                AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                    currentRepetition.RepetitonUnderConstruction.setEndingStartIndex(2, -2);
+                    this.musicSheet.SourceMeasures[fineMeasureIndex].LastRepetitionInstructions.
+                      splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                }
+            }
+            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
+            }
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
+            this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.DaCapoAlFine:
+            currentRepetition = this.getOrCreateCurrentRepetition();
+            if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0) {
+                this.finalizeRepetition(currentRepetition);
+                currentRepetition = this.createNewRepetition(0);
+            }
+            if (currentRepetition.RepetitonUnderConstruction.startMarker !== undefined && currentRepetition.RepetitonUnderConstruction.StartIndex !== 0) {
+                currentRepetition = this.createNewRepetition(0);
+            }
+            currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(0, RepetitionInstructionEnum.None,
+                                                                                                 AlignmentType.Begin,
+                                                                                                 currentRepetition.RepetitonUnderConstruction);
+            currentRepetition.RepetitonUnderConstruction.FromWords = true;
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            if (!currentRepetition.FineFound) {
+                const fineMeasureIndex: number = this.findInstructionInMainListBackwards( RepetitionInstructionEnum.Fine,
+                                                                                          currentRepetitionInstruction.measureIndex);
+                if (fineMeasureIndex >= 0) {
+                    currentRepetition.FineFound = true;
+                    currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                      new RepetitionInstruction(fineMeasureIndex, RepetitionInstructionEnum.Fine,
+                                                AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                    currentRepetition.RepetitonUnderConstruction.setEndingStartIndex(2, -2);
+                    this.musicSheet.SourceMeasures[fineMeasureIndex].LastRepetitionInstructions.
+                      splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                }
+            }
+            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
+            }
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
+            this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.DalSegnoAlCoda:
+            if (this.openRepetitions.length === 0) {
+                break;
+            }
+            currentRepetition = this.getOrCreateCurrentRepetition2(true);
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            if (!currentRepetition.SegnoFound) {
+                const segnoMeasureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.Segno,
+                                                                                          currentRepetitionInstruction.measureIndex);
+                if (segnoMeasureIndex >= 0) {
+                    currentRepetition.SegnoFound = true;
+                    currentRepetition.RepetitonUnderConstruction.startMarker =
+                      new RepetitionInstruction(segnoMeasureIndex, RepetitionInstructionEnum.Segno,
+                                                AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                    this.musicSheet.SourceMeasures[segnoMeasureIndex].FirstRepetitionInstructions.
+                      splice(0, 0, currentRepetition.RepetitonUnderConstruction.startMarker);
+                }
+            }
+            if (!currentRepetition.ToCodaFound) {
+                const toCodaMeasureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.ToCoda,
+                                                                                           currentRepetitionInstruction.measureIndex);
+                if (toCodaMeasureIndex >= 0) {
+                    currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                      new RepetitionInstruction(toCodaMeasureIndex, RepetitionInstructionEnum.ToCoda,
+                                                AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                    this.musicSheet.SourceMeasures[toCodaMeasureIndex].LastRepetitionInstructions.
+                      splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                    currentRepetition.ToCodaFound = true;
+                } else {
+                    const measureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.Coda,
+                                                                                         currentRepetitionInstruction.measureIndex);
+                    if (measureIndex >= 0) {
+                        currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                          new RepetitionInstruction(measureIndex, RepetitionInstructionEnum.ToCoda,
+                                                    AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                        this.musicSheet.SourceMeasures[measureIndex].LastRepetitionInstructions.
+                          splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                        currentRepetition.ToCodaFound = true;
+                    }
+                }
+            }
+            if (currentRepetition.ToCodaFound) {
+                currentRepetition.WaitingForCoda = true;
+            }
+            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
+            }
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
+            this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.DaCapoAlCoda:
+            currentRepetition = this.getOrCreateCurrentRepetition();
+            if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0) {
+                this.finalizeRepetition(currentRepetition);
+                currentRepetition = this.createNewRepetition(0);
+            } else if (currentRepetition.RepetitonUnderConstruction.EndingParts.length === 0) {
+                currentRepetition = this.createNewRepetition(0);
+            }
+            if (currentRepetition.RepetitonUnderConstruction.startMarker !== undefined && currentRepetition.RepetitonUnderConstruction.StartIndex !== 0) {
+                currentRepetition = this.createNewRepetition(0);
+            }
+            currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(0, RepetitionInstructionEnum.None,
+                                                                                                 AlignmentType.Begin,
+                                                                                                 currentRepetition.RepetitonUnderConstruction);
+            currentRepetition.RepetitonUnderConstruction.FromWords = true;
+            currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
+            if (!currentRepetition.ToCodaFound) {
+                const toCodaMeasureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.ToCoda,
+                                                                                           currentRepetitionInstruction.measureIndex);
+                if (toCodaMeasureIndex >= 0) {
+                    currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                      new RepetitionInstruction(toCodaMeasureIndex, RepetitionInstructionEnum.ToCoda,
+                                                AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                    this.musicSheet.SourceMeasures[toCodaMeasureIndex].LastRepetitionInstructions.
+                      splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                    currentRepetition.ToCodaFound = true;
+                } else {
+                    const measureIndex: number = this.findInstructionInMainListBackwards(RepetitionInstructionEnum.Coda,
+                                                                                         currentRepetitionInstruction.measureIndex);
+                    if (measureIndex >= 0) {
+                        currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction =
+                          new RepetitionInstruction(measureIndex, RepetitionInstructionEnum.ToCoda,
+                                                    AlignmentType.Begin, currentRepetition.RepetitonUnderConstruction);
+                        this.musicSheet.SourceMeasures[measureIndex].LastRepetitionInstructions.
+                          splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
+                        currentRepetition.ToCodaFound = true;
+                    }
+                }
+            }
+            if (currentRepetition.ToCodaFound) {
+                currentRepetition.WaitingForCoda = true;
+            }
+            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
+            }
+            currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
+            this.currentMeasure.LastRepetitionInstructions.push(currentRepetitionInstruction);
+            break;
+        case RepetitionInstructionEnum.None:
+            break;
+        default:
+            throw new ArgumentOutOfRangeException("currentRepetitionInstruction");
     }
     return true;
+  }
+
+  private findInstructionInMainListBackwards(instruction: RepetitionInstructionEnum, startMeasureIndex: number): number {
+      for (let i: number = this.repetitionInstructions.length - 1; i >= 0; i--) {
+          const repetitionInstruction: RepetitionInstruction = this.repetitionInstructions[i];
+          {
+              if (repetitionInstruction.measureIndex <= startMeasureIndex && repetitionInstruction.type === instruction) {
+                  return repetitionInstruction.measureIndex;
+              }
+          }
+      }
+      return -1;
+  }
+  private finalizeRepetition(repContainer: RepetitionBuildingContainer): void {
+      const currentRep: Repetition = repContainer.RepetitonUnderConstruction;
+      if (currentRep.BackwardJumpInstructions.length > 0) {
+          let addRepetition: boolean = true;
+          const lastRep: Repetition = this.getLastFinalizedRepetition();
+          if (lastRep !== undefined && currentRep.coversIdenticalMeasures(lastRep)) {
+              if (currentRep.NumberOfEndings > lastRep.NumberOfEndings) {
+                  const index: number = this.musicSheet.Repetitions.indexOf(lastRep, 0);
+                  if (index > -1) {
+                    this.musicSheet.Repetitions.splice(index, 1);
+                  }
+                  lastRep.removeFromRepetitionInstructions();
+                  this.musicSheet.Repetitions.push(currentRep);
+              }
+              addRepetition = false;
+              currentRep.removeFromRepetitionInstructions();
+          } else {
+              this.musicSheet.Repetitions.push(currentRep);
+          }
+          if (addRepetition) {
+              if (currentRep.startMarker.type === RepetitionInstructionEnum.None) {
+                  this.musicSheet.SourceMeasures[currentRep.StartIndex].FirstRepetitionInstructions.push(currentRep.startMarker);
+              }
+              let repetitions: number = currentRep.DefaultNumberOfRepetitions;
+              if (currentRep.BackwardJumpInstructions.length === 1 && currentRep.BackwardJumpInstructions[0].Times > 0) {
+                repetitions = currentRep.BackwardJumpInstructions[0].Times;
+              }
+              currentRep.UserNumberOfRepetitions = repetitions;
+          }
+      }
+      this.openRepetitions.splice(this.openRepetitions.length - 1, 1);
+  }
+  // private tryFinalizingLatestOpenRepetition(): void {
+  //     if (this.openRepetitions.length === 0) {
+  //         return;
+  //     }
+  //     const openRep: RepetitionBuildingContainer = this.openRepetitions.last();
+  //     const rep: Repetition = openRep.RepetitonUnderConstruction;
+  //     if (rep.BackwardJumpInstructions.length > 0 && rep.EndingParts.length > 0 && rep.EndingParts.last().part.EndIndex + 1 < this.currentMeasureIndex) {
+  //         this.finalizeRepetition(openRep);
+  //     }
+  // }
+  private getCurrentRepetition(fromWords: boolean): RepetitionBuildingContainer {
+      let currentRepetition: RepetitionBuildingContainer = undefined;
+      for (let i: number = this.openRepetitions.length - 1; i >= 0; i--) {
+          if (this.openRepetitions[i].RepetitonUnderConstruction.FromWords === fromWords) {
+              currentRepetition = this.openRepetitions[i];
+              while (i < this.openRepetitions.length - 1) {
+                  this.finalizeRepetition(this.openRepetitions.last());
+              }
+              return currentRepetition;
+          }
+      }
+      return currentRepetition;
+  }
+  private getOrCreateCurrentRepetition(): RepetitionBuildingContainer {
+    if (this.openRepetitions.length > 0) {
+        return this.openRepetitions.last();
+    }
+    const newRep: RepetitionBuildingContainer = this.createNewRepetition(0);
+    newRep.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(0, RepetitionInstructionEnum.None,
+                                                                              AlignmentType.Begin,
+                                                                              newRep.RepetitonUnderConstruction);
+    return newRep;
+  }
+  private getOrCreateCurrentRepetition2(fromWords: boolean): RepetitionBuildingContainer {
+      let currentRepetition: RepetitionBuildingContainer = undefined;
+      for (let i: number = this.openRepetitions.length - 1; i >= 0; i--) {
+          currentRepetition = this.openRepetitions[i];
+          if (currentRepetition.RepetitonUnderConstruction.FromWords === fromWords) {
+              while (i < this.openRepetitions.length - 1) {
+                  this.finalizeRepetition(this.openRepetitions.last());
+              }
+              return currentRepetition;
+          }
+      }
+      currentRepetition = this.createNewRepetition(this.lastRepetitionCommonPartStartIndex);
+      currentRepetition.RepetitonUnderConstruction.startMarker = new RepetitionInstruction(this.lastRepetitionCommonPartStartIndex,
+                                                                                           RepetitionInstructionEnum.None,
+                                                                                           AlignmentType.Begin,
+                                                                                           currentRepetition.RepetitonUnderConstruction);
+
+      // protection against missing repeat begin lines: start next repetitions from after the end of this one if no beginning given
+      //   see osmd-extended 117
+      this.lastRepetitionCommonPartStartIndex = this.currentMeasureIndex + 1;
+
+      currentRepetition.RepetitonUnderConstruction.FromWords = fromWords;
+      return currentRepetition;
+  }
+  private createNewRepetition(commonPartStartIndex: number): RepetitionBuildingContainer {
+      if (this.openRepetitions.length > 0) {
+          const last: RepetitionBuildingContainer = this.openRepetitions.last();
+          const lastRep: Repetition = last.RepetitonUnderConstruction;
+          if (lastRep.BackwardJumpInstructions.length > 0) {
+            const keys: string[] = Object.keys(lastRep.EndingIndexDict);
+            if (keys.length === 0 ||
+                lastRep.EndingIndexDict[keys[keys.length - 1]].part.EndIndex >= 0) {
+                this.finalizeRepetition(last);
+            }
+          }
+      }
+      const currentRepetition: RepetitionBuildingContainer = new RepetitionBuildingContainer(this.musicSheet);
+      this.lastRepetitionCommonPartStartIndex = commonPartStartIndex;
+      this.openRepetitions.push(currentRepetition);
+      return currentRepetition;
+  }
+  private getLastFinalizedRepetition(): Repetition {
+      if (this.musicSheet.Repetitions.length > 0) {
+          return this.musicSheet.Repetitions.last();
+      }
+      return undefined;
+  }
+}
+
+export class RepetitionBuildingContainer {
+  public RepetitonUnderConstruction: Repetition;
+  public WaitingForCoda: boolean;
+  public SegnoFound: boolean;
+  public FineFound: boolean;
+  public ToCodaFound: boolean;
+  public CodaFound: boolean;
+  constructor(musicSheet: MusicSheet) {
+      this.RepetitonUnderConstruction = new Repetition(musicSheet);
   }
 }

--- a/src/MusicalScore/VoiceData/Instructions/RepetitionInstruction.ts
+++ b/src/MusicalScore/VoiceData/Instructions/RepetitionInstruction.ts
@@ -57,6 +57,8 @@ export class RepetitionInstruction /*implements IComparable*/ {
     public type: RepetitionInstructionEnum;
     public alignment: AlignmentType;
     public parentRepetition: Repetition;
+    /** How many times this should be repeated */
+    public Times: number;
 
     public CompareTo(obj: Object): number {
         const other: RepetitionInstruction = <RepetitionInstruction>obj;

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -488,6 +488,12 @@ export class SourceMeasure {
         for (let idx: number = 0, len: number = this.FirstRepetitionInstructions.length; idx < len; ++idx) {
             const instr: RepetitionInstruction = this.FirstRepetitionInstructions[idx];
             if (instr.type === RepetitionInstructionEnum.StartLine) {
+                // Skip virtual "overall repetition" StartLine markers (FromWords=true) that are created by RepetitionCalculator
+                //   for cursor/playback purposes - these should not force a visible repeat barline.
+                //   It just creates a virtual repetition, which basically means the whole piece is a repetition, repeated 0 times.
+                if (instr.parentRepetition !== undefined && instr.parentRepetition.FromWords) {
+                    continue;
+                }
                 return true;
             }
             if (instr.parentRepetition !== undefined && instr === instr.parentRepetition.startMarker && !instr.parentRepetition.FromWords) {

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -496,7 +496,8 @@ export class SourceMeasure {
                 }
                 return true;
             }
-            if (instr.parentRepetition !== undefined && instr === instr.parentRepetition.startMarker && !instr.parentRepetition.FromWords) {
+            if (instr.parentRepetition !== undefined && instr === instr.parentRepetition.startMarker && !instr.parentRepetition.FromWords
+                && instr.type !== RepetitionInstructionEnum.None) {
                 return true;
             }
         }

--- a/test/Common/OSMD/OSMD_Test.ts
+++ b/test/Common/OSMD/OSMD_Test.ts
@@ -324,9 +324,16 @@ describe("OpenSheetMusicDisplay Main Export", () => {
                 cursor.next();
                 chai.expect(cursor.NotesUnderCursor().length).to.greaterThanOrEqual(1);
                 chai.expect(cursor.Iterator.currentTimeStamp.RealValue).to.equal(0);
+                // go past end of sheet if repetitions are ignored, which we don't do here (anymore). So, we should not reach the end here.
+                for (let i: number = 1; i <= 260; i++) {
+                    cursor.next();
+                }
+                chai.expect(cursor.Iterator.EndReached).to.equal(false);
                 // go past end of sheet
                 for (let i: number = 1; i <= 260; i++) {
-                    cursor.next(); // go past end of sheet: after 258 times in Clementi 36/1/1, the last timestamp is reached
+                    cursor.next();
+                    // go past end of sheet:
+                    //   after ~520 times (260 * 2) in Clementi 36/1/1, the last timestamp is reached
                 }
                 chai.expect(cursor.Iterator.EndReached).to.equal(true);
                 // try to go back again after going beyond end of sheet


### PR DESCRIPTION
* Fixes cursor not respecting repetitions. Now, the cursor goes back to the beginning of the repetition if you advance past the last note of it with cursor.next().
This is a merge of code from the audio player, where repetitions already worked.
* Left repeat barline x-placement now respects instructions like clef and time signature, and is correctly shifted to the right. No more repeat barlines at the beginning of the staff, before the clef
e.g. `test_subtitle_composer_multiline`:
Before:
<img width="299" height="156" alt="image" src="https://github.com/user-attachments/assets/ceab0981-addb-48bd-a35a-ed8cbf677f64" />

After:
<img width="310" height="151" alt="image" src="https://github.com/user-attachments/assets/a6616cee-bcf0-4b11-9553-00840bdbf592" />

* Some samples now correctly show a repetition right ending barline. E.g. Bach Air (last measure), test_wedge_offset
* Audio player: "to coda", "d.s. al coda" don't cause a double thin barline anymore, e.g. test_staverepetitions_coda_etc. This didn't happen in public osmd without the audio player, but got in by merging the repetition changes, and is now fixed for both.

No unwanted visual regressions.
Visual diffs (4.2MB):
[visual_diff_cursor_next_repetition_fix_left_barline_fix_etc_pr_1644.zip](https://github.com/user-attachments/files/25270112/visual_diff_cursor_next_repetition_fix_left_barline_fix_etc_pr_1644.zip)
