### PR TITLE
Feat: Implement wavy-line (e.g. after trill) (merge from audio player)

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -473,6 +473,7 @@ export class EngravingRules {
     public RenderTimeSignatures: boolean;
     public RenderFirstTempoExpression: boolean;
     public RenderPedals: boolean;
+    public RenderWavyLines: boolean;
     public DynamicExpressionMaxDistance: number;
     public DynamicExpressionSpacer: number;
     public IgnoreRepeatedDynamics: boolean;
@@ -941,6 +942,7 @@ export class EngravingRules {
         this.RenderTimeSignatures = true;
         this.RenderFirstTempoExpression = true;
         this.RenderPedals = true;
+        this.RenderWavyLines = true;
         this.ArticulationPlacementFromXML = true;
         this.BreathMarkDistance = 0.8;
         this.FingeringPosition = PlacementEnum.AboveOrBelow; // AboveOrBelow = correct bounding boxes

--- a/src/MusicalScore/Graphical/GraphicalWavyLine.ts
+++ b/src/MusicalScore/Graphical/GraphicalWavyLine.ts
@@ -1,0 +1,13 @@
+import { BoundingBox } from "./BoundingBox";
+import { WavyLine } from "../VoiceData/Expressions/ContinuousExpressions/WavyLine";
+import { GraphicalObject } from "./GraphicalObject";
+
+export class GraphicalWavyLine extends GraphicalObject {
+    constructor(wavyLine: WavyLine, parent: BoundingBox) {
+        super();
+        this.getWavyLine = wavyLine;
+        this.PositionAndShape = new BoundingBox(this, parent);
+    }
+
+    public getWavyLine: WavyLine;
+}

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -742,6 +742,16 @@ export abstract class MusicSheetCalculator {
         measureIndex: number, staffIndex: number): void;
 
     /**
+     * Calculate a single Wavy Line for a [[MultiExpression]].
+     * @param sourceMeasure
+     * @param multiExpression
+     * @param measureIndex
+     * @param staffIndex
+     */
+    protected abstract calculateSingleWavyLine(sourceMeasure: SourceMeasure, multiExpression: MultiExpression,
+        measureIndex: number, staffIndex: number): void;
+
+    /**
      * Calculate all the textual [[RepetitionInstruction]]s (e.g. dal segno) for a single [[SourceMeasure]].
      * @param repetitionInstruction
      * @param measureIndex
@@ -970,7 +980,11 @@ export abstract class MusicSheetCalculator {
                 // calculate all Pedal Expressions
                 this.calculatePedals();
             }
-            // calcualte RepetitionInstructions (Dal Segno, Coda, etc)
+            //calculate all wavy lines (vibrato, trill marks)
+            if (this.rules.RenderWavyLines) {
+                this.calculateWavyLines();
+            }
+            // calculate RepetitionInstructions (Dal Segno, Coda, etc)
             this.calculateWordRepetitionInstructions();
         }
         // calculate endings last, so they appear above measure numbers
@@ -3752,6 +3766,24 @@ export abstract class MusicSheetCalculator {
                     for (let k: number = 0; k < sourceMeasure.StaffLinkedExpressions[j].length; k++) {
                         if ((sourceMeasure.StaffLinkedExpressions[j][k].PedalStart)) {
                             this.calculateSinglePedal(sourceMeasure, sourceMeasure.StaffLinkedExpressions[j][k], i, j);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private calculateWavyLines(): void {
+        for (let i: number = 0; i < this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures.length; i++) {
+            const sourceMeasure: SourceMeasure = this.graphicalMusicSheet.ParentMusicSheet.SourceMeasures[i];
+            for (let j: number = 0; j < sourceMeasure.StaffLinkedExpressions.length; j++) {
+                if (!this.graphicalMusicSheet.MeasureList[i] || !this.graphicalMusicSheet.MeasureList[i][j]) {
+                    continue;
+                }
+                if (this.graphicalMusicSheet.MeasureList[i][j].ParentStaff.isVisible()) {
+                    for (let k: number = 0; k < sourceMeasure.StaffLinkedExpressions[j].length; k++) {
+                        if ((sourceMeasure.StaffLinkedExpressions[j][k].WavyLineStart)) {
+                            this.calculateSingleWavyLine(sourceMeasure, sourceMeasure.StaffLinkedExpressions[j][k], i, j);
                         }
                     }
                 }

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -392,6 +392,8 @@ export abstract class MusicSheetDrawer {
 
         this.drawPedals(staffLine);
 
+        this.drawWavyLines(staffLine);
+
         this.drawExpressions(staffLine);
 
         if (this.skyLineVisible) {
@@ -455,6 +457,8 @@ export abstract class MusicSheetDrawer {
     }
 
     protected abstract drawPedals(staffLine: StaffLine): void;
+
+    protected abstract drawWavyLines(staffLine: StaffLine): void;
 
     protected drawStaffLines(staffLine: StaffLine): void {
         if (staffLine.StaffLines) {

--- a/src/MusicalScore/Graphical/StaffLine.ts
+++ b/src/MusicalScore/Graphical/StaffLine.ts
@@ -15,6 +15,7 @@ import { GraphicalSlur } from "./GraphicalSlur";
 import { AbstractGraphicalExpression } from "./AbstractGraphicalExpression";
 import { GraphicalPedal } from "./GraphicalPedal";
 import { GraphicalGlissando } from "./GraphicalGlissando";
+import { GraphicalWavyLine } from "./GraphicalWavyLine";
 
 /**
  * A StaffLine contains the [[Measure]]s in one line of the music sheet
@@ -173,6 +174,7 @@ export abstract class StaffLine extends GraphicalObject {
     }
 
     public Pedals: GraphicalPedal[] = [];
+    public WavyLines: GraphicalWavyLine[] = [];
 
     public get StaffHeight(): number {
         return this.staffHeight;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -978,7 +978,6 @@ export class VexFlowConverter {
         const isTuplet: boolean = gve.notes[0].sourceNote.NoteTuplet !== undefined;
         let duration: string = VexFlowConverter.durations(frac, isTuplet)[0];
         let numDots: number = 0;
-        let tabVibrato: boolean = false;
         const rules: EngravingRules = gve.parentStaffEntry.parentMeasure.parentSourceMeasure.Rules;
         let isXNotehead: boolean = false;
         for (const note of gve.notes) {
@@ -1011,10 +1010,6 @@ export class VexFlowConverter {
                         tabPhrases.push({type: VF.Bend.DOWN, text: phraseText, width: 10});
                     }
                 });
-            }
-
-            if (tabNote.VibratoStroke) {
-                tabVibrato = true;
             }
 
             if (numDots < note.numberOfDots) {
@@ -1051,9 +1046,6 @@ export class VexFlowConverter {
                 vfnote.addModifier (new VF.Bend(phrase.text, true));
             }
         });
-        if (tabVibrato) {
-            vfnote.addModifier(new VF.Vibrato());
-        }
 
         return vfnote;
     }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -16,7 +16,7 @@ import { ClefInstruction } from "../../VoiceData/Instructions/ClefInstruction";
 import { OctaveEnum, OctaveShift } from "../../VoiceData/Expressions/ContinuousExpressions/OctaveShift";
 import { Fraction } from "../../../Common/DataObjects/Fraction";
 import { LyricWord } from "../../VoiceData/Lyrics/LyricsWord";
-import { OrnamentContainer } from "../../VoiceData/OrnamentContainer";
+import { OrnamentContainer, OrnamentEnum } from "../../VoiceData/OrnamentContainer";
 import { Articulation } from "../../VoiceData/Articulation";
 import { Tuplet } from "../../VoiceData/Tuplet";
 import { VexFlowMeasure } from "./VexFlowMeasure";
@@ -67,6 +67,8 @@ import { CollectionUtil } from "../../../Util/CollectionUtil";
 import { GraphicalGlissando } from "../GraphicalGlissando";
 import { Glissando } from "../../VoiceData/Glissando";
 import { VexFlowGlissando } from "./VexFlowGlissando";
+import { WavyLine } from "../../VoiceData/Expressions/ContinuousExpressions/WavyLine";
+import { VexFlowVibratoBracket } from "./VexFlowVibratoBracket";
 
 export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   /** space needed for a dash for lyrics spacing, calculated once */
@@ -908,7 +910,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     const maxMeasureToDrawIndex: number = this.rules.MaxMeasureToDrawIndex;
 
     let startStaffLine: StaffLine = this.graphicalMusicSheet.MeasureList[measureIndex][staffIndex].ParentStaffLine;
-    if (!startStaffLine) { // fix for rendering range set. all of these can probably done cleaner.
+    if (!startStaffLine) { // fix for rendering range set. all of these can probably be done cleaner.
       startStaffLine = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex].ParentStaffLine;
     }
 
@@ -933,11 +935,11 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       startMeasure = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex]; // first rendered measure
     }
 
-    if (startMeasure.MeasureNumber < minMeasureToDrawIndex + 1 ||
-        startMeasure.MeasureNumber > maxMeasureToDrawIndex + 1 ||
-        endMeasure.MeasureNumber < minMeasureToDrawIndex + 1 ||
-        endMeasure.MeasureNumber > maxMeasureToDrawIndex + 1) {
-      // octave shift completely out of drawing range, don't draw anything
+    if (startMeasure.parentSourceMeasure.measureListIndex < minMeasureToDrawIndex ||
+        startMeasure.parentSourceMeasure.measureListIndex > maxMeasureToDrawIndex ||
+        endMeasure.parentSourceMeasure.measureListIndex < minMeasureToDrawIndex ||
+        endMeasure.parentSourceMeasure.measureListIndex > maxMeasureToDrawIndex) {
+      // completely out of drawing range, don't draw anything
       return;
     }
 
@@ -1048,7 +1050,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             const firstNote: GraphicalStaffEntry = nextShiftFirstMeasure.staffEntries[0];
             let lastNote: GraphicalStaffEntry = nextShiftLastMeasure.staffEntries[nextShiftLastMeasure.staffEntries.length - 1];
 
-            //If the is the ending staffline, this endMeasure is the end of the shift
+            //If the end measure's staffline is the ending staffline, this endMeasure is the end of the shift
             if (endMeasure.ParentStaffLine === nextShiftStaffline) {
               nextShiftLastMeasure = endMeasure;
               lastNote = endStaffEntry;
@@ -1272,6 +1274,181 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     } else {
       log.warn("End measure or staffLines for pedal are undefined! This should not happen!");
     }
+  }
+
+  protected calculateSingleWavyLine(sourceMeasure: SourceMeasure, multiExpression: MultiExpression, measureIndex: number, staffIndex: number): void {
+    // calculate absolute Timestamp and startStaffLine (and EndStaffLine if needed)
+    const wavyLine: WavyLine = multiExpression.WavyLineStart;
+
+    const startTimeStamp: Fraction = wavyLine.ParentStartMultiExpression.Timestamp;
+    const endTimeStamp: Fraction = wavyLine.ParentEndMultiExpression?.Timestamp;
+
+    const minMeasureToDrawIndex: number = this.rules.MinMeasureToDrawIndex;
+    const maxMeasureToDrawIndex: number = this.rules.MaxMeasureToDrawIndex;
+
+    let startStaffLine: StaffLine = this.graphicalMusicSheet.MeasureList[measureIndex][staffIndex].ParentStaffLine;
+    if (!startStaffLine) { // fix for rendering range set. all of these can probably be done cleaner.
+      startStaffLine = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex].ParentStaffLine;
+    }
+    let endMeasure: GraphicalMeasure = undefined;
+    if (wavyLine.ParentEndMultiExpression) {
+      endMeasure = this.graphicalMusicSheet.getGraphicalMeasureFromSourceMeasureAndIndex(wavyLine.ParentEndMultiExpression.SourceMeasureParent,
+                                                                                          staffIndex);
+    } else {
+      endMeasure = this.graphicalMusicSheet.getLastGraphicalMeasureFromIndex(staffIndex, true); // get last rendered measure
+    }
+    if (endMeasure.MeasureNumber > maxMeasureToDrawIndex + 1) { //  ends in measure not rendered
+      endMeasure = this.graphicalMusicSheet.getLastGraphicalMeasureFromIndex(staffIndex, true);
+    }
+    let startMeasure: GraphicalMeasure = undefined;
+    if (wavyLine.ParentEndMultiExpression) {
+      startMeasure = this.graphicalMusicSheet.getGraphicalMeasureFromSourceMeasureAndIndex(wavyLine.ParentStartMultiExpression.SourceMeasureParent,
+                                                                                            staffIndex);
+    } else {
+      startMeasure = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex]; // first rendered measure
+    }
+    if (startMeasure.MeasureNumber < minMeasureToDrawIndex + 1) { //  starts before range of measures selected to render
+      startMeasure = this.graphicalMusicSheet.MeasureList[minMeasureToDrawIndex][staffIndex]; // first rendered measure
+    }
+
+    if (startMeasure.parentSourceMeasure.measureListIndex < minMeasureToDrawIndex ||
+        startMeasure.parentSourceMeasure.measureListIndex > maxMeasureToDrawIndex ||
+        endMeasure.parentSourceMeasure.measureListIndex < minMeasureToDrawIndex ||
+        endMeasure.parentSourceMeasure.measureListIndex > maxMeasureToDrawIndex) {
+      // completely out of drawing range, don't draw anything
+      return;
+    }
+
+    let endStaffLine: StaffLine = endMeasure.ParentStaffLine;
+    if (!endStaffLine) {
+      endStaffLine = startStaffLine;
+    }
+    if (endMeasure && startStaffLine && endStaffLine) {
+      const graphicalWavyLine: VexFlowVibratoBracket = new VexFlowVibratoBracket(wavyLine, startStaffLine.PositionAndShape, startMeasure.ParentStaff.isTab);
+      // calculate RelativePosition
+      let startStaffEntry: GraphicalStaffEntry = startMeasure.findGraphicalStaffEntryFromTimestamp(startTimeStamp);
+      if (!startStaffEntry) { // fix for rendering range set
+        startStaffEntry = startMeasure.staffEntries[0];
+      }
+      let endStaffEntry: GraphicalStaffEntry = endMeasure.findGraphicalStaffEntryFromTimestamp(endTimeStamp);
+      if (!endStaffEntry) { // fix for rendering range set
+        endStaffEntry = endMeasure.staffEntries[endMeasure.staffEntries.length - 1];
+      }
+      graphicalWavyLine.setStartNote(startStaffEntry);
+
+      if (endStaffLine !== startStaffLine) {
+          let lastMeasureOfFirstShift: GraphicalMeasure = startStaffLine.Measures[startStaffLine.Measures.length - 1];
+          if (lastMeasureOfFirstShift === undefined) { // TODO handle this case correctly (when drawUpToMeasureNumber etc set)
+            lastMeasureOfFirstShift = endMeasure;
+          }
+          const lastNoteOfFirstShift: GraphicalStaffEntry = lastMeasureOfFirstShift.staffEntries[lastMeasureOfFirstShift.staffEntries.length - 1];
+          graphicalWavyLine.setEndNote(lastNoteOfFirstShift);
+
+          const systemsInBetweenCount: number = endStaffLine.ParentMusicSystem.Id - startStaffLine.ParentMusicSystem.Id;
+          if (systemsInBetweenCount > 0) {
+            for (let i: number = startStaffLine.ParentMusicSystem.Id; i < endStaffLine.ParentMusicSystem.Id; i++) {
+              const nextWavyLineMusicSystem: MusicSystem = this.musicSystems[i + 1];
+              const nextWavyLineStaffline: StaffLine = nextWavyLineMusicSystem.StaffLines[staffIndex];
+              const nextWavyLineFirstMeasure: GraphicalMeasure = nextWavyLineStaffline.Measures[0];
+              // vibrato starts on the first measure
+              const nextWavyLine: VexFlowVibratoBracket = new VexFlowVibratoBracket(wavyLine, nextWavyLineFirstMeasure.PositionAndShape,
+                nextWavyLineStaffline.ParentStaff.isTab);
+              let nextWavyLineLastMeasure: GraphicalMeasure = nextWavyLineStaffline.Measures[nextWavyLineStaffline.Measures.length - 1];
+              const firstNote: GraphicalStaffEntry = nextWavyLineFirstMeasure.staffEntries[0];
+              let lastNote: GraphicalStaffEntry = nextWavyLineLastMeasure.staffEntries[nextWavyLineLastMeasure.staffEntries.length - 1];
+              //If the end measure's is the ending staffline, this endMeasure is the end of the wavy line
+              if (endMeasure.ParentStaffLine === nextWavyLineStaffline) {
+                nextWavyLineLastMeasure = endMeasure;
+                lastNote = endStaffEntry;
+              }
+
+              nextWavyLine.setStartNote(firstNote);
+              nextWavyLine.setEndNote(lastNote);
+              nextWavyLineStaffline.WavyLines.push(nextWavyLine);
+              nextWavyLine.CalculateBoundingBox();
+              this.calculateWavyLineSkyBottomLine(nextWavyLine.startVfVoiceEntry, nextWavyLine.endVfVoiceEntry, nextWavyLine, nextWavyLineStaffline);
+            }
+          }
+          graphicalWavyLine.CalculateBoundingBox();
+          this.calculateWavyLineSkyBottomLine(graphicalWavyLine.startVfVoiceEntry, graphicalWavyLine.endVfVoiceEntry, graphicalWavyLine, startStaffLine);
+      } else {
+        graphicalWavyLine.setEndNote(endStaffEntry);
+        graphicalWavyLine.CalculateBoundingBox();
+        this.calculateWavyLineSkyBottomLine(graphicalWavyLine.startVfVoiceEntry, graphicalWavyLine.endVfVoiceEntry, graphicalWavyLine, startStaffLine);
+      }
+      startStaffLine.WavyLines.push(graphicalWavyLine);
+    } else {
+      log.warn("End measure or staffLines for wavy line are undefined! This should not happen!");
+    }
+  }
+
+  private calculateWavyLineSkyBottomLine(startVfVoiceEntry: VexFlowVoiceEntry, endVfVoiceEntry: VexFlowVoiceEntry,
+    vfVibratoBracket: VexFlowVibratoBracket, parentStaffline: StaffLine): void {
+    const startStave: Vex.Flow.Stave = vfVibratoBracket.startNote.getStave();
+    const endStave: Vex.Flow.Stave = vfVibratoBracket.endNote.getStave();
+    //In VF Line positions, need to negate for our units
+    const highestVFTopTextPosition: number = Math.max(
+      startStave.options.top_text_position,
+      endStave.options.top_text_position
+    );
+
+    //Whichever is higher, set the other to match
+    startStave.options.top_text_position = highestVFTopTextPosition;
+    endStave.options.top_text_position = highestVFTopTextPosition;
+    let headroom: number = -highestVFTopTextPosition;
+    let trillStartX: number = 0;
+    let trillEndX: number = 0;
+    let trillSkyline: number = Infinity;
+    let trillWavyLineBottom: number = Infinity;
+    const TRILL_HEIGHT: number = 1.85;
+
+    let startX: number = startVfVoiceEntry.PositionAndShape.AbsolutePosition.x + startVfVoiceEntry.PositionAndShape.BorderLeft;
+    if (startVfVoiceEntry.parentVoiceEntry?.OrnamentContainer?.GetOrnament === OrnamentEnum.Trill) {
+      trillStartX = startX;
+      //Width of trill mark
+      startX += 2;
+      trillEndX = startX;
+      //Since the trill mark is not managed or calculated by our bounding boxes, we have to get the location this way
+      //Also at this point the skyline has already been updated with the trill mark. So we can't determine if it should go lower
+      //Need to trust Vexflow later on, unless the wavy line must be rendered higher
+      trillSkyline = parentStaffline.SkyBottomLineCalculator.getSkyLineMinInRange(trillStartX, trillEndX);
+      //height of the trill mark
+      trillWavyLineBottom = trillSkyline + TRILL_HEIGHT;
+    }
+
+    let stopX: number = undefined;
+    //If the end of the line is the last note in the measure, go all the way to the end of the stave
+    if(vfVibratoBracket.ToEndOfStopStave) {
+      //vexflow backs off by 1 unit (10 pixels) from stave edge
+      stopX = endVfVoiceEntry.parentStaffEntry.parentMeasure.PositionAndShape.AbsolutePosition.x +
+        endVfVoiceEntry.parentStaffEntry.parentMeasure.PositionAndShape.BorderRight - 1;
+    } else {
+      stopX = endVfVoiceEntry.PositionAndShape.AbsolutePosition.x + endVfVoiceEntry.PositionAndShape.BorderRight;
+      //Take into account in-staff clefs associated with the staff entry (they modify the bounding box position)
+      const vfClefBefore: Vex.Flow.ClefNote = (endVfVoiceEntry.parentStaffEntry as VexFlowStaffEntry).vfClefBefore;
+      if (vfClefBefore) {
+        const clefWidth: number = vfClefBefore.getWidth() / 10;
+        stopX += clefWidth;
+      }
+    }
+
+    headroom = parentStaffline.SkyBottomLineCalculator.getSkyLineMinInRange(startX, stopX);
+    if (headroom === Infinity) { // will cause Vexflow error
+      return;
+    }
+    //If somewhere in our wavy line path we have to render higher than where the trill mark is set...
+    if (headroom < trillSkyline) {
+      startStave.options.top_text_position = -headroom;
+      endStave.options.top_text_position = -headroom;
+      //A decent enough approximation. Better than recalculating via Canvas or SVG sampling
+      parentStaffline.SkyBottomLineCalculator.updateSkyLineInRange(trillStartX, trillEndX, headroom - TRILL_HEIGHT);
+    } else { //Else just render where Vexflow has set the trill mark
+      vfVibratoBracket.line = -trillWavyLineBottom;
+      headroom = trillWavyLineBottom;
+    }
+    //Update skyline to include height of the wavy line
+    headroom -= vfVibratoBracket.PositionAndShape.Size.height;
+    parentStaffline.SkyBottomLineCalculator.updateSkyLineInRange(startX, stopX, headroom);
   }
 
   private calculatePedalSkyBottomLine(startVfVoiceEntry: VexFlowVoiceEntry, endVfVoiceEntry: VexFlowVoiceEntry,

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -34,6 +34,7 @@ import { GraphicalGlissando } from "../GraphicalGlissando";
 import { VexFlowGlissando } from "./VexFlowGlissando";
 import { VexFlowGraphicalNote } from "./VexFlowGraphicalNote";
 import { SvgVexFlowBackend } from "./SvgVexFlowBackend";
+import { VexFlowVibratoBracket } from "./VexFlowVibratoBracket";
 
 /**
  * This is a global constant which denotes the height in pixels of the space between two lines of the stave
@@ -522,6 +523,18 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
                 (pedalMarking as any).render_options.color = this.rules.DefaultColorMusic;
                 pedalMarking.setContext(ctx);
                 pedalMarking.draw();
+            }
+        }
+    }
+
+    protected drawWavyLines(staffLine: StaffLine): void {
+        for (const graphicalWavyLine of staffLine.WavyLines) {
+            if (graphicalWavyLine) {
+                const vexFlowVibratoBracket: VexFlowVibratoBracket = graphicalWavyLine as VexFlowVibratoBracket;
+                const ctx: Vex.IRenderContext = this.backend.getContext();
+                const vfVibratoBracket: Vex.Flow.VibratoBracket = vexFlowVibratoBracket.getVibratoBracket();
+                (vfVibratoBracket as any).setContext(ctx);
+                vfVibratoBracket.draw();
             }
         }
     }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowVibratoBracket.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowVibratoBracket.ts
@@ -1,0 +1,86 @@
+import { WavyLine } from "../../VoiceData/Expressions/ContinuousExpressions/WavyLine";
+import { BoundingBox } from "../BoundingBox";
+import { GraphicalStaffEntry } from "../GraphicalStaffEntry";
+import { GraphicalWavyLine } from "../GraphicalWavyLine";
+import { VexFlowVoiceEntry } from "./VexFlowVoiceEntry";
+import Vex from "vexflow";
+
+export class VexFlowVibratoBracket extends GraphicalWavyLine {
+    /** Defines the note where the bracket starts */
+    public startNote: Vex.Flow.StemmableNote;
+    /** Defines the note where the bracket ends */
+    public endNote: Vex.Flow.StemmableNote;
+    public startVfVoiceEntry: VexFlowVoiceEntry;
+    public endVfVoiceEntry: VexFlowVoiceEntry;
+    //Line where vexflow renders the bracket. VF default is 1
+    public line: number = 1;
+    private isVibrato: boolean = false;
+    private toEndOfStopStave: boolean = false;
+    public get ToEndOfStopStave(): boolean {
+        return this.toEndOfStopStave;
+    }
+
+    constructor(wavyLine: WavyLine, parentBBox: BoundingBox, tabVibrato: boolean = false) {
+        super(wavyLine, parentBBox);
+        this.isVibrato = tabVibrato;
+    }
+
+    /**
+     * Set a start note using a staff entry
+     * @param graphicalStaffEntry the staff entry that holds the start note
+     */
+     public setStartNote(graphicalStaffEntry: GraphicalStaffEntry): boolean {
+        for (const gve of graphicalStaffEntry.graphicalVoiceEntries) {
+            const vve: VexFlowVoiceEntry = (gve as VexFlowVoiceEntry);
+            if (vve?.vfStaveNote) {
+                this.startNote = vve.vfStaveNote;
+                this.startVfVoiceEntry = vve;
+                return true;
+            }
+        }
+        return false; // couldn't find a startNote
+    }
+
+    /**
+     * Set an end note using a staff entry
+     * @param graphicalStaffEntry the staff entry that holds the end note
+     */
+    public setEndNote(graphicalStaffEntry: GraphicalStaffEntry): boolean {
+        // this is duplicate code from setStartNote, but if we make one general method, we add a lot of branching.
+        for (const gve of graphicalStaffEntry.graphicalVoiceEntries) {
+            const vve: VexFlowVoiceEntry = (gve as VexFlowVoiceEntry);
+            if (vve?.vfStaveNote) {
+                this.endNote = vve.vfStaveNote;
+                this.endVfVoiceEntry = vve;
+                const parentMeasureStaffEntries: GraphicalStaffEntry[] = this.endVfVoiceEntry.parentStaffEntry.parentMeasure.staffEntries;
+                const lastStaffEntry: GraphicalStaffEntry = parentMeasureStaffEntries[parentMeasureStaffEntries.length - 1];
+                //If this is the last staff entry of the stave (measure), render line to end of measure
+                this.toEndOfStopStave = (lastStaffEntry === this.endVfVoiceEntry.parentStaffEntry);
+                return true;
+            }
+        }
+        return false; // couldn't find an endNote
+    }
+
+    public CalculateBoundingBox(): void {
+        const vfBracket: any = this.getVibratoBracket();
+        //Double the height of the wave, coverted to units
+        this.boundingBox.Size.height = vfBracket.render_options.wave_height * 0.2;
+    }
+
+    public getVibratoBracket(): Vex.Flow.VibratoBracket {
+		const bracket: Vex.Flow.VibratoBracket = new Vex.Flow.VibratoBracket({
+			start: this.startNote,
+			stop: this.endNote,
+            toEndOfStopStave: this.toEndOfStopStave
+		});
+        bracket.setLine(this.line);
+        if (this.isVibrato) {
+			//Render options for vibrato style
+			(bracket as any).render_options.vibrato_width = 20;
+		} else {
+			(bracket as any).render_options.wave_girth = 4;
+		}
+		return bracket;
+    }
+}

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -339,13 +339,13 @@ export class InstrumentReader {
           const [stemDirectionXml, stemColorXml, noteheadColorXml] = this.getStemDirectionAndColors(xmlNode);
 
           // check Tremolo, Vibrato
-          let vibratoStrokes: boolean = false;
           let tremoloInfo: TremoloInfo;
+          //let vibratoStrokes: boolean = false; // not necessary, handled by wavy-line
           if (notationsNode) {
             const ornamentsNode: IXmlElement = notationsNode.element("ornaments");
             if (ornamentsNode) {
               tremoloInfo = this.getTremoloInfo(ornamentsNode);
-              vibratoStrokes = this.getVibratoStrokes(ornamentsNode);
+              this.getWavyLines(ornamentsNode, xmlNode, currentFraction, previousFraction);
             }
           }
 
@@ -406,7 +406,7 @@ export class InstrumentReader {
             measureStartAbsoluteTimestamp,
             this.maxTieNoteFraction, isChord, octavePlusOne,
             printObject, isCueNote, isGraceNote, stemDirectionXml, tremoloInfo, stemColorXml, noteheadColorXml,
-            vibratoStrokes, dots
+            dots
           );
 
           // notationsNode created further up for multiple checks
@@ -1487,15 +1487,26 @@ export class InstrumentReader {
     };
   }
 
-  private getVibratoStrokes(ornamentsNode: IXmlElement): boolean {
-    const vibratoNode: IXmlElement = ornamentsNode.element("wavy-line");
-    if (vibratoNode !== undefined) {
-      const vibratoType: Attr = vibratoNode.attribute("type");
-      if (vibratoType && vibratoType.value === "start") {
-        return true;
+  private getWavyLines(ornamentsNode: IXmlElement, xmlNode: IXmlElement, currentFraction: Fraction, previousFraction: Fraction): void {
+    const wavyLineNodes: IXmlElement[] = ornamentsNode.elements("wavy-line");
+    if (!wavyLineNodes) {
+      return;
+    }
+    /* As mentioned elsewhere, the wavy-line is technically an ornament element, but is specified and behaves
+        very much like a continuous expression, so makes more sense to interpret as an expression in our model.
+    */
+    for (const wavyLineNode of wavyLineNodes) {
+      const expressionReader: ExpressionReader = this.expressionReaders[this.readExpressionStaffNumber(xmlNode) - 1];
+      if (expressionReader) {
+        //Read placement from the wavy line node
+        expressionReader.readExpressionParameters(
+          wavyLineNode, this.instrument, this.divisions, currentFraction, previousFraction, this.currentMeasure.MeasureNumber, false
+        );
+        expressionReader.addWavyLine(
+          wavyLineNode, this.currentMeasure, currentFraction, previousFraction
+        );
       }
     }
-    return false;
   }
 
   private getNoteStaff(xmlNode: IXmlElement): number {

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -19,6 +19,7 @@ import log from "loglevel";
 import { FontStyles } from "../../../Common/Enums/FontStyles";
 import { RehearsalExpression } from "../../VoiceData/Expressions/RehearsalExpression";
 import { Pedal } from "../../VoiceData/Expressions/ContinuousExpressions/Pedal";
+import { WavyLine } from "../../VoiceData/Expressions/ContinuousExpressions/WavyLine";
 
 export class ExpressionReader {
     private musicSheet: MusicSheet;
@@ -39,6 +40,7 @@ export class ExpressionReader {
     private lastWedge: ContinuousDynamicExpression;
     private WedgeYPosXml: number;
     private openPedal: Pedal;
+    private openWavyLine: WavyLine;
     constructor(musicSheet: MusicSheet, instrument: Instrument, staffNumber: number) {
         this.musicSheet = musicSheet;
         this.staffNumber = staffNumber;
@@ -451,6 +453,37 @@ export class ExpressionReader {
         this.getMultiExpression.PedalEnd = this.openPedal;
         this.openPedal.ParentEndMultiExpression = this.getMultiExpression;
         this.openPedal = undefined;
+    }
+    public addWavyLine(wavyLineNode: IXmlElement, currentMeasure: SourceMeasure, currentTimestamp: Fraction, previousTimestamp: Fraction): void {
+        if (wavyLineNode && wavyLineNode.hasAttributes) {
+            try {
+                switch (wavyLineNode.attribute("type").value) {
+                    case "start":
+                        this.createNewMultiExpressionIfNeeded(currentMeasure, -1);
+                        this.openWavyLine = new WavyLine(this.placement);
+                        this.getMultiExpression.WavyLineStart = this.openWavyLine;
+                        this.openWavyLine.ParentStartMultiExpression = this.getMultiExpression;
+                    break;
+                    case "stop":
+                        if (this.openWavyLine) {
+                            this.createNewMultiExpressionIfNeeded(currentMeasure, -1, currentTimestamp);
+                            this.getMultiExpression.WavyLineEnd = this.openWavyLine;
+                            this.openWavyLine.ParentEndMultiExpression = this.getMultiExpression;
+                            this.openWavyLine = undefined;
+                        }
+                    break;
+                    case "continue":
+                        //Seems we can ignore this for now. TODO: Look into when this is a barline child
+                    break;
+                    default:
+                    break;
+                }
+            } catch (ex) {
+                const errorMsg: string = ITextTranslation.translateText("ReaderErrorMessages/WavyLineError", "Error while reading wavy-line.");
+                this.musicSheet.SheetErrors.pushMeasureError(errorMsg);
+                log.debug("ExpressionReader.addWavyLine", errorMsg, ex);
+            }
+        }
     }
     private initialize(): void {
         this.placement = PlacementEnum.NotYetDefined;

--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -117,7 +117,7 @@ export class VoiceGenerator {
               parentStaffEntry: SourceStaffEntry, parentMeasure: SourceMeasure,
               measureStartAbsoluteTimestamp: Fraction, maxTieNoteFraction: Fraction, chord: boolean, octavePlusOne: boolean,
               printObject: boolean, isCueNote: boolean, isGraceNote: boolean, stemDirectionXml: StemDirectionType, tremoloInfo: TremoloInfo,
-              stemColorXml: string, noteheadColorXml: string, vibratoStrokes: boolean,
+              stemColorXml: string, noteheadColorXml: string,
               dotsXml: number): Note {
     this.currentStaffEntry = parentStaffEntry;
     this.currentMeasure = parentMeasure;
@@ -127,7 +127,7 @@ export class VoiceGenerator {
       this.currentNote = restNote
         ? this.addRestNote(noteNode.element("rest"), noteDuration, noteTypeXml, typeDuration, normalNotes, printObject, isCueNote, noteheadColorXml)
         : this.addSingleNote(noteNode, noteDuration, noteTypeXml, typeDuration, normalNotes, chord, octavePlusOne,
-                             printObject, isCueNote, isGraceNote, stemDirectionXml, tremoloInfo, stemColorXml, noteheadColorXml, vibratoStrokes);
+                             printObject, isCueNote, isGraceNote, stemDirectionXml, tremoloInfo, stemColorXml, noteheadColorXml);
       this.currentNote.DotsXml = dotsXml;
       // read lyrics
       const lyricElements: IXmlElement[] = noteNode.elements("lyric");
@@ -344,7 +344,7 @@ export class VoiceGenerator {
   private addSingleNote(node: IXmlElement, noteDuration: Fraction, noteTypeXml: NoteType, typeDuration: Fraction,
                         normalNotes: number, chord: boolean, octavePlusOne: boolean,
                         printObject: boolean, isCueNote: boolean, isGraceNote: boolean, stemDirectionXml: StemDirectionType, tremoloInfo: TremoloInfo,
-                        stemColorXml: string, noteheadColorXml: string, vibratoStrokes: boolean): Note {
+                        stemColorXml: string, noteheadColorXml: string): Note {
     //log.debug("addSingleNote called");
     let noteAlter: number = 0;
     let accidentalValue: string;
@@ -498,7 +498,7 @@ export class VoiceGenerator {
     } else {
       // create TabNote
       note = new TabNote(this.currentVoiceEntry, this.currentStaffEntry, noteLength, pitch, this.currentMeasure,
-                         stringNumber, fretNumber, bends, vibratoStrokes);
+                         stringNumber, fretNumber, bends);
     }
 
     this.addNoteInfo(note, noteTypeXml, printObject, isCueNote, normalNotes,

--- a/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/WavyLine.ts
+++ b/src/MusicalScore/VoiceData/Expressions/ContinuousExpressions/WavyLine.ts
@@ -1,0 +1,12 @@
+import { AbstractExpression, PlacementEnum } from "../AbstractExpression";
+import { MultiExpression } from "../MultiExpression";
+//Represents the wavy-line element in musicxml
+//Technically not an expression, but an ornament... But behaves very much like an expression line.
+export class WavyLine extends AbstractExpression {
+    constructor(placement: PlacementEnum) {
+        super(placement);
+    }
+
+    public ParentStartMultiExpression: MultiExpression;
+    public ParentEndMultiExpression: MultiExpression;
+}

--- a/src/MusicalScore/VoiceData/Expressions/MultiExpression.ts
+++ b/src/MusicalScore/VoiceData/Expressions/MultiExpression.ts
@@ -9,6 +9,7 @@ import {AbstractExpression} from "./AbstractExpression";
 import {PlacementEnum} from "./AbstractExpression";
 import { FontStyles } from "../../../Common/Enums/FontStyles";
 import { Pedal } from "./ContinuousExpressions/Pedal";
+import { WavyLine } from "./ContinuousExpressions/WavyLine";
 
 export class MultiExpression {
 
@@ -34,6 +35,8 @@ export class MultiExpression {
     private octaveShiftEnd: OctaveShift;
     public PedalStart: Pedal;
     public PedalEnd: Pedal;
+    public WavyLineStart: WavyLine;
+    public WavyLineEnd: WavyLine;
 
     public get SourceMeasureParent(): SourceMeasure {
         return this.sourceMeasure;

--- a/src/MusicalScore/VoiceData/TabNote.ts
+++ b/src/MusicalScore/VoiceData/TabNote.ts
@@ -35,4 +35,9 @@ export class TabNote extends Note {
         return this.bendArray?.length > 0;
         // || this.vibratoStroke // vibratoStroke is handled by wavy-line (difference to public OSMD)
     }
+
+    // handled by wavy-line
+    // public get VibratoStroke(): boolean {
+    //     return this.vibratoStroke;
+    // }
 }

--- a/src/MusicalScore/VoiceData/TabNote.ts
+++ b/src/MusicalScore/VoiceData/TabNote.ts
@@ -7,19 +7,16 @@ import { SourceMeasure } from "./SourceMeasure";
 
 export class TabNote extends Note {
     constructor(voiceEntry: VoiceEntry, parentStaffEntry: SourceStaffEntry, length: Fraction, pitch: Pitch, sourceMeasure: SourceMeasure,
-                stringNumber: number, fretNumber: number, bendArray: { bendalter: number, direction: string }[],
-                vibratoStroke: boolean) {
+                stringNumber: number, fretNumber: number, bendArray: { bendalter: number, direction: string }[]) {
         super(voiceEntry, parentStaffEntry, length, pitch, sourceMeasure);
         this.stringNumberTab = stringNumber;
         this.fretNumber = fretNumber;
         this.bendArray = bendArray;
-        this.vibratoStroke = vibratoStroke;
     }
 
     private stringNumberTab: number; // there can also be string numbers for e.g. violin in treble clef.
     private fretNumber: number;
     private bendArray: { bendalter: number, direction: string }[];
-    private vibratoStroke: boolean;
 
     /** Returns the string number the note should be played on. Note there can also be violin string numbers in treble clef. */
     public get StringNumberTab(): number {
@@ -34,11 +31,8 @@ export class TabNote extends Note {
         return this.bendArray;
     }
 
-    public get VibratoStroke(): boolean {
-        return this.vibratoStroke;
-    }
-
     public hasTabEffects(): boolean {
-        return this.bendArray?.length > 0 || this.vibratoStroke;
+        return this.bendArray?.length > 0;
+        // || this.vibratoStroke // vibratoStroke is handled by wavy-line (difference to public OSMD)
     }
 }

--- a/src/VexFlowPatch/readme.txt
+++ b/src/VexFlowPatch/readme.txt
@@ -126,6 +126,9 @@ vexflow_font.js: (custom fix):
 downstem flag glyph (v9a): rotate and shift the flag so that it suits the stem better, as 1px steps don't align here)
   to shift and rotate glyphs, use src/VexFlowPatch/tools/shift_glyph.py and rorate_glyph.py
 
+vibratobracket.js: (custom option):
+add option vibratobracket.toEndOfStopStave: Render to the end of the stop note, instead of before it
+
 Currently, we are using a heavily improved and customized version of Vexflow 1.2.93,
 because of some formatter advantages compared to Vexflow 3.x versions, see this issue:
 https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/915

--- a/src/VexFlowPatch/src/vibratobracket.js
+++ b/src/VexFlowPatch/src/vibratobracket.js
@@ -1,0 +1,91 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+// Author: Balazs Forian-Szabo
+//
+// ## Description
+//
+// This file implements `VibratoBrackets`
+// that renders vibrato effect between two notes.
+
+import { Vex } from './vex';
+import { Element } from './element';
+import { Vibrato } from './vibrato';
+
+// To enable logging for this class. Set `Vex.Flow.VibratoBracket.DEBUG` to `true`.
+function L(...args) { if (VibratoBracket.DEBUG) Vex.L('Vex.Flow.VibratoBracket', args); }
+
+export class VibratoBracket extends Element {
+  // bracket_data = {
+  //   start: Vex.Flow.Note (optional)
+  //   stop: Vex.Flow.Note (optional)
+  // };
+  // Either the stop or start note must be set, or both of them.
+  // A null value for the start or stop note indicates that the vibrato
+  // is drawn from the beginning or until the end of the stave accordingly.
+  constructor(bracket_data) {
+    super();
+    this.setAttribute('type', 'VibratoBracket');
+
+    this.start = bracket_data.start;
+    this.stop = bracket_data.stop;
+    //VexFlowPatch: Needed an option to render to the end of the stop note stave vs. the stop note itself
+    this.toEndOfStopStave = bracket_data.toEndOfStopStave;
+
+    this.line = 1;
+
+    this.render_options = {
+      harsh: false,
+      wave_height: 6,
+      wave_width: 4,
+      wave_girth: 2,
+    };
+  }
+
+  // Set line position of the vibrato bracket
+  setLine(line) { this.line = line; return this; }
+  setHarsh(harsh) { this.render_options.harsh = harsh; return this; }
+
+  // Draw the vibrato bracket on the rendering context
+  draw() {
+    const ctx = this.context;
+    this.setRendered();
+    const y = (this.start)
+      ? this.start.getStave().getYForTopText(this.line)
+      : this.stop.getStave().getYForTopText(this.line);
+
+    // If start note is not set then vibrato will be drawn
+    // from the beginning of the stave
+    let start_x = 0;
+    if(this.start) {
+        let trillOffset = 0;
+        // VexFlowPatch: If we have a trill mark accompanying, need to allow space for it
+        for(const modifier of this.start.modifiers) {
+          if(modifier && modifier.type === "tr") {
+            trillOffset = modifier.glyph.bbox.w;
+            break;
+          }
+        }
+        start_x = this.start.getNoteHeadBeginX ? this.start.getNoteHeadBeginX() : this.start.getAbsoluteX();
+        start_x += trillOffset;
+    } else {
+        start_x = this.stop.getStave().getTieStartX();
+    }
+    // If stop note is not set then vibrato will be drawn
+    // until the end of the stave
+    let stop_x = 0;
+
+    if(this.stop) {
+      stop_x = (this.toEndOfStopStave) ?
+        this.stop.getStave().getTieEndX() - 10 :
+        // VexFlowPatch: Render to the end of the stop note, instead of before it
+        this.stop.getAbsoluteX() + this.stop.getWidth()
+    } else {
+      stop_x = this.start.getStave().getTieEndX() - 10;
+    }
+
+    this.render_options.vibrato_width = stop_x - start_x;
+
+    L('Rendering VibratoBracket: start_x:', start_x, 'stop_x:', stop_x, 'y:', y);
+
+    Vibrato.renderVibrato(ctx, start_x, y, this.render_options);
+  }
+}

--- a/test/data/OSMD_function_test_Ornaments.xml
+++ b/test/data/OSMD_function_test_Ornaments.xml
@@ -457,9 +457,45 @@
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <barline location="right">
-        <bar-style>light-heavy</bar-style>
-        </barline>
+      </measure>
+    <measure number="11">
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <accidental>natural</accidental>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <trill-mark/>
+            <wavy-line type="start" number="1"/>
+            </ornaments>
+          </notations>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Trill+wavy</text>
+          </lyric>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <accidental>natural</accidental>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
       </measure>
     </part>
   </score-partwise>


### PR DESCRIPTION
replacement for PR #1651 

<img width="370" height="147" alt="image" src="https://github.com/user-attachments/assets/c5312e0e-229d-4067-a467-15d28b269426" />

(new OSMD Function Test - Ornaments)

Haydn Concertante measure 261-263:

our wavy-line:
<img width="510" height="224" alt="image" src="https://github.com/user-attachments/assets/b4d09a4e-1300-40aa-b0bf-72c0bc0130b6" />