### PR TITLE
lint: Add block scoping to case clauses with lexical declarations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,7 +139,6 @@ export default defineConfig(
             "no-prototype-builtins": "off",
             "no-redeclare": "error",
             "for-direction": "off",
-            "no-case-declarations": "off",
             "no-constant-binary-expression": "off",
             "no-constant-condition": "off",
             "no-irregular-whitespace": "error",

--- a/src/MusicalScore/Graphical/GraphicalUnknownExpression.ts
+++ b/src/MusicalScore/Graphical/GraphicalUnknownExpression.ts
@@ -24,14 +24,16 @@ export class GraphicalUnknownExpression extends AbstractGraphicalExpression {
         const left: number = this.label.PositionAndShape.RelativePosition.x + this.label.PositionAndShape.BorderMarginLeft;
         const right: number = this.label.PositionAndShape.RelativePosition.x + this.label.PositionAndShape.BorderMarginRight;
         switch (this.Placement) {
-            case PlacementEnum.Above:
+            case PlacementEnum.Above: {
                 const yValueAbove: number = this.label.PositionAndShape.BorderMarginTop + this.label.PositionAndShape.RelativePosition.y;
                 skyBottomLineCalculator.updateSkyLineInRange(left, right, yValueAbove);
                 break;
-            case PlacementEnum.Below:
+            }
+            case PlacementEnum.Below: {
                 const yValueBelow: number = this.label.PositionAndShape.BorderMarginBottom + this.label.PositionAndShape.RelativePosition.y;
                 skyBottomLineCalculator.updateBottomLineInRange(left, right, yValueBelow);
                 break;
+            }
             default:
                 log.error("Placement for GraphicalUnknownExpression is unknown");
         }

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -1045,7 +1045,7 @@ export class MusicSystemBuilder {
                     const startLine: SystemLinesEnum = this.currentSystemParams.systemMeasures[measureIndex].beginLine;
                     const lineWidth: number = measure.getLineWidth(SystemLinesEnum.BoldThinDots);
                     switch (startLine) {
-                        case SystemLinesEnum.BoldThinDots:
+                        case SystemLinesEnum.BoldThinDots: {
                             let xPosition: number = currentXPosition;
                             if (measureIndex === 0) {
                                 xPosition = currentXPosition + measure.beginInstructionsWidth - lineWidth;
@@ -1053,6 +1053,7 @@ export class MusicSystemBuilder {
 
                             currentSystem.createVerticalLineForMeasure(xPosition, lineWidth, startLine, SystemLinePosition.MeasureBegin, measureIndex, measure);
                             break;
+                        }
                         default:
                     }
                 }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1651,7 +1651,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
                 case PlacementEnum.Below:
                     modifierPosition = VF.StaveModifier.Position.BELOW;
                     break;
-                case PlacementEnum.NotYetDefined: // automatic fingering placement, could be more complex/customizable
+                case PlacementEnum.NotYetDefined: { // automatic fingering placement, could be more complex/customizable
                     const sourceStaff: Staff = voiceEntry.parentStaffEntry.sourceStaffEntry.ParentStaff;
                     if (voiceEntry.notes.length > 1 || voiceEntry.parentStaffEntry.graphicalVoiceEntries.length > 1) {
                         modifierPosition = VF.StaveModifier.Position.LEFT;
@@ -1662,6 +1662,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
                         modifierPosition = VF.StaveModifier.Position.BELOW;
                         fingeringPosition = PlacementEnum.Below;
                     }
+                }
             }
 
             const fretFinger: VF.FretHandFinger = new VF.FretHandFinger(fingering.value);

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
@@ -219,7 +219,7 @@ export class RepetitionCalculator {
                 this.finalizeRepetition(currentRepetition);
             }
             break;
-        case RepetitionInstructionEnum.Ending:
+        case RepetitionInstructionEnum.Ending: {
             currentRepetition = this.getOrCreateCurrentRepetition();
             currentRepetitionInstruction.parentRepetition = currentRepetition.RepetitonUnderConstruction;
             const isFirstEndingStart: boolean = currentRepetitionInstruction.endingIndices.contains(1) &&
@@ -263,6 +263,7 @@ export class RepetitionCalculator {
                 }
             }
             break;
+        }
         case RepetitionInstructionEnum.Segno:
             currentRepetition = this.getCurrentRepetition(true);
             if (currentRepetition !== undefined &&


### PR DESCRIPTION
## Summary

- Wrap case clause bodies in `{}` blocks where `const`/`let` declarations are used
- Remove `no-case-declarations: "off"` override from ESLint config

## Files changed

- `src/MusicalScore/Graphical/GraphicalUnknownExpression.ts` (2 cases)
- `src/MusicalScore/Graphical/MusicSystemBuilder.ts` (1 case)
- `src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts` (1 case)
- `src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts` (1 case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)