### PR TITLE
Fix octave shift not applied to grace notes before stop direction

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -2893,10 +2893,12 @@ export abstract class MusicSheetCalculator {
                 }
                 // check for possible OctaveShift
                 let octaveShiftValue: OctaveEnum = OctaveEnum.NONE;
+                let activeOctaveShift: OctaveShift;
                 if (openOctaveShifts[staffIndex]) {
                     if (openOctaveShifts[staffIndex].getAbsoluteStartTimestamp.lte(sourceStaffEntry.AbsoluteTimestamp) &&
                         sourceStaffEntry.AbsoluteTimestamp.lte(openOctaveShifts[staffIndex].getAbsoluteEndTimestamp)) {
                         octaveShiftValue = openOctaveShifts[staffIndex].getOpenOctaveShift.Type;
+                        activeOctaveShift = openOctaveShifts[staffIndex].getOpenOctaveShift;
                     }
                 }
                 if (octaveShiftValue === OctaveEnum.NONE) {
@@ -2911,6 +2913,7 @@ export abstract class MusicSheetCalculator {
                         if (targetOctaveShift?.ParentStartMultiExpression?.AbsoluteTimestamp.lte(sourceStaffEntry.AbsoluteTimestamp) &&
                             !targetOctaveShift.ParentEndMultiExpression?.AbsoluteTimestamp.lt(sourceStaffEntry.AbsoluteTimestamp)) {
                                 octaveShiftValue = targetOctaveShift.Type;
+                                activeOctaveShift = targetOctaveShift;
                                 break;
                             }
                     }
@@ -2918,6 +2921,14 @@ export abstract class MusicSheetCalculator {
                 // for each visible Voice create the corresponding GraphicalNotes
                 for (let idx: number = 0, len: number = sourceStaffEntry.VoiceEntries.length; idx < len; ++idx) {
                     const voiceEntry: VoiceEntry = sourceStaffEntry.VoiceEntries[idx];
+                    // When an octave shift stop falls between grace notes at the same timestamp,
+                    // turn off the shift for VoiceEntries parsed after the stop.
+                    if (octaveShiftValue !== OctaveEnum.NONE && activeOctaveShift &&
+                        activeOctaveShift.ParentEndMultiExpression?.AbsoluteTimestamp.Equals(sourceStaffEntry.AbsoluteTimestamp) &&
+                        idx >= activeOctaveShift.endVoiceEntryIndex) {
+                        octaveShiftValue = OctaveEnum.NONE;
+                        activeOctaveShift = undefined;
+                    }
                     // Normal Notes...
                     octaveShiftValue = this.handleVoiceEntry(
                         voiceEntry, graphicalStaffEntry,

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -2924,6 +2924,7 @@ export abstract class MusicSheetCalculator {
                     // When an octave shift stop falls between grace notes at the same timestamp,
                     // turn off the shift for VoiceEntries parsed after the stop.
                     if (octaveShiftValue !== OctaveEnum.NONE && activeOctaveShift &&
+                        activeOctaveShift.endVoiceEntryIndex > 0 && // without this, last note in bracket is drawn an octave too high
                         activeOctaveShift.ParentEndMultiExpression?.AbsoluteTimestamp.Equals(sourceStaffEntry.AbsoluteTimestamp) &&
                         idx >= activeOctaveShift.endVoiceEntryIndex) {
                         octaveShiftValue = OctaveEnum.NONE;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1079,7 +1079,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
 
         this.calculateOctaveShiftSkyBottomLine(startStaffEntry, lastNoteOfFirstShift, graphicalOctaveShift, startStaffLine);
       } else {
-        graphicalOctaveShift.setEndNote(endStaffEntry);
+        graphicalOctaveShift.setEndNote(endStaffEntry, octaveShift.endVoiceEntryIndex > 0 ? octaveShift.endVoiceEntryIndex : -1);
         this.calculateOctaveShiftSkyBottomLine(startStaffEntry, endStaffEntry, graphicalOctaveShift, startStaffLine);
       }
       startStaffLine.OctaveShifts.push(graphicalOctaveShift);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1071,7 +1071,9 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
               log.warn(logPrefix + "no lastNote found");
             }
             nextOctaveShift.setStartNote(firstNote);
-            nextOctaveShift.setEndNote(lastNote);
+            const endIdx: number = endMeasure.ParentStaffLine === nextShiftStaffline && octaveShift.endVoiceEntryIndex > 0
+              ? octaveShift.endVoiceEntryIndex : -1;
+            nextOctaveShift.setEndNote(lastNote, endIdx);
             nextShiftStaffline.OctaveShifts.push(nextOctaveShift);
             this.calculateOctaveShiftSkyBottomLine(firstNote, lastNote, nextOctaveShift, nextShiftStaffline);
           }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowOctaveShift.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowOctaveShift.ts
@@ -74,10 +74,6 @@ export class VexFlowOctaveShift extends GraphicalOctaveShift {
     }
 
     /**
-     * Set an end note using a staff entry
-     * @param graphicalStaffEntry the staff entry that holds the end note
-     */
-    /**
      * Set an end note using a staff entry.
      * @param graphicalStaffEntry the staff entry that holds the end note
      * @param maxVoiceEntryIndex when >= 0, only consider voice entries before this index

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowOctaveShift.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowOctaveShift.ts
@@ -90,6 +90,9 @@ export class VexFlowOctaveShift extends GraphicalOctaveShift {
                 this.endMeasure = graphicalStaffEntry.parentMeasure;
                 if (this.endMeasure?.parentSourceMeasure.Rules.OctaveShiftOnWholeMeasureNoteUntilEndOfMeasure &&
                     vve.notes[0].sourceNote.isWholeMeasureNote()) {
+                    // draw whole note octave shift until end of measure
+                    //   Instead, we could try to fix the display of very short octaveshift brackets,
+                    //   which seem to overlap text (-> VF.TextBracket VexFlowPatch?).
                     this.graphicalEndAtMeasureEnd = true;
                 }
                 return true;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowOctaveShift.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowOctaveShift.ts
@@ -4,6 +4,7 @@ import { GraphicalOctaveShift } from "../GraphicalOctaveShift";
 import { OctaveShift, OctaveEnum } from "../../VoiceData/Expressions/ContinuousExpressions/OctaveShift";
 import { BoundingBox } from "../BoundingBox";
 import { GraphicalStaffEntry } from "../GraphicalStaffEntry";
+import { GraphicalVoiceEntry } from "../GraphicalVoiceEntry";
 import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
 import log from "loglevel";
 
@@ -76,18 +77,23 @@ export class VexFlowOctaveShift extends GraphicalOctaveShift {
      * Set an end note using a staff entry
      * @param graphicalStaffEntry the staff entry that holds the end note
      */
-    public setEndNote(graphicalStaffEntry: GraphicalStaffEntry): boolean {
-        // this is duplicate code from setStartNote, but if we make one general method, we add a lot of branching.
-        for (const gve of graphicalStaffEntry.graphicalVoiceEntries) {
-            const vve: VexFlowVoiceEntry = (gve as VexFlowVoiceEntry);
+    /**
+     * Set an end note using a staff entry.
+     * @param graphicalStaffEntry the staff entry that holds the end note
+     * @param maxVoiceEntryIndex when >= 0, only consider voice entries before this index
+     *        (used when an octave shift stop falls between grace notes sharing the same staff entry)
+     */
+    public setEndNote(graphicalStaffEntry: GraphicalStaffEntry, maxVoiceEntryIndex: number = -1): boolean {
+        const entries: GraphicalVoiceEntry[] = graphicalStaffEntry.graphicalVoiceEntries;
+        const limit: number = maxVoiceEntryIndex >= 0 ? Math.min(maxVoiceEntryIndex, entries.length) : entries.length;
+        // Search backwards to find the last covered VoiceEntry
+        for (let i: number = limit - 1; i >= 0; i--) {
+            const vve: VexFlowVoiceEntry = (entries[i] as VexFlowVoiceEntry);
             if (vve?.vfStaveNote) {
                 this.endNote = vve.vfStaveNote;
                 this.endMeasure = graphicalStaffEntry.parentMeasure;
                 if (this.endMeasure?.parentSourceMeasure.Rules.OctaveShiftOnWholeMeasureNoteUntilEndOfMeasure &&
                     vve.notes[0].sourceNote.isWholeMeasureNote()) {
-                    // draw whole note octave shift until end of measure
-                    //   Instead, we could try to fix the display of very short octaveshift brackets,
-                    //   which seem to overlap text (-> VF.TextBracket VexFlowPatch?).
                     this.graphicalEndAtMeasureEnd = true;
                 }
                 return true;

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -463,10 +463,16 @@ export class InstrumentReader {
                // Grace notes before/after a stop share the same timestamp; this count lets the
                // renderer distinguish which VoiceEntries fall under the octave shift.
                let endVoiceEntryCount: number = 0;
+               let endFraction: Fraction;
                if (this.currentStaffEntry?.Timestamp?.Equals(currentFraction)) {
+                 // Grace notes at this timestamp — use currentFraction and track which entries are covered
                  endVoiceEntryCount = this.currentStaffEntry.VoiceEntries.length;
+                 endFraction = currentFraction.clone();
+               } else {
+                 // Normal case: last note was a real note, use previousFraction
+                 endFraction = previousFraction.clone();
                }
-               expressionReader.addOctaveShift(xmlNode, this.currentMeasure, currentFraction.clone(), endVoiceEntryCount);
+               expressionReader.addOctaveShift(xmlNode, this.currentMeasure, endFraction, endVoiceEntryCount);
              }
              if (directionTypeNodes.some(dt => dt.element("pedal"))) {
               expressionReader.readExpressionParameters(

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -459,7 +459,14 @@ export class InstrumentReader {
                expressionReader.readExpressionParameters(
                  xmlNode, this.instrument, this.divisions, currentFraction, previousFraction, this.currentMeasure.MeasureNumber, true
                );
-               expressionReader.addOctaveShift(xmlNode, this.currentMeasure, previousFraction.clone());
+               // Count how many VoiceEntries at the current timestamp were parsed before this stop.
+               // Grace notes before/after a stop share the same timestamp; this count lets the
+               // renderer distinguish which VoiceEntries fall under the octave shift.
+               let endVoiceEntryCount: number = 0;
+               if (this.currentStaffEntry?.Timestamp?.Equals(currentFraction)) {
+                 endVoiceEntryCount = this.currentStaffEntry.VoiceEntries.length;
+               }
+               expressionReader.addOctaveShift(xmlNode, this.currentMeasure, currentFraction.clone(), endVoiceEntryCount);
              }
              if (directionTypeNodes.some(dt => dt.element("pedal"))) {
               expressionReader.readExpressionParameters(

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -278,7 +278,8 @@ export class ExpressionReader {
             this.closeOpenContinuousTempo(Fraction.plus(sourceMeasure.AbsoluteTimestamp, timestamp));
         }
     }
-    public addOctaveShift(directionNode: IXmlElement, currentMeasure: SourceMeasure, endTimestamp: Fraction): void {
+    public addOctaveShift(directionNode: IXmlElement, currentMeasure: SourceMeasure, endTimestamp: Fraction,
+                          endVoiceEntryCount: number = 0): void {
         let octaveStaffNumber: number = 1;
         const staffNode: IXmlElement = directionNode.element("staff");
         if (staffNode) {
@@ -341,6 +342,7 @@ export class ExpressionReader {
                         } else if (type === "stop") {
                             const matchingShift: OctaveShift = this.openOctaveShifts.get(numberXml);
                             if (matchingShift) {
+                                matchingShift.endVoiceEntryIndex = endVoiceEntryCount;
                                 this.getMultiExpression = this.createNewMultiExpressionIfNeeded(
                                     currentMeasure, matchingShift.numberXml, endTimestamp);
                                 const octaveShiftStartExpression: MultiExpression = this.getMultiExpression;

--- a/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/OctaveShift.ts
+++ b/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/OctaveShift.ts
@@ -9,9 +9,8 @@ export class OctaveShift {
     private octaveValue: OctaveEnum;
     private staffNumber: number;
     public numberXml: number = 1;
-    /** Number of VoiceEntries at the end timestamp that are still covered by this shift.
-     *  When the stop is placed between grace notes sharing the same timestamp,
-     *  this distinguishes which VoiceEntries are before vs after the stop.
+    /** Index of the first VoiceEntry at the end timestamp that is NOT covered by this shift.
+     *  Used when a stop falls between grace notes sharing the same timestamp.
      *  0 means no VoiceEntries at the end timestamp are covered. */
     public endVoiceEntryIndex: number = 0;
     private startMultiExpression: MultiExpression;

--- a/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/OctaveShift.ts
+++ b/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/OctaveShift.ts
@@ -9,6 +9,11 @@ export class OctaveShift {
     private octaveValue: OctaveEnum;
     private staffNumber: number;
     public numberXml: number = 1;
+    /** Number of VoiceEntries at the end timestamp that are still covered by this shift.
+     *  When the stop is placed between grace notes sharing the same timestamp,
+     *  this distinguishes which VoiceEntries are before vs after the stop.
+     *  0 means no VoiceEntries at the end timestamp are covered. */
+    public endVoiceEntryIndex: number = 0;
     private startMultiExpression: MultiExpression;
     private endMultiExpression: MultiExpression;
 

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -112,28 +112,23 @@ describe("VexFlow Measure", () => {
 
                const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, 0);
 
-               // Collect all grace voice entries and their octave shift values
-               const graceEntries: {isGrace: boolean, octaveShift: OctaveEnum}[] = [];
+               // Collect octave shift values for all grace notes in the measure
+               const graceOctaveShifts: OctaveEnum[] = [];
                for (const staffEntry of gm.staffEntries) {
                   for (const gve of staffEntry.graphicalVoiceEntries) {
                      if (gve.parentVoiceEntry?.IsGrace) {
                         const note: VexFlowGraphicalNote = gve.notes[0] as VexFlowGraphicalNote;
-                        graceEntries.push({
-                           isGrace: true,
-                           octaveShift: note.octaveShift,
-                        });
+                        graceOctaveShifts.push(note.octaveShift);
                      }
                   }
                }
 
-               // We have 6 grace notes total: 4 under 8va, then 2 after the stop
-               chai.expect(graceEntries.length).to.equal(6, "Should have 6 grace notes");
+               // 6 grace notes total: 4 under 8va, then 2 after the stop
+               chai.expect(graceOctaveShifts.length).to.equal(6, "Should have 6 grace notes");
 
                // First 4 grace notes should have octave shift applied (VA8 = 8va)
-               // Before fix: these had OctaveEnum.NONE because previousFraction pointed
-               // to the start of the measure instead of the current position.
                for (let i: number = 0; i < 4; i++) {
-                  chai.expect(graceEntries[i].octaveShift).to.not.equal(OctaveEnum.NONE,
+                  chai.expect(graceOctaveShifts[i]).to.not.equal(OctaveEnum.NONE,
                      `Grace note ${i} should be under 8va`);
                }
 

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -16,6 +16,8 @@ import { VexFlowVoiceEntry } from "../../../../src/MusicalScore/Graphical/VexFlo
 import { GraphicalMeasure } from "../../../../src/MusicalScore/Graphical/GraphicalMeasure";
 import { GraphicalStaffEntry } from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
 import { GraphicalVoiceEntry } from "../../../../src/MusicalScore/Graphical/GraphicalVoiceEntry";
+import { VexFlowGraphicalNote } from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowGraphicalNote";
+import { OctaveEnum } from "../../../../src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/OctaveShift";
 
 describe("VexFlow Measure", () => {
 
@@ -83,6 +85,62 @@ describe("VexFlow Measure", () => {
             }
 
             done();
+         },
+         done
+      );
+   });
+
+   // Non-regression test for octave shift stop placed after grace notes.
+   // Before fix: addOctaveShift used previousFraction as end timestamp, but previousFraction
+   // is only updated for real notes (not grace notes). When the stop is placed after grace notes,
+   // previousFraction still points to the position of the last real note before the grace notes,
+   // causing the octave shift to end too early and miss the grace notes entirely.
+   // Fix: use currentFraction instead (like addPedalMarking already does).
+   it("Octave shift should apply to grace notes before the stop direction", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("test_octaveshift_stop_after_grace_notes.musicxml");
+      if (!score) {
+         done(new Error("Score file not found"));
+         return;
+      }
+      const div: HTMLElement = TestUtils.getDivElement(document);
+      const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
+
+      osmd.load(score).then(
+         (_: {}) => {
+            try {
+               osmd.render();
+
+               const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, 0);
+
+               // Collect all grace voice entries and their octave shift values
+               const graceEntries: {isGrace: boolean, octaveShift: OctaveEnum}[] = [];
+               for (const staffEntry of gm.staffEntries) {
+                  for (const gve of staffEntry.graphicalVoiceEntries) {
+                     if (gve.parentVoiceEntry?.IsGrace) {
+                        const note: VexFlowGraphicalNote = gve.notes[0] as VexFlowGraphicalNote;
+                        graceEntries.push({
+                           isGrace: true,
+                           octaveShift: note.octaveShift,
+                        });
+                     }
+                  }
+               }
+
+               // We have 6 grace notes total: 4 under 8va, then 2 after the stop
+               chai.expect(graceEntries.length).to.equal(6, "Should have 6 grace notes");
+
+               // First 4 grace notes should have octave shift applied (VA8 = 8va)
+               // Before fix: these had OctaveEnum.NONE because previousFraction pointed
+               // to the start of the measure instead of the current position.
+               for (let i: number = 0; i < 4; i++) {
+                  chai.expect(graceEntries[i].octaveShift).to.not.equal(OctaveEnum.NONE,
+                     `Grace note ${i} should be under 8va`);
+               }
+
+               done();
+            } catch (e) {
+               done(e);
+            }
          },
          done
       );

--- a/test/data/test_octaveshift_stop_after_grace_notes.musicxml
+++ b/test/data/test_octaveshift_stop_after_grace_notes.musicxml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <!-- 8va start -->
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="down" size="8" number="1"/>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>6</octave></pitch>
+        <duration>2</duration>
+        <type>half</type>
+      </note>
+      <!-- Grace notes UNDER 8va -->
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>C</step><octave>7</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>B</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>C</step><octave>7</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>A</step><octave>6</octave></pitch>
+        <type>16th</type>
+      </note>
+      <!-- 8va stop -->
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="stop" size="8" number="1"/>
+        </direction-type>
+      </direction>
+      <!-- Grace notes OUTSIDE 8va -->
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>F</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <grace slash="yes"/>
+        <pitch><step>D</step><octave>5</octave></pitch>
+        <type>16th</type>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>2</duration>
+        <type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## Summary

- Fix `addOctaveShift` using `previousFraction` as end timestamp — `previousFraction` is only updated for real notes, not grace notes. When the stop is placed after grace notes, the end timestamp was wrong, causing the 8va to miss the grace notes entirely. Uses `currentFraction` instead (like `addPedalMarking` already does).
- Introduce `endVoiceEntryIndex` on `OctaveShift` to distinguish grace notes before vs after the stop when they share the same timestamp/`SourceStaffEntry`.
- Fix the visual 8va bracket (dashed line) to extend to the last covered grace note instead of the first note in the staff entry.

### Before

<img width="1440" height="385" alt="octaveshift-before-fix" src="https://github.com/user-attachments/assets/80e4e0f1-bdd9-42c9-87b1-3c7a58f414a8" />


### After

<img width="1440" height="376" alt="octaveshift-after-fix" src="https://github.com/user-attachments/assets/104b8c8a-04a7-47c7-9f75-bea948258e6e" />


## Test plan

- [x] Added non-regression test `"Octave shift should apply to grace notes before the stop direction"` with dedicated MusicXML fixture
- [x] All 195 existing tests pass
- [x] Visual renders verified with `generateImages_browserless.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)