### PR TITLE
Feat: Implement Tremolo between notes

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -54,6 +54,7 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
             "OSMD Function Test - Tabulature MultiBends": "OSMD_Function_Test_Tablature_Multibends.musicxml",
             "OSMD Function Test - Tabulature All Effects": "OSMD_Function_Test_Tablature_Alleffects.musicxml",
             "OSMD Function Test - Tremolo": "OSMD_Function_Test_Tremolo_2bars.musicxml",
+            "OSMD Function Test - Tremolo between two notes": "test_tremolo_between_notes.musicxml",
             "OSMD Function Test - Labels": "OSMD_Function_Test_Labels.musicxml",
             "OSMD Function Test - High Slur Test": "test_slurs_highNotes.musicxml",
             "OSMD Function Test - Auto Multirest Measures Single Staff": "Test_Auto_Multirest_1.musicxml",

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -362,6 +362,10 @@ export class EngravingRules {
     public TremoloBetweenNotesMaxLengthFactor: number;
     /** Maximum vertical rise/fall (slant) of the strokes of a tremolo between two notes, in units. */
     public TremoloBetweenNotesMaxSlant: number;
+    /** Vertical padding between the strokes of a tremolo between two notes and the notehead (edge), in units.
+     * Stems are lengthened where necessary to make room for the strokes (e.g. for 4+ strokes),
+     * as recommended by Gould (Behind Bars). */
+    public TremoloBetweenNotesYPadding: number;
     public StaffLineWidth: number;
     public StaffLineColor: string;
     public LedgerLineWidth: number;
@@ -872,6 +876,7 @@ export class EngravingRules {
         this.TremoloBetweenNotesXPadding = 0.55;
         this.TremoloBetweenNotesMaxLengthFactor = 0.667;
         this.TremoloBetweenNotesMaxSlant = 1.0;
+        this.TremoloBetweenNotesYPadding = 0.45;
         this.StemWidth = 0.15; // originally 0.13. vexflow default 0.15. should probably be adjusted when increasing vexFlowDefaultNotationFontScale,
         this.StaffLineWidth = 0.10; // originally 0.12, but this will be pixels in Vexflow (*10).
         this.StaffLineColor = undefined; // if undefined, vexflow default (grey). not a width, but affects visual line clarity.

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -350,6 +350,18 @@ export class EngravingRules {
     public TremoloStrokeScale: number;
     public TremoloYSpacingScale: number;
     public TremoloBuzzRollThickness: number;
+    /** Vertical thickness of one stroke ("tremolo beam") of a tremolo between two notes, in units (1 unit = staff space). */
+    public TremoloBetweenNotesStrokeThickness: number;
+    /** Vertical gap between the strokes of a tremolo between two notes, in units. */
+    public TremoloBetweenNotesStrokeGap: number;
+    /** Minimum horizontal padding between the strokes of a tremolo between two notes and the stems (or noteheads for stemless notes), in units. */
+    public TremoloBetweenNotesXPadding: number;
+    /** Maximum length of the strokes of a tremolo between two notes,
+     * as a fraction of the space between the stems (or noteheads for stemless notes).
+     * (Gould: the strokes span about two thirds of the space between the notes) */
+    public TremoloBetweenNotesMaxLengthFactor: number;
+    /** Maximum vertical rise/fall (slant) of the strokes of a tremolo between two notes, in units. */
+    public TremoloBetweenNotesMaxSlant: number;
     public StaffLineWidth: number;
     public StaffLineColor: string;
     public LedgerLineWidth: number;
@@ -855,6 +867,11 @@ export class EngravingRules {
         this.TremoloStrokeScale = 1;
         this.TremoloYSpacingScale = 1;
         this.TremoloBuzzRollThickness = 0.25;
+        this.TremoloBetweenNotesStrokeThickness = 0.4; // like beam thickness
+        this.TremoloBetweenNotesStrokeGap = 0.4;
+        this.TremoloBetweenNotesXPadding = 0.55;
+        this.TremoloBetweenNotesMaxLengthFactor = 0.667;
+        this.TremoloBetweenNotesMaxSlant = 1.0;
         this.StemWidth = 0.15; // originally 0.13. vexflow default 0.15. should probably be adjusted when increasing vexFlowDefaultNotationFontScale,
         this.StaffLineWidth = 0.10; // originally 0.12, but this will be pixels in Vexflow (*10).
         this.StaffLineColor = undefined; // if undefined, vexflow default (grey). not a width, but affects visual line clarity.

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -358,7 +358,7 @@ export class EngravingRules {
     public TremoloBetweenNotesXPadding: number;
     /** Maximum length of the strokes of a tremolo between two notes,
      * as a fraction of the space between the stems (or noteheads for stemless notes).
-     * (Gould: the strokes span about two thirds of the space between the notes) */
+     * (Gould - Behind Bars: the strokes span about two thirds of the space between the notes) */
     public TremoloBetweenNotesMaxLengthFactor: number;
     /** Maximum vertical rise/fall (slant) of the strokes of a tremolo between two notes, in units. */
     public TremoloBetweenNotesMaxSlant: number;
@@ -874,7 +874,7 @@ export class EngravingRules {
         this.TremoloBetweenNotesStrokeThickness = 0.4; // like beam thickness
         this.TremoloBetweenNotesStrokeGap = 0.4;
         this.TremoloBetweenNotesXPadding = 0.55;
-        this.TremoloBetweenNotesMaxLengthFactor = 0.667;
+        this.TremoloBetweenNotesMaxLengthFactor = 0.667; // Gould (Behind Bars) recommends the tremolo strokes to take up 2/3 of the space between notes
         this.TremoloBetweenNotesMaxSlant = 1.0;
         this.TremoloBetweenNotesYPadding = 0.45;
         this.StemWidth = 0.15; // originally 0.13. vexflow default 0.15. should probably be adjusted when increasing vexFlowDefaultNotationFontScale,

--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -283,6 +283,54 @@ export class SkyBottomLineCalculator {
     }
 
     /**
+     * This method merges a line (e.g. the top edge of a tremolo stroke between two notes) into the SkyLine,
+     * updating the SkyLine only where the line lies above it (preserving more extreme existing values),
+     * unlike updateSkyLineWithWedge, which overwrites the existing values.
+     * @param start Start point of the line, relative to the staffline (like the SkyLine values), in units
+     * @param end End point of the line
+     */
+    public mergeSkyLineWithLine(start: PointF2D, end: PointF2D): void {
+        const lineLength: number = end.x - start.x;
+        if (lineLength <= 0 || !this.SkyLine?.length) {
+            return;
+        }
+        const startIndex: number = Math.max(0, Math.floor(start.x * this.SamplingUnit));
+        const endIndex: number = Math.min(this.SkyLine.length, Math.ceil(end.x * this.SamplingUnit));
+        const slope: number = (end.y - start.y) / lineLength;
+        for (let i: number = startIndex; i < endIndex; i++) {
+            const lineX: number = Math.min(Math.max(i / this.SamplingUnit - start.x, 0), lineLength); // clamp to line segment
+            const lineY: number = start.y + slope * lineX;
+            if (lineY < this.SkyLine[i]) {
+                this.SkyLine[i] = lineY;
+            }
+        }
+    }
+
+    /**
+     * This method merges a line (e.g. the bottom edge of a tremolo stroke between two notes) into the BottomLine,
+     * updating the BottomLine only where the line lies below it (preserving more extreme existing values),
+     * unlike updateBottomLineWithWedge, which overwrites the existing values.
+     * @param start Start point of the line, relative to the staffline (like the BottomLine values), in units
+     * @param end End point of the line
+     */
+    public mergeBottomLineWithLine(start: PointF2D, end: PointF2D): void {
+        const lineLength: number = end.x - start.x;
+        if (lineLength <= 0 || !this.BottomLine?.length) {
+            return;
+        }
+        const startIndex: number = Math.max(0, Math.floor(start.x * this.SamplingUnit));
+        const endIndex: number = Math.min(this.BottomLine.length, Math.ceil(end.x * this.SamplingUnit));
+        const slope: number = (end.y - start.y) / lineLength;
+        for (let i: number = startIndex; i < endIndex; i++) {
+            const lineX: number = Math.min(Math.max(i / this.SamplingUnit - start.x, 0), lineLength); // clamp to line segment
+            const lineY: number = start.y + slope * lineX;
+            if (lineY > this.BottomLine[i]) {
+                this.BottomLine[i] = lineY;
+            }
+        }
+    }
+
+    /**
      * This method updates the SkyLine for a given range with a given value
      * //param  to update the SkyLine for
      * @param startIndex Start index of the range

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -178,7 +178,13 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         return undefined;
     }
 
-    public renderPath(points: PointF2D[], fill: boolean = true, id?: string): Node {
+    public renderPath(points: PointF2D[], fill: boolean = true, id?: string, color?: string): Node {
+        const oldFillStyle: string | CanvasGradient | CanvasPattern = this.CanvasRenderingCtx.fillStyle;
+        const oldStrokeStyle: string | CanvasGradient | CanvasPattern = this.CanvasRenderingCtx.strokeStyle;
+        if (color) {
+            this.CanvasRenderingCtx.fillStyle = color;
+            this.CanvasRenderingCtx.strokeStyle = color;
+        }
         this.ctx.beginPath();
         let currentPoint: PointF2D;
         for (const point of points) {
@@ -196,6 +202,8 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         } else {
             this.ctx.stroke(); // just trace outline, don't fill inner area
         }
+        this.CanvasRenderingCtx.fillStyle = oldFillStyle;
+        this.CanvasRenderingCtx.strokeStyle = oldStrokeStyle;
         return undefined;
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/SvgVexFlowBackend.ts
@@ -223,8 +223,13 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         return node;
     }
 
-    public renderPath(points: PointF2D[], fill: boolean = true, id?: string): Node {
+    public renderPath(points: PointF2D[], fill: boolean = true, id?: string, color?: string): Node {
+        this.ctx.save();
         const node: Node = this.ctx.openGroup("path", id);
+        if (color) {
+            this.ctx.attributes.fill = color;
+            this.ctx.attributes.stroke = color;
+        }
         this.ctx.beginPath();
         let currentPoint: PointF2D;
         for (const point of points) {
@@ -244,6 +249,7 @@ export class SvgVexFlowBackend extends VexFlowBackend {
         }
         this.ctx.stroke();
         this.ctx.closeGroup();
+        this.ctx.restore();
         return node;
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -109,7 +109,7 @@ public abstract getContext(): Vex.IRenderContext;
 
   public abstract renderCurve(points: PointF2D[], isSlur?: boolean, startNote?: VexFlowGraphicalNote): Node;
 
-  public abstract renderPath(points: PointF2D[], fill: boolean, id?: string): Node;
+  public abstract renderPath(points: PointF2D[], fill: boolean, id?: string, color?: string): Node;
 
   public abstract getVexflowBackendType(): VF.Renderer.Backends;
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -24,7 +24,7 @@ import { OrnamentEnum, OrnamentContainer } from "../../VoiceData/OrnamentContain
 import { Notehead, NoteHeadShape } from "../../VoiceData/Notehead";
 import { unitInPixels } from "./VexFlowMusicSheetDrawer";
 import { EngravingRules } from "../EngravingRules";
-import { Note } from "../../../MusicalScore/VoiceData/Note";
+import { Note, TremoloInfo } from "../../../MusicalScore/VoiceData/Note";
 import StaveNote = VF.StaveNote;
 import { ArpeggioType } from "../../VoiceData/Arpeggio";
 import { TabNote } from "../../VoiceData/TabNote";
@@ -691,9 +691,12 @@ export class VexFlowConverter {
                 vfnote.addAccidental(i, new VF.Accidental(accidentals[i])); // normal accidental
             }
 
-            // add Tremolo strokes (only single note tremolos for now, Vexflow doesn't have beams for two-note tremolos yet)
-            const tremoloStrokes: number = notes[i].sourceNote.TremoloStrokes;
-            if (tremoloStrokes > 0) {
+            // add Tremolo strokes for single note tremolos
+            //   (strokes for tremolos between two notes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes())
+            const tremoloInfo: TremoloInfo = notes[i].sourceNote.TremoloInfo;
+            const tremoloStrokes: number = tremoloInfo?.tremoloStrokes;
+            const isTremoloBetweenNotes: boolean = tremoloInfo?.tremoloBetweenNotesStart || tremoloInfo?.tremoloBetweenNotesStop;
+            if (tremoloStrokes > 0 && !isTremoloBetweenNotes) {
                 const tremolo: VF.Tremolo = new VF.Tremolo(tremoloStrokes);
                 (tremolo as any).extra_stroke_scale = rules.TremoloStrokeScale;
                 (tremolo as any).y_spacing_scale = rules.TremoloYSpacingScale;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowConverter.ts
@@ -24,7 +24,7 @@ import { OrnamentEnum, OrnamentContainer } from "../../VoiceData/OrnamentContain
 import { Notehead, NoteHeadShape } from "../../VoiceData/Notehead";
 import { unitInPixels } from "./VexFlowMusicSheetDrawer";
 import { EngravingRules } from "../EngravingRules";
-import { Note, TremoloInfo } from "../../../MusicalScore/VoiceData/Note";
+import { Note, TremoloBetweenNotes, TremoloInfo } from "../../../MusicalScore/VoiceData/Note";
 import StaveNote = VF.StaveNote;
 import { ArpeggioType } from "../../VoiceData/Arpeggio";
 import { TabNote } from "../../VoiceData/TabNote";
@@ -701,6 +701,26 @@ export class VexFlowConverter {
                 (tremolo as any).extra_stroke_scale = rules.TremoloStrokeScale;
                 (tremolo as any).y_spacing_scale = rules.TremoloYSpacingScale;
                 vfnote.addModifier(i, tremolo);
+            }
+        }
+
+        // tremolo between two notes: lengthen the stem if necessary to make room for the strokes (e.g. for 4+ strokes),
+        //   as recommended by Gould (Behind Bars). The strokes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes().
+        let tremoloBetweenNotes: TremoloBetweenNotes;
+        for (const note of notes) {
+            if (note.sourceNote.TremoloInfo?.tremoloBetweenNotes) {
+                tremoloBetweenNotes = note.sourceNote.TremoloInfo.tremoloBetweenNotes;
+                break;
+            }
+        }
+        if (tremoloBetweenNotes?.strokes > 0 && !gve.parentVoiceEntry.IsGrace && vfnote.hasStem()) {
+            const strokesHeight: number = tremoloBetweenNotes.strokes * rules.TremoloBetweenNotesStrokeThickness +
+                (tremoloBetweenNotes.strokes - 1) * rules.TremoloBetweenNotesStrokeGap;
+            // strokes + padding towards notehead and stem tip + half notehead height (the strokes region starts at the notehead's edge):
+            const wantedStemLengthPx: number = (strokesHeight + 2 * rules.TremoloBetweenNotesYPadding + 0.5) * unitInPixels;
+            if (wantedStemLengthPx > (VF.Stem as any).HEIGHT) { // default stem length (35px = 3.5 units)
+                (vfnote as any).setStemLength(wantedStemLengthPx); // sets vfnote.stemExtensionOverride
+                vfnote.getStem()?.setExtension(vfnote.getStemExtension()); // apply to the already built stem
             }
         }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -976,7 +976,8 @@ export class VexFlowMeasure extends GraphicalMeasure {
                         }
                     }
                     if (beamHasQuarterNoteOrLonger) {
-                        log.debug("Beam between note >= quarter, likely tremolo, currently unsupported. continuing.");
+                        log.debug("Beam between notes >= quarter, likely a tremolo between two notes. Not creating a beam." +
+                            " (tremolo strokes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes instead)");
                         continue;
                     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -35,6 +35,8 @@ import { VexFlowGlissando } from "./VexFlowGlissando";
 import { VexFlowGraphicalNote } from "./VexFlowGraphicalNote";
 import { SvgVexFlowBackend } from "./SvgVexFlowBackend";
 import { VexFlowVibratoBracket } from "./VexFlowVibratoBracket";
+import { TremoloBetweenNotes } from "../../VoiceData/Note";
+import { SkyBottomLineCalculator } from "../SkyBottomLineCalculator";
 
 /**
  * This is a global constant which denotes the height in pixels of the space between two lines of the stave
@@ -233,6 +235,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
             this.drawStaffEntry(staffEntry);
             newBuzzRollId = this.drawBuzzRolls(staffEntry, newBuzzRollId);
         }
+        this.drawTremolosBetweenNotes(measure);
     }
 
     protected drawBuzzRolls(staffEntry: GraphicalStaffEntry, newBuzzRollId): number {
@@ -309,6 +312,151 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         return newBuzzRollId;
     }
 
+    /** Draws the strokes ("tremolo beams") of tremolos between two notes in this measure,
+     *  e.g. two alternating half notes with 3 strokes between them, often seen in orchestral string parts.
+     *  (Vexflow doesn't support these tremolos, so we draw them ourselves here.)
+     *  Also updates the SkyLine/BottomLine where the strokes exceed it.
+     */
+    protected drawTremolosBetweenNotes(measure: VexFlowMeasure): void {
+        if (measure.isTabMeasure) {
+            return;
+        }
+        let strokeId: number = 0;
+        for (const staffEntry of measure.staffEntries) {
+            for (const gve of staffEntry.graphicalVoiceEntries) {
+                for (const gNote of gve.notes) {
+                    const tremolo: TremoloBetweenNotes = gNote.sourceNote.TremoloInfo?.tremoloBetweenNotes;
+                    if (!tremolo || tremolo.stopNote !== gNote.sourceNote || !(tremolo.strokes > 0)) {
+                        continue;
+                        // only draw when reaching the stop note (second note): at this point, both notes have been drawn
+                        //   and have their final positions, even if the start note is in a previously drawn measure.
+                    }
+                    try {
+                        strokeId = this.drawTremoloBetweenTwoNotes(tremolo, gNote as VexFlowGraphicalNote, measure, strokeId);
+                    } catch (ex) {
+                        log.warn("VexFlowMusicSheetDrawer.drawTremolosBetweenNotes", ex);
+                    }
+                }
+            }
+        }
+    }
+
+    /** Draws the strokes between the two notes of a TremoloBetweenNotes (see drawTremolosBetweenNotes). */
+    private drawTremoloBetweenTwoNotes(tremolo: TremoloBetweenNotes, stopGNote: VexFlowGraphicalNote,
+                                       measure: VexFlowMeasure, strokeId: number): number {
+        if (tremolo.startNote.isRest() || tremolo.stopNote.isRest()) {
+            return strokeId; // a tremolo between a note and a rest is invalid
+        }
+        const startGNote: VexFlowGraphicalNote = this.rules.GNote(tremolo.startNote) as VexFlowGraphicalNote;
+        if (!startGNote?.vfnote || !stopGNote.vfnote) {
+            return strokeId; // e.g. note not rendered (multiple rest measure)
+        }
+        const staffLine: StaffLine = measure.ParentStaffLine;
+        if (startGNote.parentVoiceEntry.parentStaffEntry.parentMeasure.ParentStaffLine !== staffLine) {
+            log.debug("VexFlowMusicSheetDrawer.drawTremoloBetweenTwoNotes: start and stop note are not in the same staffline " +
+                "(e.g. tremolo across a system break), not drawing tremolo strokes.");
+            return strokeId;
+        }
+        const vfStartNote: VF.StemmableNote = startGNote.vfnote[0];
+        const vfStopNote: VF.StemmableNote = stopGNote.vfnote[0];
+        if (vfStartNote.getAttribute("type") === "GhostNote" || vfStopNote.getAttribute("type") === "GhostNote") {
+            return strokeId; // invisible notes (print-object="no")
+        }
+
+        // calculate the anchor points of the line on which the strokes are centered (in pixels):
+        let startXPx: number;
+        let stopXPx: number;
+        let startYPx: number;
+        let stopYPx: number;
+        const startNoteHasStem: boolean = (vfStartNote as any).hasStem?.() && !!vfStartNote.getStem();
+        const stopNoteHasStem: boolean = (vfStopNote as any).hasStem?.() && !!vfStopNote.getStem();
+        if (startNoteHasStem && stopNoteHasStem && vfStartNote.getStemDirection() === vfStopNote.getStemDirection()) {
+            // anchor the strokes between the stems, in the middle of the "free" stem region between (inner) notehead and stem tip
+            const direction: number = vfStartNote.getStemDirection(); // 1: up, -1: down
+            startXPx = vfStartNote.getStemX();
+            stopXPx = vfStopNote.getStemX();
+            const startYs: number[] = vfStartNote.getYs();
+            const stopYs: number[] = vfStopNote.getYs();
+            // y of the notehead the free stem region begins at (for chords, the notehead closest to the stem tip):
+            const startInnerNoteheadY: number = direction === 1 ? Math.min(...startYs) : Math.max(...startYs);
+            const stopInnerNoteheadY: number = direction === 1 ? Math.min(...stopYs) : Math.max(...stopYs);
+            // measure the free stem region from the notehead's outer edge (~0.5 units from its center),
+            //   so that the strokes get equal visual clearance from notehead and stem tip:
+            const noteheadEdgeOffsetPx: number = direction * 0.5 * unitInPixels;
+            startYPx = (vfStartNote.getStemExtents().topY + startInnerNoteheadY - noteheadEdgeOffsetPx) / 2;
+            stopYPx = (vfStopNote.getStemExtents().topY + stopInnerNoteheadY - noteheadEdgeOffsetPx) / 2;
+        } else {
+            // stemless notes (e.g. whole notes) or opposite stem directions: anchor the strokes between the noteheads
+            const startBoundingBox: VF.BoundingBox = vfStartNote.getBoundingBox();
+            const stopBoundingBox: VF.BoundingBox = vfStopNote.getBoundingBox();
+            startXPx = startBoundingBox.getX() + startBoundingBox.getW();
+            stopXPx = stopBoundingBox.getX(); // starts at the leftmost modifier, so the strokes also avoid e.g. accidentals
+            const startNoteheadBounds: {y_top: number, y_bottom: number} = (vfStartNote as any).getNoteHeadBounds();
+            const stopNoteheadBounds: {y_top: number, y_bottom: number} = (vfStopNote as any).getNoteHeadBounds();
+            startYPx = (startNoteheadBounds.y_top + startNoteheadBounds.y_bottom) / 2;
+            stopYPx = (stopNoteheadBounds.y_top + stopNoteheadBounds.y_bottom) / 2;
+        }
+
+        // horizontal start/end of the strokes (in units), centered between the stems (or noteheads):
+        const leftX: number = startXPx / unitInPixels;
+        const rightX: number = stopXPx / unitInPixels;
+        const availableSpace: number = rightX - leftX;
+        let strokeLength: number = Math.min(
+            availableSpace - 2 * this.rules.TremoloBetweenNotesXPadding,
+            availableSpace * this.rules.TremoloBetweenNotesMaxLengthFactor);
+        const minimumStrokeLength: number = 1.0;
+        strokeLength = Math.max(strokeLength, Math.min(minimumStrokeLength, availableSpace - 0.2)); // tight layout: allow less padding
+        if (strokeLength < 0.5) {
+            log.debug("VexFlowMusicSheetDrawer.drawTremoloBetweenTwoNotes: not enough horizontal space to draw tremolo strokes.");
+            return strokeId;
+        }
+        const xCenter: number = (leftX + rightX) / 2;
+        const startX: number = xCenter - strokeLength / 2;
+        const stopX: number = xCenter + strokeLength / 2;
+
+        // vertical center of the strokes at start and stop (in units), with the slant (vertical rise/fall) limited:
+        const yMiddle: number = (startYPx + stopYPx) / 2 / unitInPixels;
+        let slant: number = (stopYPx - startYPx) / unitInPixels;
+        const maxSlant: number = this.rules.TremoloBetweenNotesMaxSlant;
+        if (Math.abs(slant) > maxSlant) {
+            slant = Math.sign(slant) * maxSlant;
+        }
+        const startY: number = yMiddle - slant / 2;
+        const stopY: number = yMiddle + slant / 2;
+
+        // draw the strokes as parallelograms (like beams), stacked vertically around the center line:
+        const strokeThickness: number = this.rules.TremoloBetweenNotesStrokeThickness;
+        const strokePeriod: number = strokeThickness + this.rules.TremoloBetweenNotesStrokeGap;
+        const totalStrokesHeight: number = tremolo.strokes * strokeThickness + (tremolo.strokes - 1) * this.rules.TremoloBetweenNotesStrokeGap;
+        const color: string = this.rules.DefaultColorMusic;
+        for (let strokeIndex: number = 0; strokeIndex < tremolo.strokes; strokeIndex++) {
+            const strokeStartTopY: number = startY - totalStrokesHeight / 2 + strokeIndex * strokePeriod;
+            const strokeStopTopY: number = stopY - totalStrokesHeight / 2 + strokeIndex * strokePeriod;
+            const strokePoints: PointF2D[] = [
+                new PointF2D(startX, strokeStartTopY),
+                new PointF2D(stopX, strokeStopTopY),
+                new PointF2D(stopX, strokeStopTopY + strokeThickness),
+                new PointF2D(startX, strokeStartTopY + strokeThickness),
+                new PointF2D(startX, strokeStartTopY)
+            ];
+            const id: string = `tremoloBetweenNotes-${measure.MeasureNumber}-${measure.ParentStaff.Id}-${strokeId}`;
+            this.DrawPath(strokePoints, stopGNote.ParentMusicPage, true, id, color);
+            strokeId++;
+        }
+
+        // update SkyLine/BottomLine with the outer edges of the strokes
+        //   (calculated geometrically, much cheaper than re-doing the pixel-based skyline calculation):
+        const skyBottomLineCalculator: SkyBottomLineCalculator = staffLine.SkyBottomLineCalculator;
+        const staffLineAbsolute: PointF2D = staffLine.PositionAndShape.AbsolutePosition;
+        skyBottomLineCalculator.mergeSkyLineWithLine(
+            new PointF2D(startX - staffLineAbsolute.x, startY - totalStrokesHeight / 2 - staffLineAbsolute.y),
+            new PointF2D(stopX - staffLineAbsolute.x, stopY - totalStrokesHeight / 2 - staffLineAbsolute.y));
+        skyBottomLineCalculator.mergeBottomLineWithLine(
+            new PointF2D(startX - staffLineAbsolute.x, startY + totalStrokesHeight / 2 - staffLineAbsolute.y),
+            new PointF2D(stopX - staffLineAbsolute.x, stopY + totalStrokesHeight / 2 - staffLineAbsolute.y));
+        return strokeId;
+    }
+
     // private drawPixel(coord: PointF2D): void {
     //     coord = this.applyScreenTransformation(coord);
     //     const ctx: any = this.backend.getContext();
@@ -355,7 +503,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     }
 
     public DrawPath(inputPoints: PointF2D[], musicPage: GraphicalMusicPage,
-        fill: boolean = true, id?: string): Node {
+        fill: boolean = true, id?: string, color?: string): Node {
         const musicPageIndex: number = musicPage.PageNumber - 1;
         const backendToUse: VexFlowBackend = this.backends[musicPageIndex];
 
@@ -363,7 +511,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         for (const inputPoint of inputPoints) {
             transformedPoints.push(this.applyScreenTransformation(inputPoint));
         }
-        return backendToUse.renderPath(transformedPoints, fill, id);
+        return backendToUse.renderPath(transformedPoints, fill, id, color);
     }
 
     protected drawSkyLine(staffline: StaffLine): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -363,11 +363,23 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
             return strokeId; // invisible notes (print-object="no")
         }
 
+        // stroke dimensions (in units):
+        const strokeThickness: number = this.rules.TremoloBetweenNotesStrokeThickness;
+        const strokePeriod: number = strokeThickness + this.rules.TremoloBetweenNotesStrokeGap;
+        const totalStrokesHeight: number = tremolo.strokes * strokeThickness + (tremolo.strokes - 1) * this.rules.TremoloBetweenNotesStrokeGap;
+        const yPadding: number = this.rules.TremoloBetweenNotesYPadding;
+
         // calculate the anchor points of the line on which the strokes are centered (in pixels):
         let startXPx: number;
         let stopXPx: number;
         let startYPx: number;
         let stopYPx: number;
+        // allowed y range for the stroke group center at each note (in units), so that the strokes
+        //   keep their distance from the noteheads and don't exceed the stem tips (used for stemmed notes):
+        let startCenterMinY: number = -Infinity;
+        let startCenterMaxY: number = Infinity;
+        let stopCenterMinY: number = -Infinity;
+        let stopCenterMaxY: number = Infinity;
         const startNoteHasStem: boolean = (vfStartNote as any).hasStem?.() && !!vfStartNote.getStem();
         const stopNoteHasStem: boolean = (vfStopNote as any).hasStem?.() && !!vfStopNote.getStem();
         if (startNoteHasStem && stopNoteHasStem && vfStartNote.getStemDirection() === vfStopNote.getStemDirection()) {
@@ -383,8 +395,23 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
             // measure the free stem region from the notehead's outer edge (~0.5 units from its center),
             //   so that the strokes get equal visual clearance from notehead and stem tip:
             const noteheadEdgeOffsetPx: number = direction * 0.5 * unitInPixels;
-            startYPx = (vfStartNote.getStemExtents().topY + startInnerNoteheadY - noteheadEdgeOffsetPx) / 2;
-            stopYPx = (vfStopNote.getStemExtents().topY + stopInnerNoteheadY - noteheadEdgeOffsetPx) / 2;
+            const startTipY: number = vfStartNote.getStemExtents().topY / unitInPixels;
+            const stopTipY: number = vfStopNote.getStemExtents().topY / unitInPixels;
+            const startNoteheadEdgeY: number = (startInnerNoteheadY - noteheadEdgeOffsetPx) / unitInPixels;
+            const stopNoteheadEdgeY: number = (stopInnerNoteheadY - noteheadEdgeOffsetPx) / unitInPixels;
+            startYPx = (startTipY + startNoteheadEdgeY) / 2 * unitInPixels;
+            stopYPx = (stopTipY + stopNoteheadEdgeY) / 2 * unitInPixels;
+            if (direction === 1) { // stems up: tips above the noteheads (lower y)
+                startCenterMinY = startTipY + totalStrokesHeight / 2; // group must not exceed the stem tip
+                startCenterMaxY = startNoteheadEdgeY - yPadding - totalStrokesHeight / 2; // group must keep its distance from the notehead
+                stopCenterMinY = stopTipY + totalStrokesHeight / 2;
+                stopCenterMaxY = stopNoteheadEdgeY - yPadding - totalStrokesHeight / 2;
+            } else { // stems down: tips below the noteheads
+                startCenterMinY = startNoteheadEdgeY + yPadding + totalStrokesHeight / 2;
+                startCenterMaxY = startTipY - totalStrokesHeight / 2;
+                stopCenterMinY = stopNoteheadEdgeY + yPadding + totalStrokesHeight / 2;
+                stopCenterMaxY = stopTipY - totalStrokesHeight / 2;
+            }
         } else {
             // stemless notes (e.g. whole notes) or opposite stem directions: anchor the strokes between the noteheads
             const startBoundingBox: VF.BoundingBox = vfStartNote.getBoundingBox();
@@ -421,13 +448,24 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         if (Math.abs(slant) > maxSlant) {
             slant = Math.sign(slant) * maxSlant;
         }
-        const startY: number = yMiddle - slant / 2;
-        const stopY: number = yMiddle + slant / 2;
+        let startY: number = yMiddle - slant / 2;
+        let stopY: number = yMiddle + slant / 2;
+
+        // shift the stroke group vertically if necessary to keep it within the allowed range at both notes,
+        //   e.g. when the slant was limited above (for notes far apart),
+        //   which moves the group out of the middle of the stems' free regions:
+        const minimumYShift: number = Math.max(startCenterMinY - startY, stopCenterMinY - stopY);
+        const maximumYShift: number = Math.min(startCenterMaxY - startY, stopCenterMaxY - stopY);
+        let yShift: number = 0;
+        if (minimumYShift <= maximumYShift) {
+            yShift = Math.min(Math.max(0, minimumYShift), maximumYShift); // smallest shift that satisfies both ranges
+        } else {
+            yShift = (minimumYShift + maximumYShift) / 2; // both ranges can't be satisfied (e.g. very short stems): balance the violations
+        }
+        startY += yShift;
+        stopY += yShift;
 
         // draw the strokes as parallelograms (like beams), stacked vertically around the center line:
-        const strokeThickness: number = this.rules.TremoloBetweenNotesStrokeThickness;
-        const strokePeriod: number = strokeThickness + this.rules.TremoloBetweenNotesStrokeGap;
-        const totalStrokesHeight: number = tremolo.strokes * strokeThickness + (tremolo.strokes - 1) * this.rules.TremoloBetweenNotesStrokeGap;
         const color: string = this.rules.DefaultColorMusic;
         for (let strokeIndex: number = 0; strokeIndex < tremolo.strokes; strokeIndex++) {
             const strokeStartTopY: number = startY - totalStrokesHeight / 2 + strokeIndex * strokePeriod;

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -1482,27 +1482,28 @@ export class InstrumentReader {
     let tremoloBetweenNotesStop: boolean;
     const tremoloNode: IXmlElement = ornamentsNode.element("tremolo");
     if (tremoloNode) {
-      const tremoloType: Attr = tremoloNode.attribute("type");
-      if (tremoloType) {
-        if (tremoloType.value === "single") {
-          const tremoloStrokesGiven: number = parseInt(tremoloNode.value, 10);
-          if (tremoloStrokesGiven > 0) {
-            tremoloStrokes = tremoloStrokesGiven;
-          }
-        } else {
-          tremoloStrokes = 0;
+      let tremoloType: string = tremoloNode.attribute("type")?.value;
+      if (!tremoloType) {
+        tremoloType = "single"; // the type attribute is optional in MusicXML and defaults to "single"
+      }
+      if (tremoloType === "single") {
+        const tremoloStrokesGiven: number = parseInt(tremoloNode.value, 10);
+        if (tremoloStrokesGiven > 0) {
+          tremoloStrokes = tremoloStrokesGiven;
         }
-        if (tremoloType.value === "unmeasured") {
-          tremoloUnmeasured = true;
-        } else if (tremoloType.value === "start" || tremoloType.value === "stop") {
-          // tremolo between (two) notes. The notes are linked in VoiceGenerator.handleTremoloBetweenNotes(),
-          //   the strokes between the notes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes().
-          tremoloBetweenNotesStart = tremoloType.value === "start";
-          tremoloBetweenNotesStop = tremoloType.value === "stop";
-          const tremoloStrokesGiven: number = parseInt(tremoloNode.value, 10);
-          if (tremoloStrokesGiven > 0) {
-            tremoloStrokes = tremoloStrokesGiven;
-          }
+      } else {
+        tremoloStrokes = 0;
+      }
+      if (tremoloType === "unmeasured") {
+        tremoloUnmeasured = true;
+      } else if (tremoloType === "start" || tremoloType === "stop") {
+        // tremolo between (two) notes. The notes are linked in VoiceGenerator.handleTremoloBetweenNotes(),
+        //   the strokes between the notes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes().
+        tremoloBetweenNotesStart = tremoloType === "start";
+        tremoloBetweenNotesStop = tremoloType === "stop";
+        const tremoloStrokesGiven: number = parseInt(tremoloNode.value, 10);
+        if (tremoloStrokesGiven > 0) {
+          tremoloStrokes = tremoloStrokesGiven;
         }
       }
     }

--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -1478,6 +1478,8 @@ export class InstrumentReader {
   private getTremoloInfo(ornamentsNode: IXmlElement): TremoloInfo {
     let tremoloStrokes: number;
     let tremoloUnmeasured: boolean;
+    let tremoloBetweenNotesStart: boolean;
+    let tremoloBetweenNotesStop: boolean;
     const tremoloNode: IXmlElement = ornamentsNode.element("tremolo");
     if (tremoloNode) {
       const tremoloType: Attr = tremoloNode.attribute("type");
@@ -1492,13 +1494,23 @@ export class InstrumentReader {
         }
         if (tremoloType.value === "unmeasured") {
           tremoloUnmeasured = true;
+        } else if (tremoloType.value === "start" || tremoloType.value === "stop") {
+          // tremolo between (two) notes. The notes are linked in VoiceGenerator.handleTremoloBetweenNotes(),
+          //   the strokes between the notes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes().
+          tremoloBetweenNotesStart = tremoloType.value === "start";
+          tremoloBetweenNotesStop = tremoloType.value === "stop";
+          const tremoloStrokesGiven: number = parseInt(tremoloNode.value, 10);
+          if (tremoloStrokesGiven > 0) {
+            tremoloStrokes = tremoloStrokesGiven;
+          }
         }
-        // TODO implement type "start". Vexflow doesn't have tremolo beams yet though (shorter than normal beams)
       }
     }
     return {
       tremoloStrokes: tremoloStrokes,
-      tremoloUnmeasured: tremoloUnmeasured
+      tremoloUnmeasured: tremoloUnmeasured,
+      tremoloBetweenNotesStart: tremoloBetweenNotesStart,
+      tremoloBetweenNotesStop: tremoloBetweenNotesStop
     };
   }
 

--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -2,7 +2,7 @@ import { LinkedVoice } from "../VoiceData/LinkedVoice";
 import { Voice } from "../VoiceData/Voice";
 import { MusicSheet } from "../MusicSheet";
 import { VoiceEntry, StemDirectionType } from "../VoiceData/VoiceEntry";
-import { Note, TremoloInfo } from "../VoiceData/Note";
+import { Note, TremoloBetweenNotes, TremoloInfo } from "../VoiceData/Note";
 import { SourceMeasure } from "../VoiceData/SourceMeasure";
 import { SourceStaffEntry } from "../VoiceData/SourceStaffEntry";
 import { Beam } from "../VoiceData/Beam";
@@ -70,6 +70,8 @@ export class VoiceGenerator {
   private currentOctaveShift: number = 0;
   private tupletDict: { [_: number]: Tuplet } = {};
   private openTupletNumber: number = 0;
+  /** The last tremolo between (two) notes started in this voice, awaiting its stop note. */
+  private openTremoloBetweenNotes: TremoloBetweenNotes;
 
   public get GetVoice(): Voice {
     return this.voice;
@@ -508,6 +510,9 @@ export class VoiceGenerator {
     note.IsGraceNote = isGraceNote;
     note.StemDirectionXml = stemDirectionXml; // maybe unnecessary, also in VoiceEntry
     note.TremoloInfo = tremoloInfo;
+    if (tremoloInfo?.tremoloBetweenNotesStart || tremoloInfo?.tremoloBetweenNotesStop) {
+      this.handleTremoloBetweenNotes(tremoloInfo, note);
+    }
     note.PlaybackInstrumentId = playbackInstrumentId;
     if ((noteheadShapeXml !== undefined && noteheadShapeXml !== "normal") || noteheadFilledXml !== undefined) {
       note.Notehead = new Notehead(note, noteheadShapeXml, noteheadFilledXml);
@@ -575,6 +580,37 @@ export class VoiceGenerator {
       // add IsGraceNote for rest notes like with Notes?
       // add PlaybackInstrumentId for rest notes?
     }
+
+  /**
+   * Links the start and stop note of a tremolo between (two) notes (XML tremolo type="start"/"stop")
+   * via a shared TremoloBetweenNotes object (note.TremoloInfo.tremoloBetweenNotes).
+   */
+  private handleTremoloBetweenNotes(tremoloInfo: TremoloInfo, note: Note): void {
+    const openTremolo: TremoloBetweenNotes = this.openTremoloBetweenNotes;
+    if (tremoloInfo.tremoloBetweenNotesStart) {
+      if (openTremolo && !openTremolo.stopNote && openTremolo.startNote?.ParentVoiceEntry === note.ParentVoiceEntry) {
+        // chord note: the tremolo start was already given on a previous note of this chord
+        tremoloInfo.tremoloBetweenNotes = openTremolo;
+        return;
+      }
+      this.openTremoloBetweenNotes = {
+        strokes: tremoloInfo.tremoloStrokes,
+        startNote: note,
+        stopNote: undefined
+      };
+      tremoloInfo.tremoloBetweenNotes = this.openTremoloBetweenNotes;
+    } else if (tremoloInfo.tremoloBetweenNotesStop) {
+      if (openTremolo && !openTremolo.stopNote) {
+        openTremolo.stopNote = note;
+        tremoloInfo.tremoloBetweenNotes = openTremolo;
+      } else if (openTremolo?.stopNote?.ParentVoiceEntry === note.ParentVoiceEntry) {
+        // chord note: the tremolo stop was already given on a previous note of this chord
+        tremoloInfo.tremoloBetweenNotes = openTremolo;
+      } else {
+        log.debug("VoiceGenerator.handleTremoloBetweenNotes: tremolo stop without preceding tremolo start. ignoring it.");
+      }
+    }
+  }
 
   /**
    * Handle the currentVoiceBeam.

--- a/src/MusicalScore/VoiceData/Note.ts
+++ b/src/MusicalScore/VoiceData/Note.ts
@@ -83,8 +83,8 @@ export class Note {
     public IsGraceNote: boolean;
     /** The stem direction asked for in XML. Not necessarily final or wanted stem direction. */
     private stemDirectionXml: StemDirectionType;
-    /** The number of tremolo strokes this note has (16th tremolo = 2 strokes).
-     * Could be a Tremolo object in future when there is more data like tremolo between two notes.
+    /** Tremolo information for this note, e.g. the number of tremolo strokes (16th tremolo = 2 strokes),
+     * or the TremoloBetweenNotes object for a tremolo between two notes.
      */
     public TremoloInfo: TremoloInfo;
     /** Color of the stem given in the XML Stem tag. RGB Hexadecimal, like #00FF00.
@@ -317,8 +317,32 @@ export enum Appearance {
 }
 
 export interface TremoloInfo {
+    /** Number of tremolo strokes (e.g. 16th tremolo = 2 strokes).
+     * For a tremolo between notes, the number of strokes ("tremolo beams") drawn between the two notes. */
     tremoloStrokes: number;
     /** Buzz roll (type="unmeasured" in XML) */
     tremoloUnmeasured: boolean;
-    // could in future be extended e.g. for tremolo between notes
+    /** Whether this note starts a tremolo between (two) notes (type="start" in XML). */
+    tremoloBetweenNotesStart?: boolean;
+    /** Whether this note stops/ends a tremolo between (two) notes (type="stop" in XML). */
+    tremoloBetweenNotesStop?: boolean;
+    /** The tremolo between (two) notes this note is part of, linking start and stop note.
+     * This object is shared between the start note and the stop note,
+     * set in VoiceGenerator.handleTremoloBetweenNotes(). */
+    tremoloBetweenNotes?: TremoloBetweenNotes;
+}
+
+/** A tremolo between two notes, e.g. two alternating half notes with 3 strokes ("tremolo beams") between them,
+ * often seen in orchestral string parts. (<tremolo type="start"> and type="stop" in MusicXML)
+ * Note that for these tremolos, each note is notated with the full duration of the tremolo,
+ * but only played for half of it (e.g. notated two half notes = tremolo over one half note duration),
+ * so Note.TypeLength is twice the Note.Length here.
+ * The strokes are drawn in VexFlowMusicSheetDrawer.drawTremolosBetweenNotes(). */
+export interface TremoloBetweenNotes {
+    /** Number of strokes ("tremolo beams") drawn between the two notes. */
+    strokes: number;
+    /** The first/left note of the tremolo. */
+    startNote: Note;
+    /** The second/right note of the tremolo. Undefined until the stop note is read. */
+    stopNote: Note;
 }

--- a/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
+++ b/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
@@ -5,6 +5,7 @@ import {MusicSheet} from "../../../src/MusicalScore/MusicSheet";
 import {IXmlElement} from "../../../src/Common/FileIO/Xml";
 import {NoteHeadShape} from "../../../src/MusicalScore/VoiceData/Notehead";
 import {Note, TremoloInfo} from "../../../src/MusicalScore/VoiceData/Note";
+import {VoiceEntry} from "../../../src/MusicalScore/VoiceData/VoiceEntry";
 
 describe("Music Sheet Reader", () => {
     const path: string = "test/data/MuzioClementi_SonatinaOpus36No1_Part1.xml";
@@ -196,6 +197,26 @@ describe("Music Sheet Reader", () => {
                     }
                 }
             }
+            done();
+        });
+    });
+
+    describe("Tremolo without type attribute", () => {
+        it("reads a tremolo without type attribute as single note tremolo (MusicXML default)", (done: Mocha.Done) => {
+            const noTypePath: string = "test/data/test_tremolo_no_type_attribute.musicxml";
+            const doc: Document = getSheet(noTypePath);
+            expect(doc).to.not.be.undefined;
+            const noTypeScore: IXmlElement = new IXmlElement(doc.getElementsByTagName("score-partwise")[0]);
+            const noTypeSheet: MusicSheet = reader.createMusicSheet(noTypeScore, noTypePath);
+
+            const voiceEntries: VoiceEntry[] = noTypeSheet.Instruments[0].Voices[0].VoiceEntries;
+            const noTypeNote: Note = voiceEntries[0].Notes[0]; // <tremolo>3</tremolo> (no type attribute)
+            const singleTypeNote: Note = voiceEntries[1].Notes[0]; // <tremolo type="single">3</tremolo>
+            expect(noTypeNote.TremoloInfo.tremoloStrokes, "tremolo without type attribute defaults to single").to.equal(3);
+            expect(noTypeNote.TremoloInfo.tremoloUnmeasured).to.be.undefined;
+            expect(noTypeNote.TremoloInfo.tremoloBetweenNotesStart).to.be.undefined;
+            expect(noTypeNote.TremoloInfo.tremoloBetweenNotesStop).to.be.undefined;
+            expect(noTypeNote.TremoloInfo.tremoloStrokes).to.equal(singleTypeNote.TremoloInfo.tremoloStrokes);
             done();
         });
     });

--- a/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
+++ b/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
@@ -4,6 +4,7 @@ import {MusicSheetReader} from "../../../src/MusicalScore/ScoreIO/MusicSheetRead
 import {MusicSheet} from "../../../src/MusicalScore/MusicSheet";
 import {IXmlElement} from "../../../src/Common/FileIO/Xml";
 import {NoteHeadShape} from "../../../src/MusicalScore/VoiceData/Notehead";
+import {Note, TremoloInfo} from "../../../src/MusicalScore/VoiceData/Note";
 
 describe("Music Sheet Reader", () => {
     const path: string = "test/data/MuzioClementi_SonatinaOpus36No1_Part1.xml";
@@ -134,6 +135,66 @@ describe("Music Sheet Reader", () => {
             // This note should have no notehead property or a normal notehead
             if (note.Notehead) {
                 expect(note.Notehead.Shape).to.not.equal(NoteHeadShape.NONE);
+            }
+            done();
+        });
+    });
+
+    describe("Tremolo between two notes", () => {
+        const tremoloBetweenNotesPath: string = "test/data/test_tremolo_between_notes_short.musicxml";
+        let tremoloSheet: MusicSheet;
+
+        before((): void => {
+            const doc: Document = getSheet(tremoloBetweenNotesPath);
+            expect(doc).to.not.be.undefined;
+            const tremoloScore: IXmlElement = new IXmlElement(doc.getElementsByTagName("score-partwise")[0]);
+            tremoloSheet = reader.createMusicSheet(tremoloScore, tremoloBetweenNotesPath);
+        });
+
+        it("links start and stop notes of tremolos between two notes", (done: Mocha.Done) => {
+            expect(tremoloSheet).to.not.be.undefined;
+            let tremoloCount: number = 0;
+            for (const instrument of tremoloSheet.Instruments) {
+                for (const voice of instrument.Voices) {
+                    let openTremoloStartNote: Note = undefined;
+                    for (const voiceEntry of voice.VoiceEntries) {
+                        for (const note of voiceEntry.Notes) {
+                            const tremoloInfo: TremoloInfo = note.TremoloInfo;
+                            expect(tremoloInfo, "every note in the test sample has tremolo info").to.not.be.undefined;
+                            expect(tremoloInfo.tremoloBetweenNotes, "start and stop notes are linked").to.not.be.undefined;
+                            expect(tremoloInfo.tremoloBetweenNotes.strokes).to.equal(3);
+                            if (tremoloInfo.tremoloBetweenNotesStart) {
+                                expect(tremoloInfo.tremoloBetweenNotes.startNote).to.equal(note);
+                                openTremoloStartNote = note;
+                            } else {
+                                expect(tremoloInfo.tremoloBetweenNotesStop, "note is start or stop note").to.be.true;
+                                expect(tremoloInfo.tremoloBetweenNotes.stopNote).to.equal(note);
+                                expect(tremoloInfo.tremoloBetweenNotes.startNote,
+                                       "stop note is linked to the previous start note in the same voice").to.equal(openTremoloStartNote);
+                                // start and stop note share the same TremoloBetweenNotes object:
+                                expect(openTremoloStartNote.TremoloInfo.tremoloBetweenNotes).to.equal(tremoloInfo.tremoloBetweenNotes);
+                                tremoloCount++;
+                            }
+                        }
+                    }
+                }
+            }
+            expect(tremoloCount, "the test sample has 4 tremolos between two notes").to.equal(4);
+            done();
+        });
+
+        it("does not add single note tremolo strokes for tremolos between two notes", (done: Mocha.Done) => {
+            for (const instrument of tremoloSheet.Instruments) {
+                for (const voice of instrument.Voices) {
+                    for (const voiceEntry of voice.VoiceEntries) {
+                        for (const note of voiceEntry.Notes) {
+                            // tremoloStrokes is set (for drawing the strokes between the notes),
+                            //   but the notes shouldn't be treated as single note tremolos:
+                            expect(note.TremoloInfo.tremoloStrokes).to.equal(3);
+                            expect(note.TremoloInfo.tremoloUnmeasured).to.be.undefined;
+                        }
+                    }
+                }
             }
             done();
         });

--- a/test/data/test_tremolo_between_notes.musicxml
+++ b/test/data/test_tremolo_between_notes.musicxml
@@ -1,0 +1,805 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!DOCTYPE score-partwise PUBLIC '-//Recordare//DTD MusicXML 4.0 Partwise//EN' 'http://www.musicxml.org/dtds/partwise.dtd'>
+<score-partwise version='4.0'>
+	<movement-title>test_tremolo_between_notes</movement-title>
+	<identification>
+		<encoding>
+			<software>Sibelius 2024.6</software>
+			<software>Dolet 8.1 for Sibelius</software>
+			<encoding-date>2024-07-17</encoding-date>
+			<supports element='accidental' type='yes'/>
+			<supports element='transpose' type='yes'/>
+			<supports attribute='new-page' element='print' type='yes' value='yes'/>
+			<supports attribute='new-system' element='print' type='yes' value='yes'/>
+		</encoding>
+	</identification>
+	<defaults>
+		<scaling>
+			<millimeters>7</millimeters>
+			<tenths>40</tenths>
+		</scaling>
+		<concert-score/>
+		<page-layout>
+			<page-height>1597</page-height>
+			<page-width>1234</page-width>
+			<page-margins type='both'>
+				<left-margin>72.5714</left-margin>
+				<right-margin>72.5714</right-margin>
+				<top-margin>72.5714</top-margin>
+				<bottom-margin>72.5714</bottom-margin>
+			</page-margins>
+		</page-layout>
+		<system-layout>
+			<system-margins>
+				<left-margin>0</left-margin>
+				<right-margin>0</right-margin>
+			</system-margins>
+			<system-distance>100</system-distance>
+			<top-system-distance>108.75</top-system-distance>
+		</system-layout>
+		<staff-layout>
+			<staff-distance>70</staff-distance>
+		</staff-layout>
+		<?DoletSibelius StaffJustificationPercentage=65?>
+		<appearance>
+			<line-width type='beam'>5</line-width>
+			<line-width type='heavy barline'>5</line-width>
+			<line-width type='leger'>1.5625</line-width>
+			<line-width type='light barline'>1.5625</line-width>
+			<line-width type='slur middle'>2.1875</line-width>
+			<line-width type='slur tip'>0.625</line-width>
+			<line-width type='staff'>1.25</line-width>
+			<line-width type='stem'>1.25</line-width>
+			<line-width type='tie middle'>2.1875</line-width>
+			<line-width type='tie tip'>0.625</line-width>
+			<note-size type='grace'>60</note-size>
+			<note-size type='cue'>75</note-size>
+		</appearance>
+		<music-font font-family='Helsinki Std,engraved'/>
+		<word-font font-family='Palatino,serif'/>
+	</defaults>
+	<credit page='1'>
+		<credit-type>title</credit-type>
+		<credit-words default-x='617' default-y='1524' justify='center' valign='top' font-weight='bold' font-size='22'>test_tremolo_between_notes</credit-words>
+	</credit>
+	<part-list>
+		<score-part id='P1'>
+			<part-name print-object='no'>Piano</part-name>
+			<part-abbreviation print-object='no'>Pno.</part-abbreviation>
+			<group>score</group>
+			<score-instrument id='P1-I1'>
+				<instrument-name>Piano</instrument-name>
+				<instrument-abbreviation>Pno.</instrument-abbreviation>
+				<instrument-sound>keyboard.piano.grand</instrument-sound>
+			</score-instrument>
+			<midi-instrument id='P1-I1'>
+				<volume>79</volume>
+				<pan>-18</pan>
+			</midi-instrument>
+		</score-part>
+	</part-list>
+<!--=========================================================-->
+	<part id='P1'>
+		<measure number='1'>
+			<print>
+				<system-layout>
+					<top-system-distance>217.8125</top-system-distance>
+				</system-layout>
+				<staff-layout>
+					<?DoletSibelius JustifyAllStaves=false?>
+				</staff-layout>
+			</print>
+			<attributes>
+				<divisions>768</divisions>
+				<key>
+					<fifths>0</fifths>
+					<mode>major</mode>
+				</key>
+				<time>
+					<beats>4</beats>
+					<beat-type>4</beat-type>
+				</time>
+				<staves>2</staves>
+				<clef number='1'>
+					<sign>G</sign>
+					<line>2</line>
+				</clef>
+				<clef number='2'>
+					<sign>F</sign>
+					<line>4</line>
+				</clef>
+			</attributes>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='2'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='3'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='4'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='5'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>3072</duration>
+				<voice>1</voice>
+				<type>whole</type>
+				<staff>1</staff>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>3072</duration>
+				<voice>5</voice>
+				<type>whole</type>
+				<staff>2</staff>
+			</note>
+			<barline location='right'>
+				<bar-style>light-heavy</bar-style>
+			</barline>
+		</measure>
+	</part>
+<!--=========================================================-->
+</score-partwise>

--- a/test/data/test_tremolo_between_notes_4strokes.musicxml
+++ b/test/data/test_tremolo_between_notes_4strokes.musicxml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <!DOCTYPE score-partwise PUBLIC '-//Recordare//DTD MusicXML 4.0 Partwise//EN' 'http://www.musicxml.org/dtds/partwise.dtd'>
 <score-partwise version='4.0'>
-	<movement-title>test_tremolo_between_notes</movement-title>
+	<movement-title>test_tremolo_between_notes_4strokes</movement-title>
 	<identification>
 		<encoding>
 			<software>Sibelius 2024.6</software>
@@ -60,7 +60,7 @@
 	</defaults>
 	<credit page='1'>
 		<credit-type>title</credit-type>
-		<credit-words default-x='617' default-y='1524' justify='center' valign='top' font-weight='bold' font-size='22'>test_tremolo_between_notes</credit-words>
+		<credit-words default-x='617' default-y='1524' justify='center' valign='top' font-weight='bold' font-size='22'>test_tremolo_between_notes_4strokes</credit-words>
 	</credit>
 	<part-list>
 		<score-part id='P1'>

--- a/test/data/test_tremolo_between_notes_4strokes.musicxml
+++ b/test/data/test_tremolo_between_notes_4strokes.musicxml
@@ -1,0 +1,805 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!DOCTYPE score-partwise PUBLIC '-//Recordare//DTD MusicXML 4.0 Partwise//EN' 'http://www.musicxml.org/dtds/partwise.dtd'>
+<score-partwise version='4.0'>
+	<movement-title>test_tremolo_between_notes</movement-title>
+	<identification>
+		<encoding>
+			<software>Sibelius 2024.6</software>
+			<software>Dolet 8.1 for Sibelius</software>
+			<encoding-date>2024-07-17</encoding-date>
+			<supports element='accidental' type='yes'/>
+			<supports element='transpose' type='yes'/>
+			<supports attribute='new-page' element='print' type='yes' value='yes'/>
+			<supports attribute='new-system' element='print' type='yes' value='yes'/>
+		</encoding>
+	</identification>
+	<defaults>
+		<scaling>
+			<millimeters>7</millimeters>
+			<tenths>40</tenths>
+		</scaling>
+		<concert-score/>
+		<page-layout>
+			<page-height>1597</page-height>
+			<page-width>1234</page-width>
+			<page-margins type='both'>
+				<left-margin>72.5714</left-margin>
+				<right-margin>72.5714</right-margin>
+				<top-margin>72.5714</top-margin>
+				<bottom-margin>72.5714</bottom-margin>
+			</page-margins>
+		</page-layout>
+		<system-layout>
+			<system-margins>
+				<left-margin>0</left-margin>
+				<right-margin>0</right-margin>
+			</system-margins>
+			<system-distance>100</system-distance>
+			<top-system-distance>108.75</top-system-distance>
+		</system-layout>
+		<staff-layout>
+			<staff-distance>70</staff-distance>
+		</staff-layout>
+		<?DoletSibelius StaffJustificationPercentage=65?>
+		<appearance>
+			<line-width type='beam'>5</line-width>
+			<line-width type='heavy barline'>5</line-width>
+			<line-width type='leger'>1.5625</line-width>
+			<line-width type='light barline'>1.5625</line-width>
+			<line-width type='slur middle'>2.1875</line-width>
+			<line-width type='slur tip'>0.625</line-width>
+			<line-width type='staff'>1.25</line-width>
+			<line-width type='stem'>1.25</line-width>
+			<line-width type='tie middle'>2.1875</line-width>
+			<line-width type='tie tip'>0.625</line-width>
+			<note-size type='grace'>60</note-size>
+			<note-size type='cue'>75</note-size>
+		</appearance>
+		<music-font font-family='Helsinki Std,engraved'/>
+		<word-font font-family='Palatino,serif'/>
+	</defaults>
+	<credit page='1'>
+		<credit-type>title</credit-type>
+		<credit-words default-x='617' default-y='1524' justify='center' valign='top' font-weight='bold' font-size='22'>test_tremolo_between_notes</credit-words>
+	</credit>
+	<part-list>
+		<score-part id='P1'>
+			<part-name print-object='no'>Piano</part-name>
+			<part-abbreviation print-object='no'>Pno.</part-abbreviation>
+			<group>score</group>
+			<score-instrument id='P1-I1'>
+				<instrument-name>Piano</instrument-name>
+				<instrument-abbreviation>Pno.</instrument-abbreviation>
+				<instrument-sound>keyboard.piano.grand</instrument-sound>
+			</score-instrument>
+			<midi-instrument id='P1-I1'>
+				<volume>79</volume>
+				<pan>-18</pan>
+			</midi-instrument>
+		</score-part>
+	</part-list>
+<!--=========================================================-->
+	<part id='P1'>
+		<measure number='1'>
+			<print>
+				<system-layout>
+					<top-system-distance>217.8125</top-system-distance>
+				</system-layout>
+				<staff-layout>
+					<?DoletSibelius JustifyAllStaves=false?>
+				</staff-layout>
+			</print>
+			<attributes>
+				<divisions>768</divisions>
+				<key>
+					<fifths>0</fifths>
+					<mode>major</mode>
+				</key>
+				<time>
+					<beats>4</beats>
+					<beat-type>4</beat-type>
+				</time>
+				<staves>2</staves>
+				<clef number='1'>
+					<sign>G</sign>
+					<line>2</line>
+				</clef>
+				<clef number='2'>
+					<sign>F</sign>
+					<line>4</line>
+				</clef>
+			</attributes>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='2'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='3'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>4</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>4</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>4</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>4</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>4</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>4</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='4'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+		</measure>
+<!--=========================================================-->
+		<measure number='5'>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>3072</duration>
+				<voice>1</voice>
+				<type>whole</type>
+				<staff>1</staff>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>3072</duration>
+				<voice>5</voice>
+				<type>whole</type>
+				<staff>2</staff>
+			</note>
+			<barline location='right'>
+				<bar-style>light-heavy</bar-style>
+			</barline>
+		</measure>
+	</part>
+<!--=========================================================-->
+</score-partwise>

--- a/test/data/test_tremolo_between_notes_short.musicxml
+++ b/test/data/test_tremolo_between_notes_short.musicxml
@@ -1,0 +1,281 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!DOCTYPE score-partwise PUBLIC '-//Recordare//DTD MusicXML 4.0 Partwise//EN' 'http://www.musicxml.org/dtds/partwise.dtd'>
+<score-partwise version='4.0'>
+	<movement-title>test_tremolo_between_notes_short</movement-title>
+	<identification>
+		<encoding>
+			<software>Sibelius 2024.6</software>
+			<software>Dolet 8.1 for Sibelius</software>
+			<encoding-date>2024-07-17</encoding-date>
+			<supports element='accidental' type='yes'/>
+			<supports element='transpose' type='yes'/>
+			<supports attribute='new-page' element='print' type='yes' value='yes'/>
+			<supports attribute='new-system' element='print' type='yes' value='yes'/>
+		</encoding>
+	</identification>
+	<defaults>
+		<scaling>
+			<millimeters>7</millimeters>
+			<tenths>40</tenths>
+		</scaling>
+		<concert-score/>
+		<page-layout>
+			<page-height>1597</page-height>
+			<page-width>1234</page-width>
+			<page-margins type='both'>
+				<left-margin>72.5714</left-margin>
+				<right-margin>72.5714</right-margin>
+				<top-margin>72.5714</top-margin>
+				<bottom-margin>72.5714</bottom-margin>
+			</page-margins>
+		</page-layout>
+		<system-layout>
+			<system-margins>
+				<left-margin>0</left-margin>
+				<right-margin>0</right-margin>
+			</system-margins>
+			<system-distance>100</system-distance>
+			<top-system-distance>108.75</top-system-distance>
+		</system-layout>
+		<staff-layout>
+			<staff-distance>70</staff-distance>
+		</staff-layout>
+		<?DoletSibelius StaffJustificationPercentage=65?>
+		<appearance>
+			<line-width type='beam'>5</line-width>
+			<line-width type='heavy barline'>5</line-width>
+			<line-width type='leger'>1.5625</line-width>
+			<line-width type='light barline'>1.5625</line-width>
+			<line-width type='slur middle'>2.1875</line-width>
+			<line-width type='slur tip'>0.625</line-width>
+			<line-width type='staff'>1.25</line-width>
+			<line-width type='stem'>1.25</line-width>
+			<line-width type='tie middle'>2.1875</line-width>
+			<line-width type='tie tip'>0.625</line-width>
+			<note-size type='grace'>60</note-size>
+			<note-size type='cue'>75</note-size>
+		</appearance>
+		<music-font font-family='Helsinki Std,engraved'/>
+		<word-font font-family='Palatino,serif'/>
+	</defaults>
+	<credit page='1'>
+		<credit-type>title</credit-type>
+		<credit-words default-x='617' default-y='1524' justify='center' valign='top' font-weight='bold' font-size='22'>test_tremolo_between_notes_short</credit-words>
+	</credit>
+	<part-list>
+		<score-part id='P1'>
+			<part-name print-object='no'>Piano</part-name>
+			<part-abbreviation print-object='no'>Pno.</part-abbreviation>
+			<group>score</group>
+			<score-instrument id='P1-I1'>
+				<instrument-name>Piano</instrument-name>
+				<instrument-abbreviation>Pno.</instrument-abbreviation>
+				<instrument-sound>keyboard.piano.grand</instrument-sound>
+			</score-instrument>
+			<midi-instrument id='P1-I1'>
+				<volume>79</volume>
+				<pan>-18</pan>
+			</midi-instrument>
+		</score-part>
+	</part-list>
+<!--=========================================================-->
+	<part id='P1'>
+		<measure number='1'>
+			<print>
+				<system-layout>
+					<top-system-distance>217.8125</top-system-distance>
+				</system-layout>
+				<staff-layout>
+					<?DoletSibelius JustifyAllStaves=false?>
+				</staff-layout>
+			</print>
+			<attributes>
+				<divisions>768</divisions>
+				<key>
+					<fifths>0</fifths>
+					<mode>major</mode>
+				</key>
+				<time>
+					<beats>4</beats>
+					<beat-type>4</beat-type>
+				</time>
+				<staves>2</staves>
+				<clef number='1'>
+					<sign>G</sign>
+					<line>2</line>
+				</clef>
+				<clef number='2'>
+					<sign>F</sign>
+					<line>4</line>
+				</clef>
+			</attributes>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>4</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>5</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>1</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>1</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<backup>
+				<duration>3072</duration>
+			</backup>
+			<note>
+				<pitch>
+					<step>C</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>down</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>B</step>
+					<octave>2</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='start'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<note>
+				<pitch>
+					<step>E</step>
+					<octave>3</octave>
+				</pitch>
+				<duration>768</duration>
+				<voice>5</voice>
+				<type>half</type>
+				<time-modification>
+					<actual-notes>2</actual-notes>
+					<normal-notes>1</normal-notes>
+				</time-modification>
+				<stem>up</stem>
+				<staff>2</staff>
+				<notations>
+					<ornaments>
+						<tremolo type='stop'>3</tremolo>
+					</ornaments>
+				</notations>
+			</note>
+			<barline location='right'>
+				<bar-style>light-heavy</bar-style>
+			</barline>
+		</measure>
+	</part>
+<!--=========================================================-->
+</score-partwise>

--- a/test/data/test_tremolo_no_type_attribute.musicxml
+++ b/test/data/test_tremolo_no_type_attribute.musicxml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <movement-title>test_tremolo_no_type_attribute</movement-title>
+  <identification>
+    <miscellaneous>
+      <miscellaneous-field name="description">The first note has a tremolo element without a type attribute,
+        which is optional in MusicXML and defaults to "single".
+        It should render like the second note, which has an explicit type="single" attribute.</miscellaneous-field>
+    </miscellaneous>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name print-object="no">Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <notations>
+          <ornaments>
+            <tremolo>3</tremolo>
+          </ornaments>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <notations>
+          <ornaments>
+            <tremolo type="single">3</tremolo>
+          </ornaments>
+        </notations>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Closes #1551

After:
<img width="1133" height="328" alt="image" src="https://github.com/user-attachments/assets/cf672e35-039f-4c41-9f0e-5e89596b152a" />

Before:
<img width="1256" height="400" alt="image" src="https://github.com/user-attachments/assets/db0214f0-f7bb-4ad1-a6d3-4bb2aa1a1739" />

Tremolos between notes weren't supported by Vexflow, so now we draw them manually without Vexflow with simple rectangles.

For tremolos with 4+ strokes/bars, the stems are extended, as recommended in Gould's Behind Bars.
Bars should cover ~66% of the space between the notes, so ~33% in total is left as free space after the first and before the last note, as recommended by Gould.

New EngravingRules:
```ts
    /** Vertical thickness of one stroke ("tremolo beam") of a tremolo between two notes, in units (1 unit = staff space). */
    public TremoloBetweenNotesStrokeThickness: number;
    /** Vertical gap between the strokes of a tremolo between two notes, in units. */
    public TremoloBetweenNotesStrokeGap: number;
    /** Minimum horizontal padding between the strokes of a tremolo between two notes and the stems (or noteheads for stemless notes), in units. */
    public TremoloBetweenNotesXPadding: number;
    /** Maximum length of the strokes of a tremolo between two notes,
     * as a fraction of the space between the stems (or noteheads for stemless notes).
     * (Gould: the strokes span about two thirds of the space between the notes) */
    public TremoloBetweenNotesMaxLengthFactor: number;
    /** Maximum vertical rise/fall (slant) of the strokes of a tremolo between two notes, in units. */
    public TremoloBetweenNotesMaxSlant: number;
    /** Vertical padding between the strokes of a tremolo between two notes and the notehead (edge), in units.
     * Stems are lengthened where necessary to make room for the strokes (e.g. for 4+ strokes),
     * as recommended by Gould (Behind Bars). */
    public TremoloBetweenNotesYPadding: number;
```

default values:
```ts
        this.TremoloBetweenNotesStrokeThickness = 0.4; // like beam thickness
        this.TremoloBetweenNotesStrokeGap = 0.4;
        this.TremoloBetweenNotesXPadding = 0.55;
        this.TremoloBetweenNotesMaxLengthFactor = 0.667;
        this.TremoloBetweenNotesMaxSlant = 1.0;
        this.TremoloBetweenNotesYPadding = 0.45;
```

The skyline and bottomline are adjusted accordingly, and the lowest and highest points are calculated geometrically, saving performance by not having to get the pixel data with getImageData(), which takes ~75% of the performance/processing in OSMD. (it's transferring data between GPU and CPU, not much we can do other than not using it)

<img width="1425" height="310" alt="image" src="https://github.com/user-attachments/assets/518f9fb3-bd9b-4d6e-9c80-702fefd38ec6" />
