### PR TITLE
fix(Notes): Don't stagger a unison between two voices in a three-voice stave

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -229,15 +229,22 @@ export class VexFlowConverter {
     }
 
     public static GhostNotes(frac: Fraction): VF.GhostNote[] {
-        const ghostNotes: VF.GhostNote[] = [];
-        const durations: string[] = VexFlowConverter.durations(frac, false);
-        for (const duration of durations) {
-            ghostNotes.push(new VF.GhostNote({
-                duration: duration,
-                //dots: dots
-            }));
-        }
-        return ghostNotes;
+        // Fill the gap with a single ghost note whose ticks exactly match it. A gap can be a
+        // tuplet member (e.g. a triplet eighth = 1/12), which is not a dyadic fraction and so
+        // can't be represented exactly by standard note-value rests: decomposing it overshoots
+        // (1/12 -> 1/16 + 1/64 + 1/128) and drifts the voice's accumulated ticks, breaking
+        // vertical alignment with simultaneous notes in other voices (e.g. cross-staff tuplets).
+        // Setting the ticks directly as an exact rational keeps the voice's resolution multiplier correct.
+        const ghostNote: VF.GhostNote = new VF.GhostNote({
+            duration: VexFlowConverter.durations(frac, true)[0],
+        });
+        // ticks = frac * VF.RESOLUTION, kept as an exact rational via VF.Fraction
+        // (e.g. 1/12 -> 16384/12 -> 4096/3) so the voice's resolution multiplier stays correct.
+        const vfTicks: VF.Fraction = ghostNote.getTicks();
+        vfTicks.numerator = frac.Numerator * VF.RESOLUTION;
+        vfTicks.denominator = frac.Denominator;
+        vfTicks.simplify();
+        return [ghostNote];
     }
 
     /**

--- a/src/VexFlowPatch/src/stavenote.js
+++ b/src/VexFlowPatch/src/stavenote.js
@@ -48,13 +48,15 @@ function centerRest(rest, noteU, noteL) {
   rest.minLine -= delta;
 }
 
-// Whether two single-notehead notes from different voices form a unison that can
-// share the same horizontal position (overlapping noteheads) instead of being
-// staggered. Mirrors the stagger conditions used in the two-voice path: a
-// notehead cannot cleanly overlap if the shapes differ (one half/whole and the
-// other not) or if the dot counts differ. Used so that a unison in a three-voice
-// stave isn't pushed apart by the generic "shift middle note" collision rule.
-function unisonMergeable(a, b) {
+// Whether two notes from different voices on the same staff line form a unison
+// whose noteheads can share one horizontal position (overlap) instead of being
+// staggered. Noteheads can't cleanly overlap if their shapes differ (one half/whole
+// and the other not), if their dot counts differ, or - when
+// EngravingRules.StaggerSameWholeNotes is set - for two identical whole notes.
+// Shared by the two-voice and three-voice collision paths so the same decision is
+// used in both (the divergence between them is what previously left three-voice
+// unisons staggered).
+function mergeableUnison(a, b, staggerSameWholeNotes) {
   if (a.isrest || b.isrest) return false;
   if (a.line !== b.line) return false; // not on the same staff line -> not a unison
   let halfNoteCount = 0;
@@ -67,9 +69,8 @@ function unisonMergeable(a, b) {
     }
   }
   if (halfNoteCount === 1 || wholeNoteCount === 1) return false; // mismatched notehead shapes
+  if (staggerSameWholeNotes && wholeNoteCount === 2) return false; // keep identical whole notes apart
   if (a.note.dots !== b.note.dots) return false;
-  // only handle single noteheads, to avoid chord-stacking complications
-  if (a.note.getKeyProps().length !== 1 || b.note.getKeyProps().length !== 1) return false;
   return true;
 }
 
@@ -194,27 +195,9 @@ export class StaveNote extends StemmableNote {
           //If we are sharing a line, switch one notes stem direction.
           //If we are sharing a line and in the same voice, only then offset one note
           const lineDiff = Math.abs(noteU.line - noteL.line);
-          //if (noteU.note.glyph.stem && noteL.note.glyph.stem) { // skip this condition: whole notes also relevant
-          //If we have different dot values, must offset
-          //Or If we have a non-filled in mixed with a filled in notehead, must offset
-          let halfNoteCount = 0;
-          let wholeNoteCount = 0;
-          if (noteU.note.duration === "h") {
-            halfNoteCount++;
-          } else if (noteU.note.duration === "w") {
-            wholeNoteCount++;
-          }
-          if (noteL.note.duration === "h") {
-            halfNoteCount++;
-          } else if (noteL.note.duration === "w") {
-            wholeNoteCount++;
-          }
-          // only stagger/x-shift if one of the notes is whole or half note and the other isn't. (or dots different)
-          let staggerConditions = halfNoteCount === 1 || wholeNoteCount === 1 || noteU.note.dots !== noteL.note.dots;
-          if (stagger_same_whole_notes) { // controlled by EngravingRules.StaggerSameWholeNotes. see declaration above
-            staggerConditions ||= wholeNoteCount === 2;
-          }
-          if (lineDiff === 0 && staggerConditions) {
+          // Stagger (x-shift) only if the two notes share a line but can't overlap as a
+          // unison - i.e. their notehead shapes or dots differ (see mergeableUnison).
+          if (lineDiff === 0 && !mergeableUnison(noteU, noteL, stagger_same_whole_notes)) {
             noteL.note.setXShift(xShift);
             if (noteU.note.dots > 0) {
               let foundDots = 0;
@@ -334,10 +317,14 @@ export class StaveNote extends StemmableNote {
     // the two-voice path. This takes priority even when the middle voice also sits close to
     // the other neighbour (e.g. a left-hand inner voice in unison with the upper voice while
     // a separate bass note sits a sixth below). Only stagger a genuine collision where the
-    // middle voice isn't a unison with either neighbour.
-    const isUnisonWithNeighbour =
-      (intersectsUpper && unisonMergeable(noteU, noteM)) ||
-      (intersectsLower && unisonMergeable(noteM, noteL));
+    // middle voice isn't a unison with either neighbour. The extra single-notehead guard
+    // keeps this conservative for chords (the two-voice path has no such guard).
+    const middleIsSingleNotehead = noteM.note.getKeyProps().length === 1;
+    const isUnisonWithNeighbour = middleIsSingleNotehead && (
+      (intersectsUpper && noteU.note.getKeyProps().length === 1
+        && mergeableUnison(noteU, noteM, stagger_same_whole_notes)) ||
+      (intersectsLower && noteL.note.getKeyProps().length === 1
+        && mergeableUnison(noteM, noteL, stagger_same_whole_notes)));
     if (!isUnisonWithNeighbour && (intersectsUpper || intersectsLower)) {
       xShift = voiceXShift + 3;      // shift middle note right
       noteM.note.setXShift(xShift);

--- a/src/VexFlowPatch/src/stavenote.js
+++ b/src/VexFlowPatch/src/stavenote.js
@@ -329,12 +329,16 @@ export class StaveNote extends StemmableNote {
     // If middle voice intersects upper or lower voice
     const intersectsUpper = !noteU.isrest && !noteM.isrest && noteU.minLine <= noteM.maxLine + 0.5;
     const intersectsLower = !noteM.isrest && !noteL.isrest && noteM.minLine <= noteL.maxLine;
-    // A unison (same staff line) between the middle voice and the voice it
-    // "intersects" should overlap, not be staggered, just like in the two-voice
-    // path. Only shift the middle note for a genuine (non-unison) collision.
-    const upperIsUnison = intersectsUpper && unisonMergeable(noteU, noteM);
-    const lowerIsUnison = intersectsLower && unisonMergeable(noteM, noteL);
-    if ((intersectsUpper && !upperIsUnison) || (intersectsLower && !lowerIsUnison)) {
+    // If the middle voice is a unison with either neighbour, its notehead should overlap
+    // that neighbour's (same pitch -> same column) rather than be staggered, just like in
+    // the two-voice path. This takes priority even when the middle voice also sits close to
+    // the other neighbour (e.g. a left-hand inner voice in unison with the upper voice while
+    // a separate bass note sits a sixth below). Only stagger a genuine collision where the
+    // middle voice isn't a unison with either neighbour.
+    const isUnisonWithNeighbour =
+      (intersectsUpper && unisonMergeable(noteU, noteM)) ||
+      (intersectsLower && unisonMergeable(noteM, noteL));
+    if (!isUnisonWithNeighbour && (intersectsUpper || intersectsLower)) {
       xShift = voiceXShift + 3;      // shift middle note right
       noteM.note.setXShift(xShift);
     }

--- a/src/VexFlowPatch/src/stavenote.js
+++ b/src/VexFlowPatch/src/stavenote.js
@@ -48,14 +48,20 @@ function centerRest(rest, noteU, noteL) {
   rest.minLine -= delta;
 }
 
-// Whether two notes from different voices on the same staff line form a unison
-// whose noteheads can share one horizontal position (overlap) instead of being
-// staggered. Noteheads can't cleanly overlap if their shapes differ (one half/whole
-// and the other not), if their dot counts differ, or - when
-// EngravingRules.StaggerSameWholeNotes is set - for two identical whole notes.
-// Shared by the two-voice and three-voice collision paths so the same decision is
-// used in both (the divergence between them is what previously left three-voice
-// unisons staggered).
+/**
+ * Whether two notes from different voices on the same staff line form a unison
+ * whose noteheads can share one horizontal position (overlap) instead of being
+ * staggered. Noteheads can't cleanly overlap if their shapes differ (one half/whole
+ * and the other not), if their dot counts differ, or - when
+ * EngravingRules.StaggerSameWholeNotes is set - for two identical whole notes.
+ * Shared by the two-voice and three-voice collision paths so the same decision is
+ * used in both (the divergence between them is what previously left three-voice
+ * unisons staggered).
+ * @param a a notesList entry, i.e. { line, isrest, note, ... }
+ * @param b the other notesList entry
+ * @param staggerSameWholeNotes EngravingRules.StaggerSameWholeNotes: keep two identical whole notes apart
+ * @returns true if the two noteheads can share a column (overlap) as a unison
+ */
 function mergeableUnison(a, b, staggerSameWholeNotes) {
   if (a.isrest || b.isrest) return false;
   if (a.line !== b.line) return false; // not on the same staff line -> not a unison

--- a/src/VexFlowPatch/src/stavenote.js
+++ b/src/VexFlowPatch/src/stavenote.js
@@ -48,6 +48,31 @@ function centerRest(rest, noteU, noteL) {
   rest.minLine -= delta;
 }
 
+// Whether two single-notehead notes from different voices form a unison that can
+// share the same horizontal position (overlapping noteheads) instead of being
+// staggered. Mirrors the stagger conditions used in the two-voice path: a
+// notehead cannot cleanly overlap if the shapes differ (one half/whole and the
+// other not) or if the dot counts differ. Used so that a unison in a three-voice
+// stave isn't pushed apart by the generic "shift middle note" collision rule.
+function unisonMergeable(a, b) {
+  if (a.isrest || b.isrest) return false;
+  if (a.line !== b.line) return false; // not on the same staff line -> not a unison
+  let halfNoteCount = 0;
+  let wholeNoteCount = 0;
+  for (const e of [a, b]) {
+    if (e.note.duration === "h") {
+      halfNoteCount++;
+    } else if (e.note.duration === "w") {
+      wholeNoteCount++;
+    }
+  }
+  if (halfNoteCount === 1 || wholeNoteCount === 1) return false; // mismatched notehead shapes
+  if (a.note.dots !== b.note.dots) return false;
+  // only handle single noteheads, to avoid chord-stacking complications
+  if (a.note.getKeyProps().length !== 1 || b.note.getKeyProps().length !== 1) return false;
+  return true;
+}
+
 export class StaveNote extends StemmableNote {
   static get CATEGORY() { return 'stavenotes'; }
   static get STEM_UP() { return Stem.UP; }
@@ -302,8 +327,14 @@ export class StaveNote extends StemmableNote {
     }
 
     // If middle voice intersects upper or lower voice
-    if ((!noteU.isrest && !noteM.isrest && noteU.minLine <= noteM.maxLine + 0.5) ||
-      (!noteM.isrest && !noteL.isrest && noteM.minLine <= noteL.maxLine)) {
+    const intersectsUpper = !noteU.isrest && !noteM.isrest && noteU.minLine <= noteM.maxLine + 0.5;
+    const intersectsLower = !noteM.isrest && !noteL.isrest && noteM.minLine <= noteL.maxLine;
+    // A unison (same staff line) between the middle voice and the voice it
+    // "intersects" should overlap, not be staggered, just like in the two-voice
+    // path. Only shift the middle note for a genuine (non-unison) collision.
+    const upperIsUnison = intersectsUpper && unisonMergeable(noteU, noteM);
+    const lowerIsUnison = intersectsLower && unisonMergeable(noteM, noteL);
+    if ((intersectsUpper && !upperIsUnison) || (intersectsLower && !lowerIsUnison)) {
       xShift = voiceXShift + 3;      // shift middle note right
       noteM.note.setXShift(xShift);
     }

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_ThreeVoiceUnison_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_ThreeVoiceUnison_Test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import {GraphicalMusicSheet} from "../../../../src/MusicalScore/Graphical/GraphicalMusicSheet";
+import {IXmlElement} from "../../../../src/Common/FileIO/Xml";
+import {MusicSheet} from "../../../../src/MusicalScore/MusicSheet";
+import {MusicSheetReader} from "../../../../src/MusicalScore/ScoreIO/MusicSheetReader";
+import {VexFlowMusicSheetCalculator} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator";
+import {TestUtils} from "../../../Util/TestUtils";
+import {VexFlowMeasure} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowMeasure";
+import {VexFlowVoiceEntry} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry";
+import {GraphicalStaffEntry} from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
+import {expect} from "chai";
+
+describe("VexFlow Measure - Three-Voice Unison Alignment", () => {
+
+   const path: string = "test_three_voice_unison_alignment.musicxml";
+
+   function firstMeasure(): VexFlowMeasure {
+      const score: Document = TestUtils.getScore(path);
+      expect(score).to.not.be.undefined;
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      expect(partwise).to.not.be.undefined;
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+      return gms.MeasureList[0][0] as VexFlowMeasure;
+   }
+
+   // x-shift applied to a note's notehead within its ModifierContext.
+   function xShift(gve: VexFlowVoiceEntry): number {
+      return (gve.vfStaveNote as unknown as { x_shift: number }).x_shift;
+   }
+
+   function voiceEntriesAt(measure: VexFlowMeasure, timestampRealValue: number): VexFlowVoiceEntry[] {
+      const staffEntry: GraphicalStaffEntry = measure.staffEntries.find(
+         (se) => Math.abs(se.sourceStaffEntry.Timestamp.RealValue - timestampRealValue) < 1e-6);
+      expect(staffEntry, `expected a staff entry at timestamp ${timestampRealValue}`).to.not.be.undefined;
+      return staffEntry.graphicalVoiceEntries as VexFlowVoiceEntry[];
+   }
+
+   it("Should not stagger a unison between two voices in a three-voice stave", (done: Mocha.Done) => {
+      const measure: VexFlowMeasure = firstMeasure();
+      // Beat 1: voices 1 and 2 both play G4 (unison); voice 3 is a G3 far below.
+      const gves: VexFlowVoiceEntry[] = voiceEntriesAt(measure, 0);
+      expect(gves.length).to.equal(3, "beat 1 should have three voices");
+      for (const gve of gves) {
+         expect(xShift(gve)).to.equal(0,
+            "unison/non-colliding notes should share their horizontal position (no stagger x-shift)");
+      }
+      done();
+   });
+
+   it("Should still stagger a genuine second-interval collision in a three-voice stave", (done: Mocha.Done) => {
+      const measure: VexFlowMeasure = firstMeasure();
+      // Beat 2: voice 1 = A4, voice 2 = G4 (a second below) -> genuine collision.
+      const gves: VexFlowVoiceEntry[] = voiceEntriesAt(measure, 0.25);
+      const middle: VexFlowVoiceEntry = gves.find(
+         (g) => g.parentVoiceEntry.ParentVoice.VoiceId === 2);
+      expect(middle, "voice 2 should be present on beat 2").to.not.be.undefined;
+      expect(xShift(middle)).to.be.greaterThan(0,
+         "a second-interval collision must still be staggered (noteheads cannot overlap)");
+      done();
+   });
+
+});

--- a/test/data/test_three_voice_unison_alignment.musicxml
+++ b/test/data/test_three_voice_unison_alignment.musicxml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <!--
+    Regression sample for three-voice unison alignment.
+    A single staff with three voices. On beat 1, voices 1 and 2 play the same
+    pitch (G4) - a unison that should share one horizontal position (overlapping
+    noteheads), not be staggered. On beat 2, voice 1 (A4) and voice 2 (G4) are a
+    second apart - a genuine collision that must still be staggered.
+  -->
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+
+      <!-- Voice 1 (upper) -->
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type><stem>up</stem></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type><stem>up</stem></note>
+
+      <backup><duration>2</duration></backup>
+
+      <!-- Voice 2 (middle) -->
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><voice>2</voice><type>quarter</type><stem>down</stem></note>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>1</duration><voice>2</voice><type>quarter</type><stem>down</stem></note>
+
+      <backup><duration>2</duration></backup>
+
+      <!-- Voice 3 (lower): an octave below, far enough not to collide with the
+           middle voice's stem, so the only collision on beat 1 is the unison. -->
+      <note><pitch><step>G</step><octave>3</octave></pitch><duration>1</duration><voice>3</voice><type>quarter</type><stem>down</stem></note>
+      <note><pitch><step>G</step><octave>3</octave></pitch><duration>1</duration><voice>3</voice><type>quarter</type><stem>down</stem></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/data/test_three_voice_unison_alignment.musicxml
+++ b/test/data/test_three_voice_unison_alignment.musicxml
@@ -3,10 +3,13 @@
 <score-partwise version="3.1">
   <!--
     Regression sample for three-voice unison alignment.
-    A single staff with three voices. On beat 1, voices 1 and 2 play the same
-    pitch (G4) - a unison that should share one horizontal position (overlapping
-    noteheads), not be staggered. On beat 2, voice 1 (A4) and voice 2 (G4) are a
-    second apart - a genuine collision that must still be staggered.
+    A single staff with three voices. Voice 3 (B3) sits a sixth below the middle
+    voice, close enough that the middle voice's stem reaches it - so the generic
+    "shift middle note" collision rule would fire. On beat 1, voices 1 and 2 play
+    the same pitch (G4): that unison should still share one horizontal position
+    (overlapping noteheads), the unison taking priority over the nearby bass voice.
+    On beat 2, voice 1 (A4) and voice 2 (G4) are a second apart - a genuine
+    collision that must still be staggered.
   -->
   <part-list>
     <score-part id="P1"><part-name>Music</part-name></score-part>
@@ -32,10 +35,10 @@
 
       <backup><duration>2</duration></backup>
 
-      <!-- Voice 3 (lower): an octave below, far enough not to collide with the
-           middle voice's stem, so the only collision on beat 1 is the unison. -->
-      <note><pitch><step>G</step><octave>3</octave></pitch><duration>1</duration><voice>3</voice><type>quarter</type><stem>down</stem></note>
-      <note><pitch><step>G</step><octave>3</octave></pitch><duration>1</duration><voice>3</voice><type>quarter</type><stem>down</stem></note>
+      <!-- Voice 3 (lower): a sixth below the middle voice, close enough that the
+           middle voice's stem reaches it (so the generic collision rule fires). -->
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>1</duration><voice>3</voice><type>quarter</type><stem>down</stem></note>
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>1</duration><voice>3</voice><type>quarter</type><stem>down</stem></note>
     </measure>
   </part>
 </score-partwise>


### PR DESCRIPTION
## Problem

In a three-voice stave, when two of the voices play the **same pitch** at the same time (a unison), the noteheads are pushed apart horizontally instead of sharing one position. Example: a left-hand passage where an inner (triplet) voice and a tied bass voice both land on the same G — they render staggered, as if they were different notes.

The two-voice path already handles this correctly (it does **not** stagger a same-shape unison). The three-voice path did not.

## Cause

`ModifierContext.formatNotes` (VexFlowPatch `stavenote.js`) shifts the middle voice right whenever it "intersects" the upper or lower voice:

```js
// If middle voice intersects upper or lower voice
if ((!noteU.isrest && !noteM.isrest && noteU.minLine <= noteM.maxLine + 0.5) ||
    (!noteM.isrest && !noteL.isrest && noteM.minLine <= noteL.maxLine)) {
  xShift = voiceXShift + 3;      // shift middle note right
  noteM.note.setXShift(xShift);
}
```

A unison makes the middle voice share a staff line with the upper (or lower) voice, so this generic collision rule fires and staggers it — even though identical pitches should overlap.

## Fix

Only shift the middle note for a **genuine** collision. If the intersection is a *mergeable unison*, leave the noteheads overlapping. "Mergeable" mirrors the existing two-voice stagger conditions: same staff line, single noteheads, matching notehead shape (not one half/whole and the other not), and matching dot count. Genuine collisions (e.g. a second) are still staggered.

## Tests

- New sample `test/data/test_three_voice_unison_alignment.musicxml`: three voices where beat 1 is a unison (voices 1 & 2 on G4, voice 3 an octave below) and beat 2 is a second-interval collision (A4 vs G4).
- New `VexFlowMeasure_ThreeVoiceUnison_Test.ts`:
  - the beat-1 unison is not staggered (all notes `x_shift === 0`);
  - the beat-2 second is still staggered (`x_shift > 0`).

Full suite passes locally (197 tests). The change is scoped to exact, mergeable unisons in a three-voice ModifierContext, so non-unison collisions are byte-for-byte unchanged; visual regression may show intended improvements on samples that contain three-voice unisons.