### PR TITLE
lint: Remove unnecessary escape character in regex

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,7 +149,6 @@ export default defineConfig(
             "no-unsafe-optional-chaining": "error",
             "no-unused-labels": "error",
             "no-useless-assignment": "off",
-            "no-useless-escape": "off",
             "no-var": "error",
             "prefer-const": "error",
             "prefer-spread": "off",

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -697,7 +697,7 @@ export class OpenSheetMusicDisplay {
             }
             // validate strings input
             for (const colorString of options.coloringSetCustom) {
-                const regExp: RegExp = /^\#[0-9a-fA-F]{6}$/;
+                const regExp: RegExp = /^#[0-9a-fA-F]{6}$/;
                 if (!regExp.test(colorString)) {
                     throw new Error(
                         "One of the color strings in options.coloringSetCustom was not a valid HTML Hex color:\n" + colorString);


### PR DESCRIPTION
## Summary

- Remove unnecessary escape `\#` → `#` in color validation regex (`OpenSheetMusicDisplay.ts:700`)
- Remove `no-useless-escape: "off"` override from ESLint config (now passes with the recommended default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)