### PR TITLE
Feat: Implement swing metronome mark and other complex metronome marks

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -46,7 +46,7 @@ import { GraphicalSlur } from "../GraphicalSlur";
 import { BoundingBox } from "../BoundingBox";
 import { ContinuousDynamicExpression } from "../../VoiceData/Expressions/ContinuousExpressions/ContinuousDynamicExpression";
 import { VexFlowContinuousDynamicExpression } from "./VexFlowContinuousDynamicExpression";
-import { InstantaneousTempoExpression, TempoType } from "../../VoiceData/Expressions/InstantaneousTempoExpression";
+import { InstantaneousTempoExpression, MetronomeNoteGroup, TempoType } from "../../VoiceData/Expressions/InstantaneousTempoExpression";
 import { AlignRestOption } from "../../../OpenSheetMusicDisplay/OSMDOptions";
 import { VexFlowStaffLine } from "./VexFlowStaffLine";
 import { EngravingRules } from "../EngravingRules";
@@ -814,12 +814,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       //   might be because of both <sound> node and <per-minute> node (within <metronome>) creating metronome marks
     }
     const vfStave: VF.Stave = vfMeasure.getVFStave();
-    //vfStave.addModifier(new VF.StaveTempo( // needs Vexflow PR
-    let vexflowDuration: string = "q";
-    if (metronomeExpression.beatUnit) {
-      const duration: Fraction = NoteTypeHandler.getNoteDurationFromType(metronomeExpression.beatUnit);
-      vexflowDuration = VexFlowConverter.durations(duration, false)[0];
-    }
 
     let yShift: number = this.rules.MetronomeMarkYShift;
     let hasExpressionsAboveStaffline: boolean = false;
@@ -841,15 +835,30 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       // console.log('max skyline: ' + maxSkylineBeginning);
     }
     const skyline: number[] = this.graphicalMusicSheet.MeasureList[0][0].ParentStaffLine?.SkyLine;
-    vfStave.setTempo(
-      {
-          bpm: metronomeExpression.TempoInBpm,
-          dots: metronomeExpression.dotted,
-          duration: vexflowDuration
-      },
-      yShift * unitInPixels);
-       // -50, -30), 0); //needs Vexflow PR
-       //.setShiftX(-50);
+
+    if (metronomeExpression.metronomeNoteGroupLeft && metronomeExpression.metronomeNoteGroupRight) {
+      // Complex metronome mark (note equation, e.g. swing notation)
+      const noteEquation: any = this.buildNoteEquationForVexFlow(
+        metronomeExpression.metronomeNoteGroupLeft,
+        metronomeExpression.metronomeNoteGroupRight
+      );
+      (vfStave as any).setTempo({ noteEquation }, yShift * unitInPixels);
+    } else {
+      // Simple metronome mark: note = BPM
+      let vexflowDuration: string = "q";
+      if (metronomeExpression.beatUnit) {
+        const duration: Fraction = NoteTypeHandler.getNoteDurationFromType(metronomeExpression.beatUnit);
+        vexflowDuration = VexFlowConverter.durations(duration, false)[0];
+      }
+      vfStave.setTempo(
+        {
+            bpm: metronomeExpression.TempoInBpm,
+            dots: metronomeExpression.dotted,
+            duration: vexflowDuration
+        },
+        yShift * unitInPixels);
+    }
+
     const xShift: number = firstMetronomeMark ? this.rules.MetronomeMarkXShift * unitInPixels : 0;
     (<any>vfStave.getModifiers()[vfStave.getModifiers().length - 1]).setShiftX(
       xShift
@@ -860,6 +869,35 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       skyline[0] = Math.min(skyline[0], -4.5 + yShift);
     }
     // somehow this is called repeatedly in Clementi, so skyline[0] = Math.min instead of -=
+  }
+
+  /** Convert MetronomeNoteGroup data into the format expected by VexFlow's StaveTempo.drawNoteEquation(). */
+  private buildNoteEquationForVexFlow(left: MetronomeNoteGroup, right: MetronomeNoteGroup): any {
+    const convertGroup: (group: MetronomeNoteGroup) => any = (group) => {
+      const notes: any[] = group.notes.map(note => {
+        const duration: Fraction = NoteTypeHandler.getNoteDurationFromType(note.type);
+        const vfDuration: string = VexFlowConverter.durations(duration, false)[0];
+        return {
+          duration: vfDuration,
+          dots: note.dots,
+          beam: note.beam,
+        };
+      });
+      const result: any = { notes };
+      if (group.tuplet) {
+        result.tuplet = {
+          actualNotes: group.tuplet.actualNotes,
+          normalNotes: group.tuplet.normalNotes,
+          bracket: group.tuplet.bracket,
+          showNumber: group.tuplet.showNumber,
+        };
+      }
+      return result;
+    };
+    return {
+      left: convertGroup(left),
+      right: convertGroup(right),
+    };
   }
 
   protected calculateRehearsalMark(measure: SourceMeasure): void {

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -205,6 +205,9 @@ export class ExpressionReader {
                                                    currentMeasure, timestampFraction);
                 } else {
                     // Simple metronome mark: beat-unit = BPM
+                    // TODO handle two <beat-unit> elements without <per-minute> (simple note equation,
+                    //   e.g. quarter = half for metric modulations). This is a simpler MusicXML pattern
+                    //   than <metronome-note> — no beams or tuplets, just two note types.
                     const beatUnit: IXmlElement = dirContentNode.element("beat-unit");
                     const dotted: boolean = dirContentNode.element("beat-unit-dot") !== undefined;
                     const bpm: IXmlElement = dirContentNode.element("per-minute");

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -9,7 +9,7 @@ import {Instrument} from "../../Instrument";
 import {MultiExpression} from "../../VoiceData/Expressions/MultiExpression";
 import {IXmlAttribute, IXmlElement} from "../../../Common/FileIO/Xml";
 import {SourceMeasure} from "../../VoiceData/SourceMeasure";
-import {InstantaneousTempoExpression} from "../../VoiceData/Expressions/InstantaneousTempoExpression";
+import {InstantaneousTempoExpression, MetronomeNote, MetronomeNoteGroup, MetronomeTuplet} from "../../VoiceData/Expressions/InstantaneousTempoExpression";
 import {MoodExpression} from "../../VoiceData/Expressions/MoodExpression";
 import {UnknownExpression} from "../../VoiceData/Expressions/UnknownExpression";
 import {PlacementEnum} from "../../VoiceData/Expressions/AbstractExpression";
@@ -196,40 +196,50 @@ export class ExpressionReader {
         for (const dirNode of dirNodes) {
             let dirContentNode: IXmlElement = dirNode.element("metronome");
             if (dirContentNode) {
-                const beatUnit: IXmlElement = dirContentNode.element("beat-unit");
-                // TODO check second "beat-unit", e.g. quarter = half
-                const dotted: boolean = dirContentNode.element("beat-unit-dot") !== undefined;
-                const bpm: IXmlElement = dirContentNode.element("per-minute");
-                // TODO check print-object = false -> don't render invisible metronome mark
-                if (beatUnit !== undefined && bpm) {
-                    const useCurrentFractionForPositioning: boolean = (dirContentNode.hasAttributes && dirContentNode.attribute("default-x") !== undefined);
-                    if (useCurrentFractionForPositioning) {
-                        this.directionTimestamp = Fraction.createFromFraction(timestampFraction);
+                const metronomeNotes: IXmlElement[] = dirContentNode.elements("metronome-note");
+                const metronomeRelation: IXmlElement = dirContentNode.element("metronome-relation");
+
+                if (metronomeNotes.length > 0 && metronomeRelation) {
+                    // Complex metronome mark (note equation, e.g. swing notation)
+                    this.parseComplexMetronomeMark(dirContentNode, metronomeNotes, metronomeRelation,
+                                                   currentMeasure, timestampFraction);
+                } else {
+                    // Simple metronome mark: beat-unit = BPM
+                    const beatUnit: IXmlElement = dirContentNode.element("beat-unit");
+                    const dotted: boolean = dirContentNode.element("beat-unit-dot") !== undefined;
+                    const bpm: IXmlElement = dirContentNode.element("per-minute");
+                    // TODO check print-object = false -> don't render invisible metronome mark
+                    if (beatUnit !== undefined && bpm) {
+                        const useCurrentFractionForPositioning: boolean =
+                            (dirContentNode.hasAttributes && dirContentNode.attribute("default-x") !== undefined);
+                        if (useCurrentFractionForPositioning) {
+                            this.directionTimestamp = Fraction.createFromFraction(timestampFraction);
+                        }
+                        // per-minute can contain text alongside the number (e.g. "c. 108" for circa)
+                        // -> find first number ("c. 108" matches 108, "108.5" would match 108.5)
+                        const bpmMatch: RegExpMatchArray = bpm.value.match(/(\d+\.?\d*)/);
+                        const bpmNumber: number = bpmMatch ? parseFloat(bpmMatch[1]) : NaN;
+                        this.createNewTempoExpressionIfNeeded(currentMeasure);
+                        const instantaneousTempoExpression: InstantaneousTempoExpression =
+                            new InstantaneousTempoExpression(undefined,
+                                                             this.placement,
+                                                             this.staffNumber,
+                                                             bpmNumber,
+                                                             this.currentMultiTempoExpression,
+                                                             true);
+                        instantaneousTempoExpression.parentMeasure = currentMeasure;
+                        this.soundTempo = bpmNumber;
+                        // make sure to take dotted beats into account
+                        currentMeasure.TempoInBPM = this.soundTempo * (dotted?1.5:1);
+                        if (this.musicSheet.DefaultStartTempoInBpm === 0) {
+                            this.musicSheet.DefaultStartTempoInBpm = this.soundTempo;
+                        }
+                        this.musicSheet.HasBPMInfo = true;
+                        instantaneousTempoExpression.dotted = dotted;
+                        instantaneousTempoExpression.beatUnit = beatUnit.value;
+                        this.currentMultiTempoExpression.addExpression(instantaneousTempoExpression, "");
+                        this.currentMultiTempoExpression.CombinedExpressionsText = "test";
                     }
-                    // per-minute can contain text alongside the number (e.g. "c. 108" for circa)
-                    // -> find first number ("c. 108" matches 108, "108.5" would match 108.5)
-                    const bpmMatch: RegExpMatchArray = bpm.value.match(/(\d+\.?\d*)/);
-                    const bpmNumber: number = bpmMatch ? parseFloat(bpmMatch[1]) : NaN;
-                    this.createNewTempoExpressionIfNeeded(currentMeasure);
-                    const instantaneousTempoExpression: InstantaneousTempoExpression =
-                        new InstantaneousTempoExpression(undefined,
-                                                         this.placement,
-                                                         this.staffNumber,
-                                                         bpmNumber,
-                                                         this.currentMultiTempoExpression,
-                                                         true);
-                    instantaneousTempoExpression.parentMeasure = currentMeasure;
-                    this.soundTempo = bpmNumber;
-                    // make sure to take dotted beats into account
-                    currentMeasure.TempoInBPM = this.soundTempo * (dotted?1.5:1);
-                    if (this.musicSheet.DefaultStartTempoInBpm === 0) {
-                        this.musicSheet.DefaultStartTempoInBpm = this.soundTempo;
-                    }
-                    this.musicSheet.HasBPMInfo = true;
-                    instantaneousTempoExpression.dotted = dotted;
-                    instantaneousTempoExpression.beatUnit = beatUnit.value;
-                    this.currentMultiTempoExpression.addExpression(instantaneousTempoExpression, "");
-                    this.currentMultiTempoExpression.CombinedExpressionsText = "test";
                 }
                 continue;
             }
@@ -526,6 +536,97 @@ export class ExpressionReader {
             log.debug("ExpressionReader.readExpressionParameters", ex);
         }
     }
+    /** Parse a complex metronome mark with metronome-note elements and a metronome-relation (e.g. swing notation). */
+    private parseComplexMetronomeMark(metronomeNode: IXmlElement, metronomeNotes: IXmlElement[],
+                                      metronomeRelationNode: IXmlElement,
+                                      currentMeasure: SourceMeasure, timestampFraction: Fraction): void {
+        const useCurrentFractionForPositioning: boolean =
+            (metronomeNode.hasAttributes && metronomeNode.attribute("default-x") !== undefined);
+        if (useCurrentFractionForPositioning) {
+            this.directionTimestamp = Fraction.createFromFraction(timestampFraction);
+        }
+
+        // Split metronome-note elements into left and right groups, divided by metronome-relation.
+        // We iterate the raw children to determine ordering.
+        const allChildren: IXmlElement[] = metronomeNode.elements();
+        const leftNotes: MetronomeNote[] = [];
+        const rightNotes: MetronomeNote[] = [];
+        let currentTuplet: MetronomeTuplet | undefined;
+        let passedRelation: boolean = false;
+
+        for (const child of allChildren) {
+            if (child.name === "metronome-relation") {
+                passedRelation = true;
+                continue;
+            }
+            if (child.name !== "metronome-note") {
+                continue;
+            }
+            const typeEl: IXmlElement = child.element("metronome-type");
+            if (!typeEl) {
+                continue;
+            }
+            const note: MetronomeNote = {
+                type: typeEl.value,
+                dots: child.elements("metronome-dot").length,
+            };
+            const beamEl: IXmlElement = child.element("metronome-beam");
+            if (beamEl) {
+                note.beam = beamEl.value; // "begin", "continue", "end"
+            }
+
+            // Parse tuplet start/stop
+            const tupletEl: IXmlElement = child.element("metronome-tuplet");
+            if (tupletEl) {
+                const tupletType: string = tupletEl.hasAttributes ? tupletEl.attribute("type")?.value : undefined;
+                if (tupletType === "start") {
+                    const actualEl: IXmlElement = tupletEl.element("actual-notes");
+                    const normalEl: IXmlElement = tupletEl.element("normal-notes");
+                    const bracketAttr: IXmlAttribute = tupletEl.attribute("bracket");
+                    const showNumberAttr: IXmlAttribute = tupletEl.attribute("show-number");
+                    currentTuplet = {
+                        actualNotes: actualEl ? parseInt(actualEl.value, 10) : 3,
+                        normalNotes: normalEl ? parseInt(normalEl.value, 10) : 2,
+                        bracket: bracketAttr ? bracketAttr.value === "yes" : true,
+                        showNumber: showNumberAttr ? showNumberAttr.value : "actual",
+                    };
+                }
+                // tupletType === "stop" — tuplet ends on this note, handled below
+            }
+
+            if (passedRelation) {
+                rightNotes.push(note);
+            } else {
+                leftNotes.push(note);
+            }
+        }
+
+        // Build note groups
+        const leftGroup: MetronomeNoteGroup = { notes: leftNotes };
+        const rightGroup: MetronomeNoteGroup = { notes: rightNotes, tuplet: currentTuplet };
+
+        // Create the tempo expression. Use the sound tempo from the parent <sound> element.
+        this.createNewTempoExpressionIfNeeded(currentMeasure);
+        const instantaneousTempoExpression: InstantaneousTempoExpression =
+            new InstantaneousTempoExpression(undefined,
+                                             this.placement,
+                                             this.staffNumber,
+                                             this.soundTempo,
+                                             this.currentMultiTempoExpression,
+                                             true);
+        instantaneousTempoExpression.parentMeasure = currentMeasure;
+        instantaneousTempoExpression.metronomeNoteGroupLeft = leftGroup;
+        instantaneousTempoExpression.metronomeNoteGroupRight = rightGroup;
+        instantaneousTempoExpression.metronomeRelation = metronomeRelationNode.value;
+
+        if (this.musicSheet.DefaultStartTempoInBpm === 0) {
+            this.musicSheet.DefaultStartTempoInBpm = this.soundTempo;
+        }
+        this.musicSheet.HasBPMInfo = true;
+        this.currentMultiTempoExpression.addExpression(instantaneousTempoExpression, "");
+        this.currentMultiTempoExpression.CombinedExpressionsText = "test";
+    }
+
     private interpretInstantaneousDynamics(dynamicsNode: IXmlElement,
                                            currentMeasure: SourceMeasure,
                                            inSourceMeasureCurrentFraction: Fraction,

--- a/src/MusicalScore/VoiceData/Expressions/InstantaneousTempoExpression.ts
+++ b/src/MusicalScore/VoiceData/Expressions/InstantaneousTempoExpression.ts
@@ -3,6 +3,34 @@ import {PlacementEnum} from "./AbstractExpression";
 import {Fraction} from "../../../Common/DataObjects/Fraction";
 import {MultiTempoExpression} from "./MultiTempoExpression";
 
+/** A single note in a complex metronome mark (e.g. swing notation: two eighth notes = quarter + eighth under triplet). */
+export interface MetronomeNote {
+    /** MusicXML note type string, e.g. "quarter", "eighth" */
+    type: string;
+    /** Number of dots on this note */
+    dots: number;
+    /** Beam state for this note: "begin", "continue", "end", or undefined */
+    beam?: string;
+}
+
+/** Tuplet bracket information for a group of metronome notes. */
+export interface MetronomeTuplet {
+    /** Actual notes in the tuplet (e.g. 3 for triplet) */
+    actualNotes: number;
+    /** Normal notes the tuplet replaces (e.g. 2 for triplet) */
+    normalNotes: number;
+    /** Whether to draw a bracket */
+    bracket: boolean;
+    /** What number to show: "actual", "both", "none" */
+    showNumber: string;
+}
+
+/** A group of metronome notes on one side of a note equation, with optional tuplet. */
+export interface MetronomeNoteGroup {
+    notes: MetronomeNote[];
+    tuplet?: MetronomeTuplet;
+}
+
 /** Tempo expressions that usually have an instantaneous and non-gradual effect on playback speed (e.g. Allegro),
  * or at least cover large sections, compared to the usually gradual effects or shorter sections of ContinuousExpressions.
  */
@@ -21,6 +49,12 @@ export class InstantaneousTempoExpression extends AbstractTempoExpression {
     public dotted: boolean;
     public beatUnit: string;
     public isMetronomeMark: boolean;
+    /** For complex metronome marks (note equations like swing): left-side note group */
+    public metronomeNoteGroupLeft: MetronomeNoteGroup;
+    /** For complex metronome marks (note equations like swing): right-side note group */
+    public metronomeNoteGroupRight: MetronomeNoteGroup;
+    /** The relation between left and right groups, e.g. "equals" */
+    public metronomeRelation: string;
     private static listInstantaneousTempoLarghissimo: string[] = ["Larghissimo", "Sehr breit", "very, very slow"]; // }), TempoEnum.larghissimo);
     private static listInstantaneousTempoGrave: string[] = ["Grave", "Schwer", "slow and solemn"]; //  }), TempoEnum.grave);
     private static listInstantaneousTempoLento: string[] = ["Lento", "Lent", "Langsam", "slowly"]; //  }), TempoEnum.lento);

--- a/src/VexFlowPatch/readme.txt
+++ b/src/VexFlowPatch/readme.txt
@@ -84,7 +84,7 @@ fix rehearsal marks not rendered with canvas backend in browser
 
 stavetempo.js (custom addition):
 open a context group for vf-stavetempo, and one for its subgroup vf-bpm (for just the "= 150" text node)
-add drawNoteEquation() and drawNoteGroup() for complex metronome marks (note equations like swing: eighth+eighth = quarter+eighth under triplet bracket)
+add drawNoteEquation() and drawNoteGroup() for complex metronome marks (note equations like swing: 8th+8th = quarter+8th under triplet bracket)
 
 stavetie.js (merged vexflow 4.x):
 context opens group for stavetie, can get stavetie SVG element via getAttribute("el")

--- a/src/VexFlowPatch/readme.txt
+++ b/src/VexFlowPatch/readme.txt
@@ -84,6 +84,7 @@ fix rehearsal marks not rendered with canvas backend in browser
 
 stavetempo.js (custom addition):
 open a context group for vf-stavetempo, and one for its subgroup vf-bpm (for just the "= 150" text node)
+add drawNoteEquation() and drawNoteGroup() for complex metronome marks (note equations like swing: eighth+eighth = quarter+eighth under triplet bracket)
 
 stavetie.js (merged vexflow 4.x):
 context opens group for stavetie, can get stavetie SVG element via getAttribute("el")

--- a/src/VexFlowPatch/src/stavetempo.js
+++ b/src/VexFlowPatch/src/stavetempo.js
@@ -45,6 +45,7 @@ export class StaveTempo extends StaveModifier {
     const duration = this.tempo.duration;
     const dots = this.tempo.dots;
     const bpm = this.tempo.bpm;
+    const noteEquation = this.tempo.noteEquation;
     const font = this.font;
     let x = this.x + this.shift_x + shift_x;
     const y = stave.getYForTopText(1) + this.shift_y;
@@ -57,7 +58,10 @@ export class StaveTempo extends StaveModifier {
       x += ctx.measureText(name).width;
     }
 
-    if (duration && bpm) {
+    if (noteEquation) {
+      // Complex metronome mark: note group = note group (e.g. swing notation)
+      x = this.drawNoteEquation(ctx, x, y, scale, noteEquation);
+    } else if (duration && bpm) {
       ctx.setFont(font.family, font.size, 'normal');
 
       if (name) {
@@ -106,5 +110,188 @@ export class StaveTempo extends StaveModifier {
     ctx.closeGroup();
     ctx.restore();
     return this;
+  }
+
+  /**
+   * Draw a complex metronome mark: leftNotes = rightNotes (with optional tuplet bracket).
+   * noteEquation: { left: { notes: [{duration, dots, beam}], tuplet? }, right: { ... } }
+   */
+  drawNoteEquation(ctx, x, y, scale, noteEquation) {
+    const options = this.render_options;
+    const font = this.font;
+
+    // Draw left note group
+    x = this.drawNoteGroup(ctx, x, y, scale, noteEquation.left);
+
+    // Draw "=" sign
+    ctx.setFont(font.family, font.size, 'bold');
+    const equalsText = ' = ';
+    ctx.fillText(equalsText, x + 2 * scale, y);
+    x += ctx.measureText(equalsText).width + 2 * scale;
+
+    // Draw right note group (with optional tuplet)
+    x = this.drawNoteGroup(ctx, x, y, scale, noteEquation.right);
+
+    return x;
+  }
+
+  /**
+   * Draw a group of notes (with beams connecting flagged notes, and optional tuplet bracket).
+   * group: { notes: [{duration, dots, beam}], tuplet?: {actualNotes, bracket, showNumber} }
+   */
+  drawNoteGroup(ctx, x, y, scale, group) {
+    const options = this.render_options;
+    const notes = group.notes;
+    const tuplet = group.tuplet;
+
+    // Track positions for beams and tuplet bracket
+    const notePositions = []; // [{x, y_top, stemX, code}]
+    const beamSegments = []; // groups of notes to beam together
+
+    let currentBeamGroup = [];
+
+    for (let i = 0; i < notes.length; i++) {
+      const note = notes[i];
+      const code = Flow.getGlyphProps(note.duration);
+      if (!code) continue;
+
+      x += 3 * scale;
+      const noteX = x;
+      Glyph.renderGlyph(ctx, x, y, options.glyph_font_scale, code.code_head);
+      x += code.getWidth() * scale;
+
+      let stemTopY = y;
+      const stemX = x;
+
+      // Draw stem
+      if (code.stem) {
+        let stem_height = 30;
+        // For beamed notes, use consistent stem height (don't add extra for beam_count,
+        // since we draw beams manually instead of flags)
+        stem_height *= scale;
+
+        stemTopY = y - stem_height;
+        ctx.fillRect(x - scale, stemTopY, scale, stem_height);
+
+        // Only draw flags for notes that are NOT beamed
+        if (code.flag && !note.beam) {
+          Glyph.renderGlyph(ctx, x, stemTopY, options.glyph_font_scale, code.code_flag_upstem);
+          if (!note.dots) x += 6 * scale;
+        }
+      }
+
+      // Draw dots
+      for (let d = 0; d < (note.dots || 0); d++) {
+        x += 6 * scale;
+        ctx.beginPath();
+        ctx.arc(x, y + 2 * scale, 2 * scale, 0, Math.PI * 2, false);
+        ctx.fill();
+      }
+
+      const pos = { x: noteX, y_top: stemTopY, stemX: stemX, code: code };
+      notePositions.push(pos);
+
+      // Track beam groups
+      if (note.beam === 'begin') {
+        currentBeamGroup = [pos];
+      } else if (note.beam === 'continue') {
+        currentBeamGroup.push(pos);
+      } else if (note.beam === 'end') {
+        currentBeamGroup.push(pos);
+        beamSegments.push(currentBeamGroup);
+        currentBeamGroup = [];
+      }
+
+      // Add spacing between notes in the group
+      if (i < notes.length - 1) {
+        x += 2 * scale;
+      }
+    }
+
+    // Draw beams
+    const beamThickness = 3 * scale;
+    for (const segment of beamSegments) {
+      if (segment.length < 2) continue;
+      const firstStem = segment[0];
+      const lastStem = segment[segment.length - 1];
+
+      // Determine how many beam lines based on the maximum beam_count in the segment
+      let maxBeamCount = 0;
+      for (const pos of segment) {
+        if (pos.code.beam_count) {
+          maxBeamCount = Math.max(maxBeamCount, pos.code.beam_count);
+        }
+      }
+
+      for (let b = 0; b < maxBeamCount; b++) {
+        const beamY = firstStem.y_top + b * (beamThickness + 1 * scale);
+        ctx.fillRect(
+          firstStem.stemX - scale,
+          beamY,
+          lastStem.stemX - firstStem.stemX + scale,
+          beamThickness
+        );
+      }
+    }
+
+    // Draw tuplet bracket and number
+    if (tuplet && notePositions.length > 0) {
+      const firstPos = notePositions[0];
+      const lastPos = notePositions[notePositions.length - 1];
+
+      // Find the highest (smallest y) stem top in the group
+      let minY = firstPos.y_top;
+      for (const pos of notePositions) {
+        minY = Math.min(minY, pos.y_top);
+      }
+
+      const bracketY = minY - 6 * scale;
+      const bracketStartX = firstPos.stemX - 3 * scale;
+      const bracketEndX = lastPos.stemX + 3 * scale;
+
+      if (tuplet.bracket) {
+        const hookHeight = 4 * scale;
+        ctx.beginPath();
+        // Left hook
+        ctx.moveTo(bracketStartX, bracketY + hookHeight);
+        ctx.lineTo(bracketStartX, bracketY);
+
+        // Determine the gap for the tuplet number
+        const midX = (bracketStartX + bracketEndX) / 2;
+        const numberText = tuplet.showNumber === 'both'
+          ? `${tuplet.actualNotes}:${tuplet.normalNotes}`
+          : `${tuplet.actualNotes}`;
+
+        ctx.setFont(this.font.family, this.font.size - 3, 'bold');
+        const numberWidth = ctx.measureText(numberText).width;
+        const gapHalf = numberWidth / 2 + 2 * scale;
+
+        // Line to gap
+        ctx.lineTo(midX - gapHalf, bracketY);
+        ctx.stroke();
+
+        ctx.beginPath();
+        // Line from gap
+        ctx.moveTo(midX + gapHalf, bracketY);
+        ctx.lineTo(bracketEndX, bracketY);
+        // Right hook
+        ctx.lineTo(bracketEndX, bracketY + hookHeight);
+        ctx.stroke();
+
+        // Draw the number
+        ctx.fillText(numberText, midX - numberWidth / 2, bracketY - 1 * scale);
+      } else if (tuplet.showNumber !== 'none') {
+        // No bracket, just the number
+        const midX = (bracketStartX + bracketEndX) / 2;
+        const numberText = tuplet.showNumber === 'both'
+          ? `${tuplet.actualNotes}:${tuplet.normalNotes}`
+          : `${tuplet.actualNotes}`;
+        ctx.setFont(this.font.family, this.font.size - 3, 'bold');
+        const numberWidth = ctx.measureText(numberText).width;
+        ctx.fillText(numberText, midX - numberWidth / 2, bracketY - 1 * scale);
+      }
+    }
+
+    return x;
   }
 }

--- a/src/VexFlowPatch/src/stavetempo.js
+++ b/src/VexFlowPatch/src/stavetempo.js
@@ -59,7 +59,7 @@ export class StaveTempo extends StaveModifier {
     }
 
     if (noteEquation) {
-      // Complex metronome mark: note group = note group (e.g. swing notation)
+      // Complex metronome mark: note group = note group (e.g. swing notation) (VexFlowPatch)
       x = this.drawNoteEquation(ctx, x, y, scale, noteEquation);
     } else if (duration && bpm) {
       ctx.setFont(font.family, font.size, 'normal');
@@ -115,6 +115,7 @@ export class StaveTempo extends StaveModifier {
   /**
    * Draw a complex metronome mark: leftNotes = rightNotes (with optional tuplet bracket).
    * noteEquation: { left: { notes: [{duration, dots, beam}], tuplet? }, right: { ... } }
+   * (added in VexFlowPatch)
    */
   drawNoteEquation(ctx, x, y, scale, noteEquation) {
     const font = this.font;
@@ -142,6 +143,7 @@ export class StaveTempo extends StaveModifier {
    * Draw a group of notes (with beams connecting flagged notes, and optional tuplet bracket).
    * @param baseSpacing Base spacing unit — all internal spacing is derived from this.
    * group: { notes: [{duration, dots, beam}], tuplet?: {actualNotes, bracket, showNumber} }
+   * (added in VexFlowPatch)
    */
   drawNoteGroup(ctx, x, y, scale, baseSpacing, group) {
     const options = this.render_options;

--- a/src/VexFlowPatch/src/stavetempo.js
+++ b/src/VexFlowPatch/src/stavetempo.js
@@ -117,29 +117,33 @@ export class StaveTempo extends StaveModifier {
    * noteEquation: { left: { notes: [{duration, dots, beam}], tuplet? }, right: { ... } }
    */
   drawNoteEquation(ctx, x, y, scale, noteEquation) {
-    const options = this.render_options;
     const font = this.font;
 
-    // Draw left note group
-    x = this.drawNoteGroup(ctx, x, y, scale, noteEquation.left);
+    // Base spacing unit — controls overall density of the note equation.
+    // All spacing values below are derived from this so they scale together.
+    const baseSpacing = 4 * scale;
 
-    // Draw "=" sign
+    // Draw left note group
+    x = this.drawNoteGroup(ctx, x, y, scale, baseSpacing, noteEquation.left);
+
+    // Draw "=" sign with padding derived from base spacing
     ctx.setFont(font.family, font.size, 'bold');
-    const equalsText = ' = ';
-    ctx.fillText(equalsText, x + 2 * scale, y);
-    x += ctx.measureText(equalsText).width + 2 * scale;
+    x += 1.5 * baseSpacing;
+    ctx.fillText('=', x, y);
+    x += ctx.measureText('=').width + 1.5 * baseSpacing;
 
     // Draw right note group (with optional tuplet)
-    x = this.drawNoteGroup(ctx, x, y, scale, noteEquation.right);
+    x = this.drawNoteGroup(ctx, x, y, scale, baseSpacing, noteEquation.right);
 
     return x;
   }
 
   /**
    * Draw a group of notes (with beams connecting flagged notes, and optional tuplet bracket).
+   * @param baseSpacing Base spacing unit — all internal spacing is derived from this.
    * group: { notes: [{duration, dots, beam}], tuplet?: {actualNotes, bracket, showNumber} }
    */
-  drawNoteGroup(ctx, x, y, scale, group) {
+  drawNoteGroup(ctx, x, y, scale, baseSpacing, group) {
     const options = this.render_options;
     const notes = group.notes;
     const tuplet = group.tuplet;
@@ -202,9 +206,9 @@ export class StaveTempo extends StaveModifier {
         currentBeamGroup = [];
       }
 
-      // Add spacing between notes in the group
+      // Inter-note spacing: tuplet groups get double spacing so the bracket has room
       if (i < notes.length - 1) {
-        x += 2 * scale;
+        x += tuplet ? 2 * baseSpacing : baseSpacing;
       }
     }
 
@@ -245,12 +249,13 @@ export class StaveTempo extends StaveModifier {
         minY = Math.min(minY, pos.y_top);
       }
 
-      const bracketY = minY - 6 * scale;
-      const bracketStartX = firstPos.stemX - 3 * scale;
-      const bracketEndX = lastPos.stemX + 3 * scale;
+      const bracketOverhang = 1.25 * baseSpacing;
+      const bracketY = minY - 1.5 * baseSpacing;
+      const bracketStartX = firstPos.x - 0.5 * baseSpacing;
+      const bracketEndX = lastPos.stemX + bracketOverhang;
 
       if (tuplet.bracket) {
-        const hookHeight = 4 * scale;
+        const hookHeight = baseSpacing;
         ctx.beginPath();
         // Left hook
         ctx.moveTo(bracketStartX, bracketY + hookHeight);

--- a/test/data/test_swing_and_complex_metronome_markings.musicxml
+++ b/test/data/test_swing_and_complex_metronome_markings.musicxml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <movement-title>test_swing_and_complex_metronome_markings</movement-title>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>Finale v27.4 for Mac</software>
+      <encoding-date>2026-03-11</encoding-date>
+      <supports attribute="new-system" element="print" type="yes" value="yes" />
+      <supports attribute="new-page" element="print" type="yes" value="yes" />
+      <supports element="accidental" type="yes" />
+      <supports element="beam" type="yes" />
+      <supports element="stem" type="yes" />
+    </encoding>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.1472</millimeters>
+      <tenths>40</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>1818</page-height>
+      <page-width>1405</page-width>
+      <page-margins type="both">
+        <left-margin>83</left-margin>
+        <right-margin>83</right-margin>
+        <top-margin>83</top-margin>
+        <bottom-margin>83</bottom-margin>
+      </page-margins>
+    </page-layout>
+    <system-layout>
+      <system-margins>
+        <left-margin>54</left-margin>
+        <right-margin>0</right-margin>
+      </system-margins>
+      <system-distance>146</system-distance>
+      <top-system-distance>73</top-system-distance>
+    </system-layout>
+    <staff-layout>
+      <staff-distance>93</staff-distance>
+    </staff-layout>
+    <appearance>
+      <line-width type="stem">0.957</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="staff">0.957</line-width>
+      <line-width type="light barline">0.957</line-width>
+      <line-width type="heavy barline">5.0391</line-width>
+      <line-width type="leger">0.957</line-width>
+      <line-width type="ending">1.4583</line-width>
+      <line-width type="wedge">1.4583</line-width>
+      <line-width type="enclosure">0.957</line-width>
+      <line-width type="tuplet bracket">0.4167</line-width>
+      <note-size type="grace">50</note-size>
+      <note-size type="cue">50</note-size>
+      <distance type="hyphen">60</distance>
+      <distance type="beam">7.5</distance>
+      <glyph type="percussion-clef">unpitchedPercussionClef1</glyph>
+    </appearance>
+  </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Test Instrument</part-name>
+      <part-abbreviation>TST INST</part-abbreviation>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <?SmartMusic maxVoice=1?>
+    <measure number="1" width="448">
+      <print page-number="1">
+        <page-layout>
+          <page-height>1818</page-height>
+          <page-width>1405</page-width>
+          <page-margins>
+            <left-margin>172</left-margin>
+            <right-margin>172</right-margin>
+            <top-margin>83</top-margin>
+            <bottom-margin>83</bottom-margin>
+          </page-margins>
+        </page-layout>
+        <system-layout>
+          <system-margins>
+            <left-margin>0</left-margin>
+            <right-margin>0</right-margin>
+          </system-margins>
+          <top-system-distance>146</top-system-distance>
+        </system-layout>
+        <measure-numbering multiple-rest-always="no" multiple-rest-range="no" system="only-top">
+          system</measure-numbering>
+      </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>3</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <sound tempo="102" />
+      <direction placement="above" system="only-top">
+        <direction-type>
+          <metronome default-y="42" halign="left" relative-x="-28">
+            <metronome-note>
+              <metronome-type>eighth</metronome-type>
+              <metronome-beam number="1">begin</metronome-beam>
+            </metronome-note>
+            <metronome-note>
+              <metronome-type>eighth</metronome-type>
+              <metronome-beam number="1">end</metronome-beam>
+            </metronome-note>
+            <metronome-relation>equals</metronome-relation>
+            <metronome-note>
+              <metronome-type>quarter</metronome-type>
+              <metronome-tuplet bracket="yes" show-number="actual" type="start">
+                <actual-notes>3</actual-notes>
+                <normal-notes>2</normal-notes>
+                <normal-type>eighth</normal-type>
+              </metronome-tuplet>
+            </metronome-note>
+            <metronome-note>
+              <metronome-type>eighth</metronome-type>
+              <metronome-tuplet type="stop">
+                <actual-notes>3</actual-notes>
+                <normal-notes>2</normal-notes>
+                <normal-type>eighth</normal-type>
+              </metronome-tuplet>
+            </metronome-note>
+          </metronome>
+        </direction-type>
+        <sound>
+          <swing>
+            <first>2</first>
+            <second>1</second>
+            <swing-style>Standard</swing-style>
+          </swing>
+        </sound>
+      </direction>
+      <note default-x="154">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-15">up</stem>
+      </note>
+      <note default-x="218">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem default-y="-15">up</stem>
+        <beam number="1">begin</beam>
+      </note>
+      <note default-x="264">
+        <pitch>
+          <step>B</step>
+          <alter>1</alter>
+          <octave>3</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>sharp</accidental>
+        <stem default-y="-17">up</stem>
+        <beam number="1">end</beam>
+      </note>
+      <note default-x="321">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-15">up</stem>
+      </note>
+      <note default-x="385">
+        <rest />
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>


### PR DESCRIPTION
Closes #1654

Swing and complex metronome marks were not rendered before in OSMD, as they're more complex to read, and vexflow didn't have direct support for it (in 1.2.93).

They are now implemented, with extensions of Vexflow (VexFlowPatch).

<img width="403" height="179" alt="Image" src="https://github.com/user-attachments/assets/45c62e9c-05c5-4948-8c84-7c429ec6b0a8" />

[test_swing_and_complex_metronome_markings.musicxml.txt](https://github.com/user-attachments/files/26122683/test_swing_and_complex_metronome_markings.musicxml.txt)

Before, OSMD just rendered no metronome mark at all in complex cases like this.
<img width="505" height="153" alt="image" src="https://github.com/user-attachments/assets/3f10abcd-4070-49fb-909b-bb5f9cedbb48" />
