### PR TITLE
fix: ensure currentVoiceEntries is safely cloned in MusicPartManagerIterator

### DIFF
--- a/src/MusicalScore/MusicParts/MusicPartManagerIterator.ts
+++ b/src/MusicalScore/MusicParts/MusicPartManagerIterator.ts
@@ -14,10 +14,10 @@ import {InstantaneousDynamicExpression} from "../VoiceData/Expressions/Instantan
 import {MultiTempoExpression} from "../VoiceData/Expressions/MultiTempoExpression";
 import {AbstractExpression} from "../VoiceData/Expressions/AbstractExpression";
 import log from "loglevel";
-import { MusicSheet } from "../MusicSheet";
-import { NoteHeadShape } from "../VoiceData/Notehead";
-import { PlaybackSettings } from "../../Common/DataObjects/PlaybackSettings";
-import { Note } from "../VoiceData";
+import {MusicSheet} from "../MusicSheet";
+import {NoteHeadShape} from "../VoiceData/Notehead";
+import {PlaybackSettings} from "../../Common/DataObjects/PlaybackSettings";
+import {Note} from "../VoiceData";
 
 export class MusicPartManagerIterator {
     constructor(musicSheet: MusicSheet, startTimestamp?: Fraction, endTimestamp?: Fraction) {
@@ -159,7 +159,7 @@ export class MusicPartManagerIterator {
         ret.currentVoiceEntryIndex = this.currentVoiceEntryIndex;
         ret.currentMappingPart = this.currentMappingPart;
         ret.currentPartIndex = this.currentPartIndex;
-        ret.currentVoiceEntries = this.currentVoiceEntries;
+        ret.currentVoiceEntries = this.currentVoiceEntries?.slice() ?? undefined;
         ret.endReached = this.endReached;
         ret.frontReached = this.frontReached;
         // alternative method to set currentTimeStamp? may not fully affect current iterator position


### PR DESCRIPTION
MusicPartManagerIterator.clone() assigns currentVoiceEntries by reference rather than by value. Any code that
advances the returned clone (e.g. via moveToNextVisibleVoiceEntry or moveToNext) calls moveToNext() on the clone,
which zeroes the shared array in-place with this.currentVoiceEntries.length = 0. This silently destroys the
original iterator's voice entry list, so subsequent calls to CurrentVisibleVoiceEntries(), GNotesUnderCursor(), or
NotesUnderCursor() on the original cursor return empty arrays.