### PR TITLE
Fix octave shift dashed line too short on intermediate systems

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1027,7 +1027,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             const nextOctaveShift: VexFlowOctaveShift = new VexFlowOctaveShift(octaveShift, nextShiftFirstMeasure.PositionAndShape);
             let nextShiftLastMeasure: GraphicalMeasure = this.findLastStafflineMeasure(nextShiftStaffline);
 
-            if (i < systemsInBetweenCount - 1) {
+            if (i < endStaffLine.ParentMusicSystem.Id - 1) {
               // if not - 1, the last octaveshift will always go to the end of the staffline
               nextOctaveShift.endsOnDifferentStaffLine = true;
               nextOctaveShift.graphicalEndAtMeasureEnd = true;

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -16,9 +16,7 @@ import { VexFlowVoiceEntry } from "../../../../src/MusicalScore/Graphical/VexFlo
 import { GraphicalMeasure } from "../../../../src/MusicalScore/Graphical/GraphicalMeasure";
 import { GraphicalStaffEntry } from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
 import { GraphicalVoiceEntry } from "../../../../src/MusicalScore/Graphical/GraphicalVoiceEntry";
-import { GraphicalOctaveShift } from "../../../../src/MusicalScore/Graphical/GraphicalOctaveShift";
 import { GraphicalMusicPage } from "../../../../src/MusicalScore/Graphical/GraphicalMusicPage";
-import { MusicSystem } from "../../../../src/MusicalScore/Graphical/MusicSystem";
 import { StaffLine } from "../../../../src/MusicalScore/Graphical/StaffLine";
 
 describe("VexFlow Measure", () => {
@@ -102,33 +100,33 @@ describe("VexFlow Measure", () => {
       const div: HTMLElement = TestUtils.getDivElement(document);
       const osmd: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div, {
          autoResize: false,
-         newSystemFromXML: true,
       });
 
       osmd.load(score).then(
          (_: {}) => {
             osmd.render();
 
+            // Find intermediate octave shifts: those that both start and end on a different
+            // staff line (i.e. the shift continues through this system without starting or
+            // stopping here). These are the ones affected by the bug.
             const musicPage: GraphicalMusicPage = osmd.GraphicSheet.MusicPages[0];
-            // System 0: no octave shift (measure 1)
-            // System 1: 8va starts (measure 2)
-            // System 2: intermediate (measure 3 with grace notes) - this is where the bug was
-            // System 3: 8va ends (measures 4-5)
             chai.expect(musicPage.MusicSystems.length).to.be.greaterThanOrEqual(4,
                "Score should have at least 4 systems for this test to be valid");
 
-            // The intermediate system (index 2) should have an octave shift
-            const intermediateSystem: MusicSystem = musicPage.MusicSystems[2];
-            const staffLine: StaffLine = intermediateSystem.StaffLines[0];
-            const octaveShifts: GraphicalOctaveShift[] = staffLine.OctaveShifts;
-
-            chai.expect(octaveShifts.length).to.equal(1,
-               "Intermediate system should have exactly one octave shift");
-
-            const shift: GraphicalOctaveShift = octaveShifts[0];
-            chai.expect(shift.endsOnDifferentStaffLine).to.be.true;
-            chai.expect(shift.graphicalEndAtMeasureEnd).to.be.true;
-            chai.expect(shift.endMeasure).to.not.be.undefined;
+            let foundIntermediate: boolean = false;
+            for (const system of musicPage.MusicSystems) {
+               const staffLine: StaffLine = system.StaffLines[0];
+               for (const shift of staffLine.OctaveShifts) {
+                  // An intermediate shift has endsOnDifferentStaffLine=true but is not
+                  // the first part (isFirstPart is set on the system where the 8va starts).
+                  if (shift.endsOnDifferentStaffLine && !shift.isFirstPart) {
+                     foundIntermediate = true;
+                     chai.expect(shift.graphicalEndAtMeasureEnd).to.be.true;
+                     chai.expect(shift.endMeasure).to.not.be.undefined;
+                  }
+               }
+            }
+            chai.expect(foundIntermediate).to.be.true;
 
             done();
          },

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -16,6 +16,10 @@ import { VexFlowVoiceEntry } from "../../../../src/MusicalScore/Graphical/VexFlo
 import { GraphicalMeasure } from "../../../../src/MusicalScore/Graphical/GraphicalMeasure";
 import { GraphicalStaffEntry } from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
 import { GraphicalVoiceEntry } from "../../../../src/MusicalScore/Graphical/GraphicalVoiceEntry";
+import { GraphicalOctaveShift } from "../../../../src/MusicalScore/Graphical/GraphicalOctaveShift";
+import { GraphicalMusicPage } from "../../../../src/MusicalScore/Graphical/GraphicalMusicPage";
+import { MusicSystem } from "../../../../src/MusicalScore/Graphical/MusicSystem";
+import { StaffLine } from "../../../../src/MusicalScore/Graphical/StaffLine";
 
 describe("VexFlow Measure", () => {
 
@@ -81,6 +85,50 @@ describe("VexFlow Measure", () => {
                      "Single grace notes should have baseFingeringXOffset=0");
                }
             }
+
+            done();
+         },
+         done
+      );
+   });
+
+   // Non-regression test for octave shift spanning 3+ systems.
+   // Before fix: the condition `i < systemsInBetweenCount - 1` compared a system ID against
+   // a count, causing graphicalEndAtMeasureEnd to never be set on intermediate systems when
+   // the octave shift started on system ID >= 1. The dashed line would stop at the last note
+   // instead of extending to the end of the measure.
+   it("Octave shift on intermediate system should have graphicalEndAtMeasureEnd set", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("test_octaveshift_multiline_grace_notes.musicxml");
+      const div: HTMLElement = TestUtils.getDivElement(document);
+      const osmd: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div, {
+         autoResize: false,
+         newSystemFromXML: true,
+      });
+
+      osmd.load(score).then(
+         (_: {}) => {
+            osmd.render();
+
+            const musicPage: GraphicalMusicPage = osmd.GraphicSheet.MusicPages[0];
+            // System 0: no octave shift (measure 1)
+            // System 1: 8va starts (measure 2)
+            // System 2: intermediate (measure 3 with grace notes) - this is where the bug was
+            // System 3: 8va ends (measures 4-5)
+            chai.expect(musicPage.MusicSystems.length).to.be.greaterThanOrEqual(4,
+               "Score should have at least 4 systems for this test to be valid");
+
+            // The intermediate system (index 2) should have an octave shift
+            const intermediateSystem: MusicSystem = musicPage.MusicSystems[2];
+            const staffLine: StaffLine = intermediateSystem.StaffLines[0];
+            const octaveShifts: GraphicalOctaveShift[] = staffLine.OctaveShifts;
+
+            chai.expect(octaveShifts.length).to.equal(1,
+               "Intermediate system should have exactly one octave shift");
+
+            const shift: GraphicalOctaveShift = octaveShifts[0];
+            chai.expect(shift.endsOnDifferentStaffLine).to.be.true;
+            chai.expect(shift.graphicalEndAtMeasureEnd).to.be.true;
+            chai.expect(shift.endMeasure).to.not.be.undefined;
 
             done();
          },

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -16,7 +16,9 @@ import { VexFlowVoiceEntry } from "../../../../src/MusicalScore/Graphical/VexFlo
 import { GraphicalMeasure } from "../../../../src/MusicalScore/Graphical/GraphicalMeasure";
 import { GraphicalStaffEntry } from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
 import { GraphicalVoiceEntry } from "../../../../src/MusicalScore/Graphical/GraphicalVoiceEntry";
+import { GraphicalOctaveShift } from "../../../../src/MusicalScore/Graphical/GraphicalOctaveShift";
 import { GraphicalMusicPage } from "../../../../src/MusicalScore/Graphical/GraphicalMusicPage";
+import { MusicSystem } from "../../../../src/MusicalScore/Graphical/MusicSystem";
 import { StaffLine } from "../../../../src/MusicalScore/Graphical/StaffLine";
 
 describe("VexFlow Measure", () => {
@@ -100,33 +102,33 @@ describe("VexFlow Measure", () => {
       const div: HTMLElement = TestUtils.getDivElement(document);
       const osmd: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div, {
          autoResize: false,
+         newSystemFromXML: true,
       });
 
       osmd.load(score).then(
          (_: {}) => {
             osmd.render();
 
-            // Find intermediate octave shifts: those that both start and end on a different
-            // staff line (i.e. the shift continues through this system without starting or
-            // stopping here). These are the ones affected by the bug.
             const musicPage: GraphicalMusicPage = osmd.GraphicSheet.MusicPages[0];
+            // System 0: no octave shift (measure 1)
+            // System 1: 8va starts (measure 2)
+            // System 2: intermediate (measure 3 with grace notes) - this is where the bug was
+            // System 3: 8va ends (measures 4-5)
             chai.expect(musicPage.MusicSystems.length).to.be.greaterThanOrEqual(4,
                "Score should have at least 4 systems for this test to be valid");
 
-            let foundIntermediate: boolean = false;
-            for (const system of musicPage.MusicSystems) {
-               const staffLine: StaffLine = system.StaffLines[0];
-               for (const shift of staffLine.OctaveShifts) {
-                  // An intermediate shift has endsOnDifferentStaffLine=true but is not
-                  // the first part (isFirstPart is set on the system where the 8va starts).
-                  if (shift.endsOnDifferentStaffLine && !shift.isFirstPart) {
-                     foundIntermediate = true;
-                     chai.expect(shift.graphicalEndAtMeasureEnd).to.be.true;
-                     chai.expect(shift.endMeasure).to.not.be.undefined;
-                  }
-               }
-            }
-            chai.expect(foundIntermediate).to.be.true;
+            // The intermediate system (index 2) should have an octave shift
+            const intermediateSystem: MusicSystem = musicPage.MusicSystems[2];
+            const staffLine: StaffLine = intermediateSystem.StaffLines[0];
+            const octaveShifts: GraphicalOctaveShift[] = staffLine.OctaveShifts;
+
+            chai.expect(octaveShifts.length).to.equal(1,
+               "Intermediate system should have exactly one octave shift");
+
+            const shift: GraphicalOctaveShift = octaveShifts[0];
+            chai.expect(shift.endsOnDifferentStaffLine).to.be.true;
+            chai.expect(shift.graphicalEndAtMeasureEnd).to.be.true;
+            chai.expect(shift.endMeasure).to.not.be.undefined;
 
             done();
          },

--- a/test/data/test_octaveshift_multiline_grace_notes.musicxml
+++ b/test/data/test_octaveshift_multiline_grace_notes.musicxml
@@ -7,202 +7,104 @@
     </score-part>
   </part-list>
   <part id="P1">
-    <!-- Measures 1-3: fill system 0, no octave shift -->
+    <!-- Measure 1: no octave shift, own system (system 0) -->
     <measure number="1">
       <attributes>
-        <divisions>4</divisions>
+        <divisions>1</divisions>
         <key><fifths>0</fifths></key>
         <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
-      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
     </measure>
+    <!-- Measure 2: 8va starts here (system 1) -->
     <measure number="2">
-      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-    </measure>
-    <measure number="3">
-      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-    </measure>
-    <!-- Measures 4-6: system 1, 8va starts here -->
-    <measure number="4">
+      <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
           <octave-shift type="up" size="8"/>
         </direction-type>
       </direction>
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
     </measure>
-    <measure number="5">
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+    <!-- Measure 3: intermediate system with chord + grace notes (system 2) -->
+    <measure number="3">
+      <print new-system="yes"/>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>G</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>A</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>B</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>C</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>D</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>E</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>F</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
     </measure>
-    <measure number="6">
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-    </measure>
-    <!-- Measures 7-9: system 2 (intermediate), still under 8va, with trailing grace notes -->
-    <measure number="7">
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-    </measure>
-    <measure number="8">
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-    </measure>
-    <measure number="9">
-      <!-- A chord followed by grace notes, like the Nocturne's measure 32 -->
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>16</duration><type>whole</type></note>
-      <note><grace/><pitch><step>F</step><octave>5</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>G</step><octave>5</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>A</step><octave>5</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>B</step><octave>5</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>C</step><octave>6</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>D</step><octave>6</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>E</step><octave>6</octave></pitch><type>16th</type></note>
-      <note><grace/><pitch><step>F</step><octave>6</octave></pitch><type>16th</type></note>
-    </measure>
-    <!-- Measures 10-12: system 3, 8va ends here -->
-    <measure number="10">
-      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
-      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+    <!-- Measure 4: 8va ends here (system 3) -->
+    <measure number="4">
+      <print new-system="yes"/>
+      <note>
+        <pitch><step>G</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
       <direction placement="above">
         <direction-type>
           <octave-shift type="stop" size="8"/>
         </direction-type>
       </direction>
     </measure>
-    <measure number="11">
-      <note><pitch><step>C</step><octave>4</octave></pitch><duration>16</duration><type>whole</type></note>
+    <!-- Measure 5: normal, no octave shift -->
+    <measure number="5">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
       </barline>

--- a/test/data/test_octaveshift_multiline_grace_notes.musicxml
+++ b/test/data/test_octaveshift_multiline_grace_notes.musicxml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <!-- Measure 1: no octave shift, own system (system 0) -->
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!-- Measure 2: 8va starts here (system 1) -->
+    <measure number="2">
+      <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="up" size="8"/>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!-- Measure 3: intermediate system with chord + grace notes (system 2) -->
+    <measure number="3">
+      <print new-system="yes"/>
+      <note>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>G</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>A</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>B</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>C</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>D</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>E</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace/>
+        <pitch><step>F</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+    </measure>
+    <!-- Measure 4: 8va ends here (system 3) -->
+    <measure number="4">
+      <print new-system="yes"/>
+      <note>
+        <pitch><step>G</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="stop" size="8"/>
+        </direction-type>
+      </direction>
+    </measure>
+    <!-- Measure 5: normal, no octave shift -->
+    <measure number="5">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/data/test_octaveshift_multiline_grace_notes.musicxml
+++ b/test/data/test_octaveshift_multiline_grace_notes.musicxml
@@ -7,104 +7,202 @@
     </score-part>
   </part-list>
   <part id="P1">
-    <!-- Measure 1: no octave shift, own system (system 0) -->
+    <!-- Measures 1-3: fill system 0, no octave shift -->
     <measure number="1">
       <attributes>
-        <divisions>1</divisions>
+        <divisions>4</divisions>
         <key><fifths>0</fifths></key>
         <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
-      <note>
-        <pitch><step>C</step><octave>4</octave></pitch>
-        <duration>4</duration>
-        <type>whole</type>
-      </note>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
     </measure>
-    <!-- Measure 2: 8va starts here (system 1) -->
     <measure number="2">
-      <print new-system="yes"/>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+    </measure>
+    <measure number="3">
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>4</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+    </measure>
+    <!-- Measures 4-6: system 1, 8va starts here -->
+    <measure number="4">
       <direction placement="above">
         <direction-type>
           <octave-shift type="up" size="8"/>
         </direction-type>
       </direction>
-      <note>
-        <pitch><step>C</step><octave>5</octave></pitch>
-        <duration>4</duration>
-        <type>whole</type>
-      </note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
     </measure>
-    <!-- Measure 3: intermediate system with chord + grace notes (system 2) -->
-    <measure number="3">
-      <print new-system="yes"/>
-      <note>
-        <pitch><step>E</step><octave>5</octave></pitch>
-        <duration>4</duration>
-        <type>whole</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>F</step><octave>5</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>G</step><octave>5</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>A</step><octave>5</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>B</step><octave>5</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>C</step><octave>6</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>D</step><octave>6</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>E</step><octave>6</octave></pitch>
-        <type>16th</type>
-      </note>
-      <note>
-        <grace/>
-        <pitch><step>F</step><octave>6</octave></pitch>
-        <type>16th</type>
-      </note>
+    <measure number="5">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
     </measure>
-    <!-- Measure 4: 8va ends here (system 3) -->
-    <measure number="4">
-      <print new-system="yes"/>
-      <note>
-        <pitch><step>G</step><octave>5</octave></pitch>
-        <duration>4</duration>
-        <type>whole</type>
-      </note>
+    <measure number="6">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+    </measure>
+    <!-- Measures 7-9: system 2 (intermediate), still under 8va, with trailing grace notes -->
+    <measure number="7">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+    </measure>
+    <measure number="8">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+    </measure>
+    <measure number="9">
+      <!-- A chord followed by grace notes, like the Nocturne's measure 32 -->
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>16</duration><type>whole</type></note>
+      <note><grace/><pitch><step>F</step><octave>5</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>G</step><octave>5</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>A</step><octave>5</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>B</step><octave>5</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>C</step><octave>6</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>D</step><octave>6</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>E</step><octave>6</octave></pitch><type>16th</type></note>
+      <note><grace/><pitch><step>F</step><octave>6</octave></pitch><type>16th</type></note>
+    </measure>
+    <!-- Measures 10-12: system 3, 8va ends here -->
+    <measure number="10">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>E</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>F</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>G</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>A</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>B</step><octave>6</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>C</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
+      <note><pitch><step>D</step><octave>7</octave></pitch><duration>1</duration><type>16th</type></note>
       <direction placement="above">
         <direction-type>
           <octave-shift type="stop" size="8"/>
         </direction-type>
       </direction>
     </measure>
-    <!-- Measure 5: normal, no octave shift -->
-    <measure number="5">
-      <note>
-        <pitch><step>C</step><octave>4</octave></pitch>
-        <duration>4</duration>
-        <type>whole</type>
-      </note>
+    <measure number="11">
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>16</duration><type>whole</type></note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
       </barline>


### PR DESCRIPTION
## Summary

- Fix octave shift (8va/8vb) dashed continuation line stopping too short on intermediate systems when the shift spans 3+ systems
- The condition at line 1030 compared a system **ID** (`i`) against a **count** (`systemsInBetweenCount - 1`), which always evaluated `false` when the start system ID >= 1
- One-line fix: compare against `endStaffLine.ParentMusicSystem.Id - 1` instead

### Before 
<img width="348" height="493" alt="Screenshot 2026-02-14 at 18 17 37" src="https://github.com/user-attachments/assets/d26c0020-00b3-4321-881c-1344431f07e3" />

### After
<img width="367" height="512" alt="Screenshot 2026-02-14 at 18 19 22" src="https://github.com/user-attachments/assets/d4bf8c09-d2c6-4063-b282-0bd50c3a005d" />


## Test plan

- [x] Added regression test in `VexFlowMeasure_Test.ts` that verifies `graphicalEndAtMeasureEnd` is set on intermediate systems
- [x] Added test MusicXML file with an 8va spanning 3 systems (with grace notes on the intermediate system)
- [x] All 195 tests pass (194 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)