### PR TITLE
lint: Replace .hasOwnProperty() with Object.hasOwn()

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,7 +136,6 @@ export default defineConfig(
             "no-fallthrough": "error",
             "no-multiple-empty-lines": "off",
             "no-new-wrappers": "error",
-            "no-prototype-builtins": "off",
             "no-redeclare": "error",
             "for-direction": "off",
             "no-case-declarations": "off",

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -587,7 +587,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
                 const prevStaveModifiers: VF.StaveModifier[] = prevMeasure.stave.getModifiers();
                 for (let i: number = 0; i < prevStaveModifiers.length; i++) {
                     const nextStaveModifier: VF.StaveModifier = prevStaveModifiers[i];
-                    if (nextStaveModifier.hasOwnProperty("volta")) {
+                    if (Object.hasOwn(nextStaveModifier, "volta")) {
                         const prevskyBottomLineCalculator: SkyBottomLineCalculator = prevMeasure.ParentStaffLine.SkyBottomLineCalculator;
                         const prevStart: number = prevMeasure.PositionAndShape.AbsolutePosition.x + prevMeasure.PositionAndShape.BorderMarginLeft + 0.4;
                         const prevEnd: number = Math.max(
@@ -650,7 +650,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
         this.stave.setContext(ctx).draw();
         // Draw all voices
         for (const voiceID in this.vfVoices) {
-            if (this.vfVoices.hasOwnProperty(voiceID)) {
+            if (Object.hasOwn(this.vfVoices, voiceID)) {
                 ctx.save();
                 this.vfVoices[voiceID].draw(ctx, this.stave);
                 ctx.restore();
@@ -660,7 +660,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
         }
         // Draw beams
         for (const voiceID in this.vfbeams) {
-            if (this.vfbeams.hasOwnProperty(voiceID)) {
+            if (Object.hasOwn(this.vfbeams, voiceID)) {
                 for (const beam of this.vfbeams[voiceID]) {
                     beam.setContext(ctx).draw();
                 }
@@ -680,7 +680,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
             }
             // Draw tuplets
             for (const voiceID in this.vftuplets) {
-                if (this.vftuplets.hasOwnProperty(voiceID)) {
+                if (Object.hasOwn(this.vftuplets, voiceID)) {
                     for (let i: number = 0; i < this.tuplets[voiceID].length; i++) {
                         const tuplet: Tuplet = this.tuplets[voiceID][i][0];
                         const vftuplet: VF.Tuplet = this.vftuplets[voiceID][i];
@@ -960,7 +960,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
         }
         const beamedNotes: StaveNote[] = []; // already beamed notes, will be ignored by this.autoBeamNotes()
         for (const voiceID in this.beams) {
-            if (this.beams.hasOwnProperty(voiceID)) {
+            if (Object.hasOwn(this.beams, voiceID)) {
                 let vfbeams: VF.Beam[] = this.vfbeams[voiceID];
                 if (!vfbeams) {
                     vfbeams = this.vfbeams[voiceID] = [];
@@ -1249,7 +1249,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
         // should the old tuplets be removed manually from the notes?
         this.vftuplets = {};
         for (const voiceID in this.tuplets) {
-            if (this.tuplets.hasOwnProperty(voiceID)) {
+            if (Object.hasOwn(this.tuplets, voiceID)) {
                 let vftuplets: VF.Tuplet[] = this.vftuplets[voiceID];
                 if (!vftuplets) {
                     vftuplets = this.vftuplets[voiceID] = [];
@@ -1566,7 +1566,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
             const gvoices: { [voiceID: number]: GraphicalVoiceEntry } = graphicalStaffEntry.graphicalVoiceEntries;
 
             for (const voiceID in gvoices) {
-                if (gvoices.hasOwnProperty(voiceID)) {
+                if (Object.hasOwn(gvoices, voiceID)) {
                     const vfStaveNote: StemmableNote = (gvoices[voiceID] as VexFlowVoiceEntry).vfStaveNote;
                     const ornamentContainer: OrnamentContainer = gvoices[voiceID].notes[0].sourceNote.ParentVoiceEntry.OrnamentContainer;
                     if (ornamentContainer) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -182,7 +182,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       const mvoices: { [voiceID: number]: VF.Voice } = (measure as VexFlowMeasure).vfVoices;
       const voices: VF.Voice[] = [];
       for (const voiceID in mvoices) {
-        if (mvoices.hasOwnProperty(voiceID)) {
+        if (Object.hasOwn(mvoices, voiceID)) {
           const mvoice: any = mvoices[voiceID];
           if (measure.hasOnlyRests && !mvoice.ticksUsed.equals(mvoice.totalTicks)) {
             // fix layouting issues with whole measure rests in one staff and notes in other. especially in 12/8 rthythm (#1187)
@@ -338,7 +338,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       const mvoices: { [voiceID: number]: VF.Voice } = (measure as VexFlowMeasure).vfVoices;
       const voices: VF.Voice[] = [];
       for (const voiceID in mvoices) {
-        if (mvoices.hasOwnProperty(voiceID)) {
+        if (Object.hasOwn(mvoices, voiceID)) {
           voices.push(mvoices[voiceID]);
         }
       }

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -533,7 +533,7 @@ export class InstrumentReader {
         }
       }
       for (const j in this.voiceGeneratorsDict) {
-        if (this.voiceGeneratorsDict.hasOwnProperty(j)) {
+        if (Object.hasOwn(this.voiceGeneratorsDict, j)) {
           const voiceGenerator: VoiceGenerator = this.voiceGeneratorsDict[j];
           voiceGenerator.checkForOpenBeam();
         }
@@ -624,7 +624,7 @@ export class InstrumentReader {
 
   public doCalculationsAfterDurationHasBeenSet(): void {
     for (const j in this.voiceGeneratorsDict) {
-      if (this.voiceGeneratorsDict.hasOwnProperty(j)) {
+      if (Object.hasOwn(this.voiceGeneratorsDict, j)) {
         this.voiceGeneratorsDict[j].checkOpenTies();
       }
     }

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts
@@ -193,7 +193,7 @@ export class ArticulationReader {
     };
 
     for (const xmlArticulation in xmlElementToArticulationEnum) {
-      if (!xmlElementToArticulationEnum.hasOwnProperty(xmlArticulation)) {
+      if (!Object.hasOwn(xmlElementToArticulationEnum, xmlArticulation)) {
         continue;
       }
       const articulationEnum: ArticulationEnum = xmlElementToArticulationEnum[xmlArticulation];
@@ -289,7 +289,7 @@ export class ArticulationReader {
       };
 
       for (const ornamentElement in elementToOrnamentEnum) {
-        if (!elementToOrnamentEnum.hasOwnProperty(ornamentElement)) {
+        if (!Object.hasOwn(elementToOrnamentEnum, ornamentElement)) {
           continue;
         }
         const node: IXmlElement = ornamentsNode.element(ornamentElement);

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts
@@ -226,7 +226,7 @@ export class RepetitionCalculator {
                                                 currentRepetitionInstruction.alignment === AlignmentType.Begin;
             if (isFirstEndingStart) {
                 if (currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.length > 0 ||
-                    currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+                    Object.hasOwn(currentRepetition.RepetitonUnderConstruction.EndingIndexDict, 1)) {
                     currentRepetition = undefined;
                     for (let i: number = this.openRepetitions.length - 1; i >= 0; i--) {
                         const openRep: RepetitionBuildingContainer = this.openRepetitions[i];
@@ -387,7 +387,7 @@ export class RepetitionCalculator {
                       0, 0, currentRepetition.RepetitonUnderConstruction.startMarker);
                 }
             }
-            if (currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+            if (Object.hasOwn(currentRepetition.RepetitonUnderConstruction.EndingIndexDict, 1)) {
                 currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
             }
             currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
@@ -424,7 +424,7 @@ export class RepetitionCalculator {
                       splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
                 }
             }
-            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+            if (!Object.hasOwn(currentRepetition.RepetitonUnderConstruction.EndingIndexDict, 1)) {
                 currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
             }
             currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
@@ -457,7 +457,7 @@ export class RepetitionCalculator {
                       splice(0, 0, currentRepetition.RepetitonUnderConstruction.forwardJumpInstruction);
                 }
             }
-            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+            if (!Object.hasOwn(currentRepetition.RepetitonUnderConstruction.EndingIndexDict, 1)) {
                 currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
             }
             currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
@@ -507,7 +507,7 @@ export class RepetitionCalculator {
             if (currentRepetition.ToCodaFound) {
                 currentRepetition.WaitingForCoda = true;
             }
-            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+            if (!Object.hasOwn(currentRepetition.RepetitonUnderConstruction.EndingIndexDict, 1)) {
                 currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
             }
             currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);
@@ -555,7 +555,7 @@ export class RepetitionCalculator {
             if (currentRepetition.ToCodaFound) {
                 currentRepetition.WaitingForCoda = true;
             }
-            if (!currentRepetition.RepetitonUnderConstruction.EndingIndexDict.hasOwnProperty(1)) {
+            if (!Object.hasOwn(currentRepetition.RepetitonUnderConstruction.EndingIndexDict, 1)) {
                 currentRepetition.RepetitonUnderConstruction.setEndingEndIndex(1, this.currentMeasureIndex);
             }
             currentRepetition.RepetitonUnderConstruction.BackwardJumpInstructions.push(currentRepetitionInstruction);

--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -294,7 +294,7 @@ export class VoiceGenerator {
   public checkOpenTies(): void {
     const openTieDict: { [key: number]: Tie } = this.openTieDict;
     for (const key in openTieDict) {
-      if (openTieDict.hasOwnProperty(key)) {
+      if (Object.hasOwn(openTieDict, key)) {
         const tie: Tie = openTieDict[key];
         if (Fraction.plus(tie.StartNote.ParentStaffEntry.Timestamp, tie.Duration)
           .lt(tie.StartNote.SourceMeasure.Duration)) {
@@ -1110,7 +1110,7 @@ export class VoiceGenerator {
   private findCurrentNoteInTieDict(candidateNote: Note): number {
     const openTieDict: { [_: number]: Tie } = this.openTieDict;
     for (const key in openTieDict) {
-      if (openTieDict.hasOwnProperty(key)) {
+      if (Object.hasOwn(openTieDict, key)) {
         const tie: Tie = openTieDict[key];
         const tieTabNote: TabNote = tie.Notes[0] as TabNote;
         const tieCandidateNote: TabNote = candidateNote as TabNote;

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -962,7 +962,7 @@ export class OpenSheetMusicDisplay {
         pageFormatString = pageFormatString.replace("Landscape", "L");
         pageFormatString = pageFormatString.replace("Portrait", "P");
         //console.log("change format to: " + formatId);
-        if (OpenSheetMusicDisplay.PageFormatStandards.hasOwnProperty(pageFormatString)) {
+        if (Object.hasOwn(OpenSheetMusicDisplay.PageFormatStandards, pageFormatString)) {
             pageFormat = OpenSheetMusicDisplay.PageFormatStandards[pageFormatString];
             return pageFormat;
         }


### PR DESCRIPTION
## Summary

- Replace `obj.hasOwnProperty(key)` with `Object.hasOwn(obj, key)` (22 occurrences across 7 files)
- Remove `no-prototype-builtins: "off"` override from ESLint config

## Files changed

- `src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts` (7)
- `src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts` (2)
- `src/MusicalScore/ScoreIO/InstrumentReader.ts` (2)
- `src/MusicalScore/ScoreIO/MusicSymbolModules/ArticulationReader.ts` (2)
- `src/MusicalScore/ScoreIO/MusicSymbolModules/RepetitionCalculator.ts` (5)
- `src/MusicalScore/ScoreIO/VoiceGenerator.ts` (2)
- `src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts` (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)