### PR TITLE
fix(Tuplet): Align cross-staff tuplet notes with simultaneous notes in other voices

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -229,6 +229,29 @@ export class VexFlowConverter {
     }
 
     public static GhostNotes(frac: Fraction): VF.GhostNote[] {
+        // When a gap's duration is not a dyadic fraction (denominator not a power of two) -
+        // e.g. a tuplet member like a triplet eighth (1/12) - it cannot be represented exactly
+        // by standard note-value rests. durations() then decomposes it greedily and overshoots
+        // (1/12 -> 1/16 + 1/64 + 1/128), so the voice's accumulated ticks drift and every
+        // following note is pushed out of vertical alignment with simultaneous notes in other
+        // voices. This typically happens with cross-staff tuplets, where the off-staff members
+        // are filled with ghost notes on this staff. Emit a single ghost note whose ticks match
+        // the gap exactly, mirroring the StaveNote tuplet tick fix in graphicalMeasureCreatedCalculations().
+        const denominator: number = frac.Denominator;
+        // dyadic = denominator is a power of two (1, 2, 4, 8, ...), i.e. log2 is an integer.
+        const isDyadic: boolean = denominator > 0 && Number.isInteger(Math.log2(denominator));
+        if (!isDyadic) {
+            const ghostNote: VF.GhostNote = new VF.GhostNote({
+                duration: VexFlowConverter.durations(frac, true)[0],
+            });
+            // ticks = frac * VF.RESOLUTION, kept as an exact rational via VF.Fraction
+            // (e.g. 1/12 -> 16384/12 -> 4096/3) so the voice's resolution multiplier stays correct.
+            const vfTicks: VF.Fraction = ghostNote.getTicks();
+            vfTicks.numerator = frac.Numerator * VF.RESOLUTION;
+            vfTicks.denominator = frac.Denominator;
+            vfTicks.simplify();
+            return [ghostNote];
+        }
         const ghostNotes: VF.GhostNote[] = [];
         const durations: string[] = VexFlowConverter.durations(frac, false);
         for (const duration of durations) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -229,38 +229,25 @@ export class VexFlowConverter {
     }
 
     public static GhostNotes(frac: Fraction): VF.GhostNote[] {
-        // When a gap's duration is not a dyadic fraction (denominator not a power of two) -
-        // e.g. a tuplet member like a triplet eighth (1/12) - it cannot be represented exactly
-        // by standard note-value rests. durations() then decomposes it greedily and overshoots
-        // (1/12 -> 1/16 + 1/64 + 1/128), so the voice's accumulated ticks drift and every
-        // following note is pushed out of vertical alignment with simultaneous notes in other
-        // voices. This typically happens with cross-staff tuplets, where the off-staff members
-        // are filled with ghost notes on this staff. Emit a single ghost note whose ticks match
-        // the gap exactly, mirroring the StaveNote tuplet tick fix in graphicalMeasureCreatedCalculations().
-        const denominator: number = frac.Denominator;
-        // dyadic = denominator is a power of two (1, 2, 4, 8, ...), i.e. log2 is an integer.
-        const isDyadic: boolean = denominator > 0 && Number.isInteger(Math.log2(denominator));
-        if (!isDyadic) {
-            const ghostNote: VF.GhostNote = new VF.GhostNote({
-                duration: VexFlowConverter.durations(frac, true)[0],
-            });
-            // ticks = frac * VF.RESOLUTION, kept as an exact rational via VF.Fraction
-            // (e.g. 1/12 -> 16384/12 -> 4096/3) so the voice's resolution multiplier stays correct.
-            const vfTicks: VF.Fraction = ghostNote.getTicks();
-            vfTicks.numerator = frac.Numerator * VF.RESOLUTION;
-            vfTicks.denominator = frac.Denominator;
-            vfTicks.simplify();
-            return [ghostNote];
-        }
-        const ghostNotes: VF.GhostNote[] = [];
-        const durations: string[] = VexFlowConverter.durations(frac, false);
-        for (const duration of durations) {
-            ghostNotes.push(new VF.GhostNote({
-                duration: duration,
-                //dots: dots
-            }));
-        }
-        return ghostNotes;
+        // Emit a single ghost note whose ticks exactly match the gap.
+        // Previously the gap was decomposed into standard note-value rests via durations(),
+        // but for a non-dyadic gap - a tuplet member such as a triplet eighth (1/12) - that
+        // decomposition cannot represent the length exactly and overshoots
+        // (1/12 -> 1/16 + 1/64 + 1/128), so the voice's accumulated ticks drift and following
+        // notes lose vertical alignment with simultaneous notes in other voices (e.g. cross-staff
+        // tuplets). A single exact-tick ghost avoids that, is at least as compact (it slightly
+        // improves spacing in some samples), and mirrors the StaveNote tuplet tick fix in
+        // graphicalMeasureCreatedCalculations().
+        const ghostNote: VF.GhostNote = new VF.GhostNote({
+            duration: VexFlowConverter.durations(frac, true)[0],
+        });
+        // ticks = frac * VF.RESOLUTION, kept as an exact rational via VF.Fraction
+        // (e.g. 1/12 -> 16384/12 -> 4096/3) so the voice's resolution multiplier stays correct.
+        const vfTicks: VF.Fraction = ghostNote.getTicks();
+        vfTicks.numerator = frac.Numerator * VF.RESOLUTION;
+        vfTicks.denominator = frac.Denominator;
+        vfTicks.simplify();
+        return [ghostNote];
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -229,15 +229,12 @@ export class VexFlowConverter {
     }
 
     public static GhostNotes(frac: Fraction): VF.GhostNote[] {
-        // Emit a single ghost note whose ticks exactly match the gap.
-        // Previously the gap was decomposed into standard note-value rests via durations(),
-        // but for a non-dyadic gap - a tuplet member such as a triplet eighth (1/12) - that
-        // decomposition cannot represent the length exactly and overshoots
-        // (1/12 -> 1/16 + 1/64 + 1/128), so the voice's accumulated ticks drift and following
-        // notes lose vertical alignment with simultaneous notes in other voices (e.g. cross-staff
-        // tuplets). A single exact-tick ghost avoids that, is at least as compact (it slightly
-        // improves spacing in some samples), and mirrors the StaveNote tuplet tick fix in
-        // graphicalMeasureCreatedCalculations().
+        // Fill the gap with a single ghost note whose ticks exactly match it. A gap can be a
+        // tuplet member (e.g. a triplet eighth = 1/12), which is not a dyadic fraction and so
+        // can't be represented exactly by standard note-value rests: decomposing it overshoots
+        // (1/12 -> 1/16 + 1/64 + 1/128) and drifts the voice's accumulated ticks, breaking
+        // vertical alignment with simultaneous notes in other voices (e.g. cross-staff tuplets).
+        // Setting the ticks directly as an exact rational keeps the voice's resolution multiplier correct.
         const ghostNote: VF.GhostNote = new VF.GhostNote({
             duration: VexFlowConverter.durations(frac, true)[0],
         });

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_TupletAlignment_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_TupletAlignment_Test.ts
@@ -162,3 +162,83 @@ describe("VexFlow Measure - Tuplet Voice Alignment", () => {
    });
 
 });
+
+describe("VexFlow Measure - Cross-Staff Tuplet Alignment", () => {
+
+   const path: string = "test_tuplet_crossstaff_alignment.musicxml";
+
+   function calculateCrossStaffSheet(): GraphicalMusicSheet {
+      const score: Document = TestUtils.getScore(path);
+      expect(score).to.not.be.undefined;
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      expect(partwise).to.not.be.undefined;
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+      return gms;
+   }
+
+   it("Should fill a cross-staff tuplet gap with a ghost note of the exact tuplet length", (done: Mocha.Done) => {
+      const gms: GraphicalMusicSheet = calculateCrossStaffSheet();
+      // The lower staff is the second graphical measure of the first vertical measure.
+      const bassMeasure: VexFlowMeasure = gms.MeasureList[0][1] as VexFlowMeasure;
+      const tupletVoice: VF.Voice = bassMeasure.vfVoices[2];
+      expect(tupletVoice, "tuplet voice (id 2) should exist on the lower staff").to.not.be.undefined;
+
+      // The third note of each triplet (G4) is notated on the upper staff, so the lower
+      // staff fills that slot with a ghost note. A triplet eighth lasts RESOLUTION / 12 ticks.
+      const tripletEighthTicks: number = VF.RESOLUTION / 12;
+      const tickables: VF.Note[] = tupletVoice.getTickables() as VF.Note[];
+      const ghostTickables: VF.Note[] = tickables.filter((t: VF.Note) => t.isRest());
+      expect(ghostTickables.length).to.equal(2, "each of the two triplets should leave exactly one ghost-filled slot");
+      for (const ghost of ghostTickables) {
+         expect(ghost.getTicks().value()).to.be.closeTo(tripletEighthTicks, 0.001,
+            "the cross-staff ghost note should be exactly one triplet eighth, not an overshooting dyadic decomposition");
+      }
+
+      // The whole voice should still add up to the measure length (2/4 = RESOLUTION / 2).
+      const totalTicks: number = tickables.reduce((sum: number, t: VF.Note) => sum + t.getTicks().value(), 0);
+      expect(totalTicks).to.be.closeTo(VF.RESOLUTION / 2, 0.001,
+         "tuplet voice ticks should sum to the measure duration");
+
+      done();
+   });
+
+   it("Should align the beat-2 tuplet note with the simultaneous note in the other voice", (done: Mocha.Done) => {
+      const gms: GraphicalMusicSheet = calculateCrossStaffSheet();
+      const bassMeasure: VexFlowMeasure = gms.MeasureList[0][1] as VexFlowMeasure;
+      const tupletVoice: VF.Voice = bassMeasure.vfVoices[2];
+      const eighthVoice: VF.Voice = bassMeasure.vfVoices[5];
+      expect(eighthVoice, "eighth-note voice (id 5) should exist on the lower staff").to.not.be.undefined;
+
+      // Cumulative tick position where each voice reaches beat 2 (a quarter into a 2/4 measure).
+      const beat2Ticks: number = VF.RESOLUTION / 4;
+
+      function cumulativePositions(voice: VF.Voice): number[] {
+         const positions: number[] = [];
+         let pos: number = 0;
+         for (const tickable of voice.getTickables()) {
+            positions.push(pos);
+            pos += tickable.getTicks().value();
+         }
+         return positions;
+      }
+      const tupletPositions: number[] = cumulativePositions(tupletVoice);
+      const eighthPositions: number[] = cumulativePositions(eighthVoice);
+
+      // Both voices must have a note that starts exactly at beat 2; those starts must match.
+      const tupletBeat2: number = tupletPositions.find((p: number) => Math.abs(p - beat2Ticks) < 0.001);
+      const eighthBeat2: number = eighthPositions.find((p: number) => Math.abs(p - beat2Ticks) < 0.001);
+      expect(eighthBeat2, "the eighth-note voice should have a note starting on beat 2").to.not.be.undefined;
+      expect(tupletBeat2,
+         "the tuplet voice's beat-2 note should start at the same tick position as the simultaneous eighth note")
+         .to.not.be.undefined;
+      expect(tupletBeat2).to.be.closeTo(eighthBeat2, 0.001,
+         "notes at the same timestamp in different voices should share the same cumulative tick position");
+
+      done();
+   });
+
+});

--- a/test/data/test_tuplet_crossstaff_alignment.musicxml
+++ b/test/data/test_tuplet_crossstaff_alignment.musicxml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <!--
+    Regression sample for cross-staff tuplet alignment.
+    A two-staff piano part where voice 2 is a triplet whose third note (G4) is
+    notated on the upper staff, so the lower staff must fill that slot with a
+    ghost note. Voice 5 plays plain eighth notes on the lower staff. On beat 2,
+    voice 2's first triplet note and voice 5's eighth note share the same
+    timestamp and must be horizontally aligned. Before the fix, the ghost filler
+    used a greedy dyadic rest decomposition (1/16 + 1/64 + 1/128) that overshot
+    the triplet-eighth gap and pushed the beat-2 notes out of alignment.
+  -->
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+
+      <!-- Voice 1: melody on the upper staff -->
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff>
+      </note>
+
+      <backup><duration>24</duration></backup>
+
+      <!-- Voice 2: cross-staff triplets (3rd note of each triplet on the upper staff) -->
+      <note>
+        <pitch><step>B</step><octave>3</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <staff>2</staff>
+        <notations><tuplet type="start" bracket="yes"/></notations>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <staff>2</staff>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <staff>1</staff>
+        <notations><tuplet type="stop"/></notations>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>3</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <staff>2</staff>
+        <notations><tuplet type="start" bracket="yes"/></notations>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <staff>2</staff>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <staff>1</staff>
+        <notations><tuplet type="stop"/></notations>
+      </note>
+
+      <backup><duration>24</duration></backup>
+
+      <!-- Voice 5: plain eighth notes on the lower staff -->
+      <note>
+        <pitch><step>G</step><octave>3</octave></pitch>
+        <duration>6</duration><voice>5</voice><type>eighth</type><staff>2</staff>
+      </note>
+      <note>
+        <rest/><duration>6</duration><voice>5</voice><type>eighth</type><staff>2</staff>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>3</octave></pitch>
+        <duration>6</duration><voice>5</voice><type>eighth</type><staff>2</staff>
+      </note>
+      <note>
+        <rest/><duration>6</duration><voice>5</voice><type>eighth</type><staff>2</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## Problem

When a tuplet voice is split across staves — e.g. a left-hand triplet whose top note is notated on the upper staff — the notes of the tuplet that fall on a given staff are not horizontally aligned with simultaneous notes in other voices on that staff.

A concrete example is the left hand of Schumann's *Kinderszenen No. 1*: on every second beat the first note of the triplet should sit exactly above the bass note it is played with, but it is shifted noticeably to the right.

## Root cause

When a voice is missing a member on a staff (because that member is notated on the other staff), `VexFlowMeasure` fills the gap with ghost notes via `VexFlowConverter.GhostNotes()`, which decomposed the gap into standard note-value rests with `durations(frac, false)`.

A tuplet member such as a triplet eighth lasts `1/12` of a whole note, which is **not a dyadic fraction** and cannot be represented exactly by standard rests. The greedy decomposition overshoots:

```
1/12  ->  1/16 + 1/64 + 1/128  =  11/128   (1024 + 256 + 128 = 1408 ticks)
```

instead of the correct `RESOLUTION / 12 ≈ 1365.33` ticks. The voice's accumulated ticks then drift (~42.67 ticks per gap), so every following note is placed in a different `TickContext` than the simultaneous notes in other voices and is no longer vertically aligned.

This is the cross-staff / ghost-note counterpart of the StaveNote tuplet tick fix in #1631.

## Fix

`GhostNotes()` now always emits a **single** ghost note and sets its ticks to exactly match the gap (`frac * VF.RESOLUTION`, kept as an exact rational via `VF.Fraction`), mirroring the StaveNote approach. Since ghost notes are invisible, the standard-rest decomposition was never needed; a single exact-tick ghost is simpler, behaves identically for dyadic gaps, and (per review) slightly improves spacing in some samples with no visual regressions.

## Tests

- New sample `test/data/test_tuplet_crossstaff_alignment.musicxml`: a two-staff part with a cross-staff triplet (3rd note on the upper staff) over plain eighth notes on the lower staff.
- Two unit tests in `VexFlowMeasure_TupletAlignment_Test.ts`:
  - the cross-staff ghost filler has the exact triplet-eighth length (no overshoot) and the voice's ticks sum to the measure duration;
  - the beat-2 tuplet note and the simultaneous eighth note share the same cumulative tick position.

Full suite passes locally (197 tests).