### PR TITLE
lint: Replace .apply() with spread operator

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -152,7 +152,6 @@ export default defineConfig(
             "no-useless-escape": "off",
             "no-var": "error",
             "prefer-const": "error",
-            "prefer-spread": "off",
             radix: "error",
             "spaced-comment": [
                 "off",

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -963,8 +963,8 @@ export class InstrumentReader {
       const typeList: IXmlElement[] = [];
       for (let idx: number = 0, len: number = timeList.length; idx < len; ++idx) {
         const xmlNode: IXmlElement = timeList[idx];
-        beatsList.push.apply(beatsList, xmlNode.elements("beats"));
-        typeList.push.apply(typeList, xmlNode.elements("beat-type"));
+        beatsList.push(...xmlNode.elements("beats"));
+        typeList.push(...xmlNode.elements("beat-type"));
       }
       if (!senzaMisura) {
         try {

--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -371,7 +371,7 @@ export class Cursor {
     const voiceEntries: VoiceEntry[]  = this.VoicesUnderCursor(instrument);
     const notes: Note[] = [];
     voiceEntries.forEach(voiceEntry => {
-      notes.push.apply(notes, voiceEntry.Notes);
+      notes.push(...voiceEntry.Notes);
     });
     return notes;
   }


### PR DESCRIPTION
## Summary

- Replace `arr.push.apply(arr, items)` with `arr.push(...items)` in 3 locations
- Remove `prefer-spread: "off"` override from ESLint config

## Files changed

- `src/MusicalScore/ScoreIO/InstrumentReader.ts` (2 occurrences)
- `src/OpenSheetMusicDisplay/Cursor.ts` (1 occurrence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)