### PR TITLE
Fix lyrics overlap for pickup measure / last note in measure multi-syllable mid-word continuation

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -293,7 +293,7 @@ export class EngravingRules {
      *  has a syllable + dash glyph right at its start — the usual measure-end buffer doesn't apply.
      *  Set to 0 for maximum cross-measure clearance (no reduction), or up to
      *  LyricsXPaddingReductionForLastNoteInMeasure for the same reduction as a normal last note.
-     *  Default 0.6 (half of the regular 1.2). */
+     *  Default 1.0 (regular note 1.2). */
     public LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord: number;
     public VerticalBetweenLyricsDistance: number;
     public HorizontalBetweenLyricsDistance: number;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -825,7 +825,9 @@ export class EngravingRules {
         this.LyricsXPaddingReductionForLongNotes = 0.7;
         this.LyricsXPaddingReductionForLastNoteInMeasure = 1.2;
         this.LyricsXPaddingForLastNoteInMeasure = true;
-        this.LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord = 0.6;
+        this.LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord = 1.0;
+        // 1.0 avoids too much padding/measure width e.g. in Schubert measure 9 end, Mozart Veilchen measure 18 and 19 end
+
         this.VerticalBetweenLyricsDistance = 0.5;
         this.HorizontalBetweenLyricsDistance = 0.2;
         this.BetweenSyllableMaximumDistance = 10.0;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -287,6 +287,14 @@ export class EngravingRules {
     /** Last note in measure needs less padding because of measure bar and bar start/end padding. */
     public LyricsXPaddingReductionForLastNoteInMeasure: number;
     public LyricsXPaddingForLastNoteInMeasure: boolean;
+    /** Reduction applied for the last note of a measure when its lyric is a multi-syllable
+     *  mid-word continuation (a dash trails to the next syllable, which lives in the next measure).
+     *  Lower than LyricsXPaddingReductionForLastNoteInMeasure because the next measure's first note
+     *  has a syllable + dash glyph right at its start — the usual measure-end buffer doesn't apply.
+     *  Set to 0 for maximum cross-measure clearance (no reduction), or up to
+     *  LyricsXPaddingReductionForLastNoteInMeasure for the same reduction as a normal last note.
+     *  Default 0.6 (half of the regular 1.2). */
+    public LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord: number;
     public VerticalBetweenLyricsDistance: number;
     public HorizontalBetweenLyricsDistance: number;
     public BetweenSyllableMaximumDistance: number;
@@ -817,6 +825,7 @@ export class EngravingRules {
         this.LyricsXPaddingReductionForLongNotes = 0.7;
         this.LyricsXPaddingReductionForLastNoteInMeasure = 1.2;
         this.LyricsXPaddingForLastNoteInMeasure = true;
+        this.LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord = 0.6;
         this.VerticalBetweenLyricsDistance = 0.5;
         this.HorizontalBetweenLyricsDistance = 0.2;
         this.BetweenSyllableMaximumDistance = 10.0;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -561,15 +561,17 @@ export class VexFlowConverter {
                         const measureStaffEntries: GraphicalStaffEntry[] = currentStaffEntry.parentMeasure.staffEntries;
                         const currentStaffEntryIndex: number = measureStaffEntries.indexOf(currentStaffEntry);
                         const isLastNoteInMeasure: boolean = currentStaffEntryIndex === measureStaffEntries.length - 1;
-                        // The reduction here normally compensates for the natural buffer between the last
-                        // note and the bar line. But if this lyric is a multi-syllable mid-word continuation
-                        // (a dash trails to the next syllable), and we're at the last note of the measure,
-                        // the next syllable lives in the next measure and starts right at its first note —
-                        // there is no buffer to compensate for. Skip the reduction so the lyric gets enough
-                        // padding to clear the bar (and leave room for the inter-measure dash).
+                        // The regular reduction compensates for the natural buffer between the last note
+                        // and the bar line. If this lyric is a multi-syllable mid-word continuation
+                        // (a dash trails to the next syllable in the next measure), that buffer is much
+                        // smaller — the next measure's first note has a syllable + dash glyph right at
+                        // its start. Use a smaller reduction (LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord)
+                        // to add some extra padding without over-padding.
                         const isCrossMeasureMidWord: boolean = isLastNoteInMeasure && lyricsEntry.hasDashFromLyricWord();
-                        if (isLastNoteInMeasure && !isCrossMeasureMidWord) {
-                            extraExistingPadding += rules.LyricsXPaddingReductionForLastNoteInMeasure; // need less padding
+                        if (isLastNoteInMeasure) {
+                            extraExistingPadding += isCrossMeasureMidWord
+                                ? rules.LyricsXPaddingReductionForLastNoteInMeasureCrossMeasureMidWord
+                                : rules.LyricsXPaddingReductionForLastNoteInMeasure;
                         }
                         if (!hasShortNotes) {
                             extraExistingPadding += rules.LyricsXPaddingReductionForLongNotes; // quarter or longer notes need less padding

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -561,7 +561,14 @@ export class VexFlowConverter {
                         const measureStaffEntries: GraphicalStaffEntry[] = currentStaffEntry.parentMeasure.staffEntries;
                         const currentStaffEntryIndex: number = measureStaffEntries.indexOf(currentStaffEntry);
                         const isLastNoteInMeasure: boolean = currentStaffEntryIndex === measureStaffEntries.length - 1;
-                        if (isLastNoteInMeasure) {
+                        // The reduction here normally compensates for the natural buffer between the last
+                        // note and the bar line. But if this lyric is a multi-syllable mid-word continuation
+                        // (a dash trails to the next syllable), and we're at the last note of the measure,
+                        // the next syllable lives in the next measure and starts right at its first note —
+                        // there is no buffer to compensate for. Skip the reduction so the lyric gets enough
+                        // padding to clear the bar (and leave room for the inter-measure dash).
+                        const isCrossMeasureMidWord: boolean = isLastNoteInMeasure && lyricsEntry.hasDashFromLyricWord();
+                        if (isLastNoteInMeasure && !isCrossMeasureMidWord) {
                             extraExistingPadding += rules.LyricsXPaddingReductionForLastNoteInMeasure; // need less padding
                         }
                         if (!hasShortNotes) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -69,11 +69,17 @@ import { Glissando } from "../../VoiceData/Glissando";
 import { VexFlowGlissando } from "./VexFlowGlissando";
 import { WavyLine } from "../../VoiceData/Expressions/ContinuousExpressions/WavyLine";
 import { VexFlowVibratoBracket } from "./VexFlowVibratoBracket";
+import { Staff } from "../../VoiceData/Staff";
 
 export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   /** space needed for a dash for lyrics spacing, calculated once */
   private dashSpace: number;
   public beamsNeedUpdate: boolean = false;
+  /** Per-staff overflow (in pre-elongation units) of the previous measure's last lyric/chord
+   *  past its bar line. Used to prevent the next measure's first lyric/chord from colliding
+   *  with the overflow. Indexed first by Staff, then by verse/container index. */
+  private previousLyricOverflowsByStaff: Map<Staff, number[]> = new Map<Staff, number[]>();
+  private previousChordOverflowsByStaff: Map<Staff, number[]> = new Map<Staff, number[]>();
 
   constructor(rules: EngravingRules) {
     super();
@@ -356,17 +362,30 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     return minStaffEntriesWidth;
   }
 
+  /**
+   * @param crossMeasureFloorRef Out-parameter (mutated). Tracks the minimum elongation factor
+   *   this measure must have in order to clear the *previous* measure's lyric/chord overflow
+   *   that spilled past its bar line into this measure (seeded into lastEntryDict via
+   *   isCrossMeasureSeed entries before this function runs). The caller uses this as a lower
+   *   bound that bypasses MaximumLyricsElongationFactor — the regular within-measure elongation
+   *   factor is capped, but cross-measure clearance must always be honored, otherwise lyrics
+   *   from the previous measure overlap the first lyric of this one.
+   *   `.value` starts at 1 (no extra elongation needed) and is raised via Math.max.
+   */
   private calculateElongationFactor(containers: (GraphicalLyricEntry|GraphicalChordSymbolContainer)[], staffEntry: GraphicalStaffEntry, lastEntryDict: any,
                                     oldMinimumStaffEntriesWidth: number, elongationFactorForMeasureWidth: number,
-                                    measureNumber: number, oldMinSpacing: number, nextMeasureOverlap: number): number {
+                                    measureNumber: number, oldMinSpacing: number, nextMeasureOverlap: number,
+                                    crossMeasureFloorRef?: { value: number }): number {
     let newElongationFactorForMeasureWidth: number = elongationFactorForMeasureWidth;
     let currentContainerIndex: number = 0;
 
+    let needsDashSpaceAtEnd: boolean = false;
     for (const container of containers) {
       const alignment: TextAlignmentEnum = container.GraphicalLabel.Label.textAlignment;
       let minSpacing: number = oldMinSpacing;
 
       let overlapAllowedIntoNextMeasure: number = nextMeasureOverlap;
+      needsDashSpaceAtEnd = false;
 
       if (container instanceof GraphicalLyricEntry && container.ParentLyricWord) {
         // spacing for multi-syllable words
@@ -381,6 +400,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         const syllables: LyricsEntry[] = container.ParentLyricWord.GetLyricWord.Syllables;
         if (syllables.length > 1) {
           if (container.LyricsEntry.SyllableIndex < syllables.length - 1) {
+            needsDashSpaceAtEnd = true;
             // if a middle syllable of a word, give less measure overlap into next measure, to give room for dash
             if (this.dashSpace === undefined) { // don't replace undefined check
               this.dashSpace = 1.5;
@@ -446,8 +466,16 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
 
       // get factor of how much we need to stretch the measure to space the current lyric
       let elongationFactorForMeasureWidthForCurrentContainer: number = 1;
-      const elongationFactorNeededForMeasureEnd: number =
-        spacingNeededToMeasureEnd / currentSpacingToMeasureEnd;
+      let elongationFactorNeededForMeasureEnd: number;
+      if (currentSpacingToMeasureEnd > 0) {
+        elongationFactorNeededForMeasureEnd = spacingNeededToMeasureEnd / currentSpacingToMeasureEnd;
+      } else {
+        // currentSpacingToMeasureEnd <= 0 happens for pickup/anacrusis measures, where the staff entry
+        // sits past the staff-entries-only width because xPosition includes begin instructions (clef, key,
+        // time signature) but maxXInMeasure does not. The xPosition - oldMin offset is roughly the
+        // begin-instructions width. Solve for F directly: oldMin*F >= xPosition + labelWidth - overlapAllowed.
+        elongationFactorNeededForMeasureEnd = (xPosition + spacingNeededToMeasureEnd) / oldMinimumStaffEntriesWidth;
+      }
       let elongationFactorNeededForLastContainer: number = 1;
 
       if (container instanceof GraphicalLyricEntry && container.LyricsEntry) {
@@ -476,6 +504,16 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         elongationFactorForMeasureWidthForCurrentContainer
       );
 
+      // Raise the cross-measure clearance floor: this is the minimum elongation factor required
+      // to keep the current container clear of the previous measure's lyric/chord overflow
+      // (synthesized into lastEntryDict before this loop, marked with isCrossMeasureSeed).
+      // The caller will apply this as a lower bound exempt from MaximumLyricsElongationFactor,
+      // because otherwise pickup-measure overflows that exceed the cap can never be cleared.
+      if (crossMeasureFloorRef && lastEntryDict[currentContainerIndex] &&
+          lastEntryDict[currentContainerIndex].isCrossMeasureSeed) {
+        crossMeasureFloorRef.value = Math.max(crossMeasureFloorRef.value, elongationFactorNeededForLastContainer);
+      }
+
       let overlap: number = Math.max((spacingNeededToLastContainer - currentSpacingToLastContainer) || 0, 0);
       if (lastEntryDict[currentContainerIndex]) {
         overlap += lastEntryDict[currentContainerIndex].cumulativeOverlap;
@@ -487,6 +525,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         extend: container instanceof GraphicalLyricEntry ? container.LyricsEntry.extend : false,
         labelWidth: labelWidth,
         measureNumber: measureNumber,
+        needsDashSpaceAtEnd: needsDashSpaceAtEnd,
         sourceNoteDuration: container instanceof GraphicalLyricEntry ? (container.LyricsEntry && container.LyricsEntry.Parent.Notes[0].Length) : false,
         text: container instanceof GraphicalLyricEntry ? container.LyricsEntry.Text : container.GraphicalLabel.Label.text,
         xPosition: xPosition,
@@ -498,12 +537,37 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     return newElongationFactorForMeasureWidth;
   }
 
+  /**
+   * @param previousLyricOverflows Per-verse-index array (`[verseIndex]`) holding how far the
+   *   previous measure's last lyric extends past its bar line into this measure (in pre-elongation
+   *   units, +dashSpace if mid-word). Used to seed lastLyricEntryDict so the first lyric in this
+   *   measure is forced to leave clearance from the overhang.
+   * @param previousChordOverflows Same as previousLyricOverflows but for chord symbols.
+   * @returns
+   *   - `factor`: regular elongation factor from within-measure spacing constraints (subject to
+   *     MaximumLyricsElongationFactor cap by the caller).
+   *   - `crossMeasureFloor`: minimum elongation factor required to clear the previous measure's
+   *     overflow. The caller enforces this as a lower bound that bypasses the cap, otherwise
+   *     a pickup whose lyric exceeds the allowed overlap can never be cleared.
+   *   - `lastLyricEntryDict` / `lastChordEntryDict`: final state of the per-verse last-entry
+   *     dicts after processing. The caller uses these (with the post-cap measure width) to
+   *     compute the overflows passed into the next measure's call.
+   */
   public calculateElongationFactorFromStaffEntries(staffEntries: GraphicalStaffEntry[], oldMinimumStaffEntriesWidth: number,
-                                                  elongationFactorForMeasureWidth: number, measureNumber: number): number {
+                                                  elongationFactorForMeasureWidth: number, measureNumber: number,
+                                                  previousLyricOverflows?: number[],
+                                                  previousChordOverflows?: number[]): {
+    factor: number;
+    crossMeasureFloor: number;
+    lastLyricEntryDict: { [i: number]: any };
+    lastChordEntryDict: { [i: number]: any };
+  } {
     interface EntryInfo {
       cumulativeOverlap: number;
       extend: boolean;
+      isCrossMeasureSeed?: boolean;
       labelWidth: number;
+      needsDashSpaceAtEnd?: boolean;
       xPosition: number;
       sourceNoteDuration: Fraction;
       text: string;
@@ -519,6 +583,51 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     const lastLyricEntryDict: EntryDict = {}; // holds info about last lyric entries for all verses j???
     const lastChordEntryDict: EntryDict = {}; // holds info about last chord entries for all verses j???
 
+    // Seed dicts with previous-measure overflow as synthetic entries, so the first lyric/chord
+    // in this measure is forced to leave clearance from the previous measure's overhang.
+    // The synthetic entry sits at xPosition 0 with labelWidth = overflow, so for left-aligned
+    // labels (the standard) the existing logic requires xPosition_first >= overflow + minSpacing.
+    if (previousLyricOverflows) {
+      for (let i: number = 0; i < previousLyricOverflows.length; i++) {
+        const overflow: number = previousLyricOverflows[i];
+        if (overflow > 0) {
+          lastLyricEntryDict[i] = {
+            cumulativeOverlap: 0,
+            extend: false,
+            isCrossMeasureSeed: true,
+            labelWidth: overflow,
+            measureNumber: measureNumber - 1,
+            sourceNoteDuration: new Fraction(1, 4),
+            text: "",
+            xPosition: 0,
+          };
+        }
+      }
+    }
+    if (previousChordOverflows) {
+      for (let i: number = 0; i < previousChordOverflows.length; i++) {
+        const overflow: number = previousChordOverflows[i];
+        if (overflow > 0) {
+          lastChordEntryDict[i] = {
+            cumulativeOverlap: 0,
+            extend: false,
+            isCrossMeasureSeed: true,
+            labelWidth: overflow,
+            measureNumber: measureNumber - 1,
+            sourceNoteDuration: new Fraction(1, 4),
+            text: "",
+            xPosition: 0,
+          };
+        }
+      }
+    }
+
+    /** Lower bound on the final elongation factor of this measure, raised whenever a synthetic
+     *  cross-measure-seed entry forces extra spacing on the first container of a verse.
+     *  Wrapped in an object so calculateElongationFactor can mutate it via Math.max.
+     *  Default 1 = no extra elongation required beyond regular within-measure spacing. */
+    const crossMeasureFloorRef: { value: number } = { value: 1 };
+
     // for all staffEntries i, each containing the lyric entry for all verses at that timestamp in the measure
     for (const staffEntry of staffEntries) {
       if (staffEntry.LyricsEntries.length > 0 && this.rules.RenderLyrics) {
@@ -532,6 +641,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             measureNumber,
             this.rules.HorizontalBetweenLyricsDistance,
             this.rules.LyricOverlapAllowedIntoNextMeasure,
+            crossMeasureFloorRef,
           );
       }
       if (staffEntry.graphicalChordContainers.length > 0 && this.rules.RenderChordSymbols) {
@@ -545,38 +655,123 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             measureNumber,
             this.rules.ChordSymbolXSpacing,
             this.rules.ChordOverlapAllowedIntoNextMeasure,
+            crossMeasureFloorRef,
           );
       }
     }
 
-    return newElongationFactorForMeasureWidth;
+    return {
+      factor: newElongationFactorForMeasureWidth,
+      crossMeasureFloor: crossMeasureFloorRef.value,
+      lastLyricEntryDict,
+      lastChordEntryDict,
+    };
   }
 
   public calculateMeasureWidthFromStaffEntries(measuresVertical: GraphicalMeasure[], oldMinimumStaffEntriesWidth: number): number {
     let elongationFactorForMeasureWidth: number = 1;
+    /** Lower bound on the final elongation factor required to clear the previous measure's lyric/chord
+     *  overflow into this measure. Aggregated as the max across all vertical staves of this bar.
+     *  Applied after the MaximumLyricsElongationFactor cap so cross-measure clearance is honored
+     *  even when the cap would otherwise prevent it. */
+    let crossMeasureFloor: number = 1;
+
+    interface PerStaffResult {
+      staff: Staff;
+      lastLyricEntryDict: { [i: number]: any };
+      lastChordEntryDict: { [i: number]: any };
+    }
+    const perStaffResults: PerStaffResult[] = [];
+    const visibleStaves: Set<Staff> = new Set<Staff>();
 
     for (const measure of measuresVertical) {
       if (!measure || measure.staffEntries.length === 0 || !measure.isVisible()) {
         continue;
       }
+      const staff: Staff = measure.ParentStaff;
+      visibleStaves.add(staff);
+      const previousLyricOverflows: number[] = this.previousLyricOverflowsByStaff.get(staff);
+      const previousChordOverflows: number[] = this.previousChordOverflowsByStaff.get(staff);
 
       // (measure as VexFlowMeasure).format(); // needed to get vexflow bbox / x-position
-      elongationFactorForMeasureWidth =
+      const result: { factor: number, crossMeasureFloor: number, lastLyricEntryDict: { [i: number]: any }, lastChordEntryDict: { [i: number]: any } } =
         this.calculateElongationFactorFromStaffEntries(
           measure.staffEntries,
           oldMinimumStaffEntriesWidth,
           elongationFactorForMeasureWidth,
           measure.MeasureNumber,
+          previousLyricOverflows,
+          previousChordOverflows,
         );
-
+      elongationFactorForMeasureWidth = result.factor;
+      // accumulate the per-staff cross-measure clearance requirement; the widest constraint wins
+      crossMeasureFloor = Math.max(crossMeasureFloor, result.crossMeasureFloor);
+      perStaffResults.push({
+        staff,
+        lastLyricEntryDict: result.lastLyricEntryDict,
+        lastChordEntryDict: result.lastChordEntryDict,
+      });
     }
+    // Apply the cap to regular within-measure elongation, but enforce a floor for cross-measure
+    // clearance — otherwise lyrics that overflowed past the previous measure's bar can never be
+    // cleared in the next measure. Cross-measure pressure is bounded by the inputs (overflow +
+    // dashSpace + minSpacing), so this can't blow up arbitrarily.
     elongationFactorForMeasureWidth = Math.min(elongationFactorForMeasureWidth, this.rules.MaximumLyricsElongationFactor);
+    elongationFactorForMeasureWidth = Math.max(elongationFactorForMeasureWidth, crossMeasureFloor);
     // console.log(`elongationFactor for measure ${measuresVertical[0]?.MeasureNumber}: ${elongationFactorForMeasureWidth}`);
     // TODO check when this is > 2.0. See PR #1474
 
     const newMinimumStaffEntriesWidth: number = oldMinimumStaffEntriesWidth * elongationFactorForMeasureWidth;
 
+    // Compute overflow of this measure's last lyric/chord into the next measure, per staff and per verse,
+    // so the next measure's calculation can leave clearance for it.
+    // overflow is measured against newMinimumStaffEntriesWidth (the bar position) using the same
+    // pre-elongation xPosition convention used elsewhere in this calculator.
+    for (const result of perStaffResults) {
+      const lyricOverflows: number[] = this.computeContainerOverflows(result.lastLyricEntryDict, newMinimumStaffEntriesWidth);
+      const chordOverflows: number[] = this.computeContainerOverflows(result.lastChordEntryDict, newMinimumStaffEntriesWidth);
+      this.previousLyricOverflowsByStaff.set(result.staff, lyricOverflows);
+      this.previousChordOverflowsByStaff.set(result.staff, chordOverflows);
+    }
+    // For staves that were skipped (invisible or empty) this measure, drop the previous overflow
+    // so it doesn't get applied across a gap.
+    for (const staff of Array.from(this.previousLyricOverflowsByStaff.keys())) {
+      if (!visibleStaves.has(staff)) {
+        this.previousLyricOverflowsByStaff.delete(staff);
+      }
+    }
+    for (const staff of Array.from(this.previousChordOverflowsByStaff.keys())) {
+      if (!visibleStaves.has(staff)) {
+        this.previousChordOverflowsByStaff.delete(staff);
+      }
+    }
+
     return newMinimumStaffEntriesWidth;
+  }
+
+  private computeContainerOverflows(lastEntryDict: { [i: number]: any }, measureWidth: number): number[] {
+    const overflows: number[] = [];
+    for (const key of Object.keys(lastEntryDict)) {
+      const i: number = Number(key);
+      const entry: any = lastEntryDict[i];
+      if (!entry) {
+        continue;
+      }
+      // entry.xPosition is the lyric label's left edge in pre-elongation units.
+      // entry.labelWidth is the label width (does not scale with elongation).
+      // measureWidth is the elongated bar position.
+      const rightEdge: number = entry.xPosition + entry.labelWidth;
+      let overflow: number = Math.max(0, rightEdge - measureWidth);
+      // If this lyric is a multi-syllable mid-word, the next syllable is connected by a dash.
+      // The previous-measure elongation already reserved this.dashSpace for the dash via
+      // overlapAllowedIntoNextMeasure -= dashSpace; the next measure's first lyric must clear
+      // the dash too, otherwise the dash has no room to render between the two syllables.
+      if (entry.needsDashSpaceAtEnd && this.dashSpace !== undefined) {
+        overflow += this.dashSpace;
+      }
+      overflows[i] = overflow;
+    }
+    return overflows;
   }
 
   protected createGraphicalTie(tie: Tie, startGse: GraphicalStaffEntry, endGse: GraphicalStaffEntry,

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -362,20 +362,9 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     return minStaffEntriesWidth;
   }
 
-  /**
-   * @param crossMeasureFloorRef Out-parameter (mutated). Tracks the minimum elongation factor
-   *   this measure must have in order to clear the *previous* measure's lyric/chord overflow
-   *   that spilled past its bar line into this measure (seeded into lastEntryDict via
-   *   isCrossMeasureSeed entries before this function runs). The caller uses this as a lower
-   *   bound that bypasses MaximumLyricsElongationFactor — the regular within-measure elongation
-   *   factor is capped, but cross-measure clearance must always be honored, otherwise lyrics
-   *   from the previous measure overlap the first lyric of this one.
-   *   `.value` starts at 1 (no extra elongation needed) and is raised via Math.max.
-   */
   private calculateElongationFactor(containers: (GraphicalLyricEntry|GraphicalChordSymbolContainer)[], staffEntry: GraphicalStaffEntry, lastEntryDict: any,
                                     oldMinimumStaffEntriesWidth: number, elongationFactorForMeasureWidth: number,
-                                    measureNumber: number, oldMinSpacing: number, nextMeasureOverlap: number,
-                                    crossMeasureFloorRef?: { value: number }): number {
+                                    measureNumber: number, oldMinSpacing: number, nextMeasureOverlap: number): number {
     let newElongationFactorForMeasureWidth: number = elongationFactorForMeasureWidth;
     let currentContainerIndex: number = 0;
 
@@ -504,16 +493,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         elongationFactorForMeasureWidthForCurrentContainer
       );
 
-      // Raise the cross-measure clearance floor: this is the minimum elongation factor required
-      // to keep the current container clear of the previous measure's lyric/chord overflow
-      // (synthesized into lastEntryDict before this loop, marked with isCrossMeasureSeed).
-      // The caller will apply this as a lower bound exempt from MaximumLyricsElongationFactor,
-      // because otherwise pickup-measure overflows that exceed the cap can never be cleared.
-      if (crossMeasureFloorRef && lastEntryDict[currentContainerIndex] &&
-          lastEntryDict[currentContainerIndex].isCrossMeasureSeed) {
-        crossMeasureFloorRef.value = Math.max(crossMeasureFloorRef.value, elongationFactorNeededForLastContainer);
-      }
-
       let overlap: number = Math.max((spacingNeededToLastContainer - currentSpacingToLastContainer) || 0, 0);
       if (lastEntryDict[currentContainerIndex]) {
         overlap += lastEntryDict[currentContainerIndex].cumulativeOverlap;
@@ -546,9 +525,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
    * @returns
    *   - `factor`: regular elongation factor from within-measure spacing constraints (subject to
    *     MaximumLyricsElongationFactor cap by the caller).
-   *   - `crossMeasureFloor`: minimum elongation factor required to clear the previous measure's
-   *     overflow. The caller enforces this as a lower bound that bypasses the cap, otherwise
-   *     a pickup whose lyric exceeds the allowed overlap can never be cleared.
    *   - `lastLyricEntryDict` / `lastChordEntryDict`: final state of the per-verse last-entry
    *     dicts after processing. The caller uses these (with the post-cap measure width) to
    *     compute the overflows passed into the next measure's call.
@@ -558,14 +534,12 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
                                                   previousLyricOverflows?: number[],
                                                   previousChordOverflows?: number[]): {
     factor: number;
-    crossMeasureFloor: number;
     lastLyricEntryDict: { [i: number]: any };
     lastChordEntryDict: { [i: number]: any };
   } {
     interface EntryInfo {
       cumulativeOverlap: number;
       extend: boolean;
-      isCrossMeasureSeed?: boolean;
       labelWidth: number;
       needsDashSpaceAtEnd?: boolean;
       xPosition: number;
@@ -594,7 +568,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
           lastLyricEntryDict[i] = {
             cumulativeOverlap: 0,
             extend: false,
-            isCrossMeasureSeed: true,
             labelWidth: overflow,
             measureNumber: measureNumber - 1,
             sourceNoteDuration: new Fraction(1, 4),
@@ -611,7 +584,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
           lastChordEntryDict[i] = {
             cumulativeOverlap: 0,
             extend: false,
-            isCrossMeasureSeed: true,
             labelWidth: overflow,
             measureNumber: measureNumber - 1,
             sourceNoteDuration: new Fraction(1, 4),
@@ -621,12 +593,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         }
       }
     }
-
-    /** Lower bound on the final elongation factor of this measure, raised whenever a synthetic
-     *  cross-measure-seed entry forces extra spacing on the first container of a verse.
-     *  Wrapped in an object so calculateElongationFactor can mutate it via Math.max.
-     *  Default 1 = no extra elongation required beyond regular within-measure spacing. */
-    const crossMeasureFloorRef: { value: number } = { value: 1 };
 
     // for all staffEntries i, each containing the lyric entry for all verses at that timestamp in the measure
     for (const staffEntry of staffEntries) {
@@ -641,7 +607,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             measureNumber,
             this.rules.HorizontalBetweenLyricsDistance,
             this.rules.LyricOverlapAllowedIntoNextMeasure,
-            crossMeasureFloorRef,
           );
       }
       if (staffEntry.graphicalChordContainers.length > 0 && this.rules.RenderChordSymbols) {
@@ -655,14 +620,12 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
             measureNumber,
             this.rules.ChordSymbolXSpacing,
             this.rules.ChordOverlapAllowedIntoNextMeasure,
-            crossMeasureFloorRef,
           );
       }
     }
 
     return {
       factor: newElongationFactorForMeasureWidth,
-      crossMeasureFloor: crossMeasureFloorRef.value,
       lastLyricEntryDict,
       lastChordEntryDict,
     };
@@ -670,11 +633,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
 
   public calculateMeasureWidthFromStaffEntries(measuresVertical: GraphicalMeasure[], oldMinimumStaffEntriesWidth: number): number {
     let elongationFactorForMeasureWidth: number = 1;
-    /** Lower bound on the final elongation factor required to clear the previous measure's lyric/chord
-     *  overflow into this measure. Aggregated as the max across all vertical staves of this bar.
-     *  Applied after the MaximumLyricsElongationFactor cap so cross-measure clearance is honored
-     *  even when the cap would otherwise prevent it. */
-    let crossMeasureFloor: number = 1;
 
     interface PerStaffResult {
       staff: Staff;
@@ -694,7 +652,7 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       const previousChordOverflows: number[] = this.previousChordOverflowsByStaff.get(staff);
 
       // (measure as VexFlowMeasure).format(); // needed to get vexflow bbox / x-position
-      const result: { factor: number, crossMeasureFloor: number, lastLyricEntryDict: { [i: number]: any }, lastChordEntryDict: { [i: number]: any } } =
+      const result: { factor: number, lastLyricEntryDict: { [i: number]: any }, lastChordEntryDict: { [i: number]: any } } =
         this.calculateElongationFactorFromStaffEntries(
           measure.staffEntries,
           oldMinimumStaffEntriesWidth,
@@ -704,20 +662,13 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
           previousChordOverflows,
         );
       elongationFactorForMeasureWidth = result.factor;
-      // accumulate the per-staff cross-measure clearance requirement; the widest constraint wins
-      crossMeasureFloor = Math.max(crossMeasureFloor, result.crossMeasureFloor);
       perStaffResults.push({
         staff,
         lastLyricEntryDict: result.lastLyricEntryDict,
         lastChordEntryDict: result.lastChordEntryDict,
       });
     }
-    // Apply the cap to regular within-measure elongation, but enforce a floor for cross-measure
-    // clearance — otherwise lyrics that overflowed past the previous measure's bar can never be
-    // cleared in the next measure. Cross-measure pressure is bounded by the inputs (overflow +
-    // dashSpace + minSpacing), so this can't blow up arbitrarily.
     elongationFactorForMeasureWidth = Math.min(elongationFactorForMeasureWidth, this.rules.MaximumLyricsElongationFactor);
-    elongationFactorForMeasureWidth = Math.max(elongationFactorForMeasureWidth, crossMeasureFloor);
     // console.log(`elongationFactor for measure ${measuresVertical[0]?.MeasureNumber}: ${elongationFactorForMeasureWidth}`);
     // TODO check when this is > 2.0. See PR #1474
 

--- a/test/data/test_lyrics_overlap_pickup_anacrusis_dash_minden_m1.musicxml
+++ b/test/data/test_lyrics_overlap_pickup_anacrusis_dash_minden_m1.musicxml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>test_lyrics_overlap_pickup_anacrusis_minden_m1</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore Studio 4.6.5</software>
+      <encoding-date>2026-05-05</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    <miscellaneous>
+      <miscellaneous-field name="creationDate">2026-03-12</miscellaneous-field>
+      <miscellaneous-field name="platform">Microsoft Windows</miscellaneous-field>
+      </miscellaneous>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.72</page-height>
+      <page-width>1200.33</page-width>
+      <page-margins type="even">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7143</left-margin>
+        <right-margin>85.7143</right-margin>
+        <top-margin>85.7143</top-margin>
+        <bottom-margin>85.7143</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="600.165" default-y="1611.0057" justify="center" valign="top" font-size="22">Minden időben áldom</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="600.165" default-y="1553.862843" justify="center" valign="top" font-size="14">Subtitle</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1114.6157" default-y="1506.028556" justify="right" valign="bottom">Composer / arranger</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="0" implicit="yes" width="191.65">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>174.97</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>1</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above" system="only-top">
+        <direction-type>
+          <metronome parentheses="no" default-x="-37.67" default-y="6.52" relative-y="20">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>80</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="80"/>
+        </direction>
+      <note default-x="97.47" default-y="-55">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="-20.56" default-y="-55.32" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>1. Min</text>
+          </lyric>
+        <lyric number="2" default-x="-22.17" default-y="-79.02" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>2. Meg</text>
+          </lyric>
+        <lyric number="3" default-x="-21.77" default-y="-102.73" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>3. Az</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="1" width="787.25">
+      <harmony print-frame="no">
+        <root>
+          <root-step>E</root-step>
+          </root>
+        <kind text="m">minor</kind>
+        </harmony>
+      <note default-x="12.5" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" default-x="6.5" default-y="-55.32" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>den</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-79.02" relative-y="-30">
+          <syllabic>middle</syllabic>
+          <text>ke</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>Úr</text>
+          </lyric>
+        </note>
+      <note default-x="104.88" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">begin</beam>
+        <lyric number="1" default-x="6.5" default-y="-55.32" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>i</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-79.02" relative-y="-30">
+          <syllabic>middle</syllabic>
+          <text>res</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>an</text>
+          </lyric>
+        </note>
+      <note default-x="166.46" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        <lyric number="1" default-y="-55.32" relative-y="-30">
+          <syllabic>middle</syllabic>
+          <text>dő</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-79.02" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>tem</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>middle</syllabic>
+          <text>gya</text>
+          </lyric>
+        </note>
+      <note default-x="228.05" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>la</text>
+          </lyric>
+        </note>
+      <note default-x="320.43" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" default-x="6.5" default-y="-55.32" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>ben</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-79.02" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>az</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>tá</text>
+          </lyric>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>B</root-step>
+          </root>
+        <kind text="m">minor</kind>
+        </harmony>
+      <note default-x="412.81" default-y="-35">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <lyric number="1" default-x="6.5" default-y="-55.32" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>ál</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-79.02" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>U</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>bort</text>
+          </lyric>
+        </note>
+      <note default-x="505.18" default-y="-55">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <lyric number="1" default-x="9.12" default-y="-55.32" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>dom,</text>
+          </lyric>
+        <lyric number="2" default-x="9.12" default-y="-79.02" relative-y="-30">
+          <syllabic>end</syllabic>
+          <text>rat,</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>jár</text>
+          </lyric>
+        </note>
+      <note default-x="597.56" default-y="-20">
+        <rest/>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <dot default-x="613.6" default-y="-15"/>
+        </note>
+      <note default-x="714.67" default-y="-55">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <lyric number="1" default-y="-55.32" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>di</text>
+          </lyric>
+        <lyric number="2" default-y="-79.02" relative-y="-30">
+          <syllabic>begin</syllabic>
+          <text>s meg</text>
+          </lyric>
+        <lyric number="3" default-x="6.5" default-y="-102.73" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>az</text>
+          </lyric>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test/data/test_lyrics_overlap_pickup_anacrusis_longed_for.musicxml
+++ b/test/data/test_lyrics_overlap_pickup_anacrusis_longed_for.musicxml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>test_lyrics_overlap_pickup_anacrusis</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore Studio 4.6.5</software>
+      <encoding-date>2026-05-05</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    <miscellaneous>
+      <miscellaneous-field name="creationDate">2026-05-05</miscellaneous-field>
+      <miscellaneous-field name="platform">Microsoft Windows</miscellaneous-field>
+      <miscellaneous-field name="subtitle">Subtitle</miscellaneous-field>
+      </miscellaneous>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.94</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="600.241935" default-y="1611.210312" justify="center" valign="top" font-size="22">test_lyrics_overlap_pickup_anacrusis</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Soprano</part-name>
+      <part-abbreviation>S.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Soprano</instrument-name>
+        <instrument-sound>voice.soprano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="0" implicit="yes" width="337.99">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>4</fifths>
+          </key>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="130.34" default-y="-25">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <lyric number="1" default-x="6.5" default-y="-42.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>Longed</text>
+          </lyric>
+        </note>
+      </measure>
+    <measure number="1" width="641.05">
+      <note default-x="12.5" default-y="-15">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" default-x="6.5" default-y="-42.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>for</text>
+          </lyric>
+        </note>
+      <note default-x="321.27" default-y="-10">
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <lyric number="1" default-x="6.5" default-y="-42.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>space</text>
+          </lyric>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Fixes #1659

before:
<img width="757" height="200" alt="image" src="https://github.com/user-attachments/assets/aefe4c53-c37c-4205-9ef9-2bca23777a8f" />

after:
<img width="1314" height="275" alt="image" src="https://github.com/user-attachments/assets/80c24ebd-e5e5-4816-b8f0-9f80912dfd92" />

