### PR TITLE
lint: Enable no-unused-vars rule with ignore patterns

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,7 +66,14 @@ export default defineConfig(
             ],
             "@typescript-eslint/no-this-alias": "off",
             "@typescript-eslint/no-unused-expressions": "error",
-            "@typescript-eslint/no-unused-vars": "off",
+            "@typescript-eslint/no-unused-vars": [
+                "error",
+                {
+                    args: "none",
+                    varsIgnorePattern: "^_",
+                    caughtErrorsIgnorePattern: "^_|^e$|^err$|^exc$",
+                },
+            ],
             "@typescript-eslint/no-wrapper-object-types": "off",
             "@typescript-eslint/prefer-namespace-keyword": "error",
             "@stylistic/quotes": [
@@ -167,7 +174,13 @@ export default defineConfig(
         files: ["test/Util/*.js", "test/Util/*.mjs"],
         rules: {
             "@typescript-eslint/explicit-function-return-type": "off",
-            "@typescript-eslint/no-unused-vars": "off",
+            "@typescript-eslint/no-unused-vars": [
+                "error",
+                {
+                    argsIgnorePattern: "^_",
+                    varsIgnorePattern: "^_",
+                },
+            ],
             "@typescript-eslint/typedef": "off",
             "no-useless-assignment": "off",
         },

--- a/src/Util/CollectionUtil.ts
+++ b/src/Util/CollectionUtil.ts
@@ -26,7 +26,7 @@ if (!Array.prototype.clear) {
     Object.defineProperty(Array.prototype, "clear", {
         enumerable: false,
         writable: true,
-        value: function<T>(): void {
+        value: function(): void {
             this.length = 0;
         }
     });

--- a/test/Util/generateDiffImagesPuppeteerLocalhost.js
+++ b/test/Util/generateDiffImagesPuppeteerLocalhost.js
@@ -105,9 +105,9 @@ async function init () {
 
     // fix navigation error
     var responseEventOccurred = false
-    var responseHandler = function (event) { responseEventOccurred = true }
+    var responseHandler = function (_event) { responseEventOccurred = true }
 
-    var responseWatcher = new Promise(function (resolve, reject) {
+    var responseWatcher = new Promise(function (resolve, _reject) {
         setTimeout(function () {
             if (!responseEventOccurred) {
                 resolve(true)


### PR DESCRIPTION
## Summary

- Enable `@typescript-eslint/no-unused-vars` as `error` with configuration:
  - `args: "none"` — skip unused function arguments (many callback signatures in the codebase intentionally declare parameters they don't use)
  - `varsIgnorePattern: "^_"` — allow `_`-prefixed unused variables
  - `caughtErrorsIgnorePattern` — allow common error variable names (`e`, `err`, `exc`)
- Remove unused generic type parameter `<T>` in `CollectionUtil.ts`
- Prefix unused callback parameters with `_` in test utility

## Note

As a further improvement, unused function arguments could be prefixed with `_` (e.g., `event` → `_event`) to make the intent explicit. This would allow tightening `args` from `"none"` to `"after-used"` in the future. If you'd like, feel free to mention me and I can help with that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)