### PR TITLE
Improve performance by ~1.8x: Implement geometric skyline calculation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -192,7 +192,7 @@ export default defineConfig(
         },
     },
     {
-        files: ["test/Util/*.js", "test/Util/*.mjs"],
+        files: ["test/Util/*.js", "test/Util/*.mjs", "test/performance/*.mjs"],
         languageOptions: {
             globals: {
                 ...globals.browser,

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -401,6 +401,15 @@ export class EngravingRules {
     public GraceLineWidth: number;
     public MinimumStaffLineDistance: number;
     public MinSkyBottomDistBetweenStaves: number;
+    /** Whether to snap the y positions of stafflines and music systems to positions where the
+     *  (1px) staff lines render as crisp single pixel rows, instead of being spread (anti-aliased)
+     *  over two half-covered, gray-ish pixel rows. Default true.
+     *  This makes the staff line weight consistent across all systems (and across releases:
+     *  otherwise sub-pixel layout changes shift the anti-aliasing per system, which shows up as
+     *  bolder/lighter staff lines, e.g. in visual regression tests).
+     *  Exact at zoom 1 (and its integer multiples), within a page.
+     */
+    public SnapStafflinesToCrispPixels: boolean;
     public MinimumCrossedBeamDifferenceMargin: number;
 
     /** Maximum width of sheet / HTMLElement containing the score. Canvas is limited to 32767 in current browsers, though SVG isn't.
@@ -619,6 +628,7 @@ export class EngravingRules {
         this.BetweenStaffDistance = 5.0;
         this.MinimumStaffLineDistance = 4.0;
         this.MinSkyBottomDistBetweenStaves = 1.0; // default. compacttight mode sets it to 1.0 (as well).
+        this.SnapStafflinesToCrispPixels = true;
 
         // System Sizing and Label Variables
         this.StaffHeight = 4.0;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -556,7 +556,13 @@ export class EngravingRules {
      */
     public RenderCount: number = 0;
 
-    /** The skyline and bottom-line batch calculation algorithm to use.
+    /** Whether to calculate the skyline and bottom-line geometrically, from the extents of the VexFlow draw calls,
+     *  instead of drawing each measure on a hidden canvas and reading back its pixels (getImageData), which is much slower (see #937).
+     *  Default true. If set to false, the previous pixel-based calculation is used,
+     *  see PreferredSkyBottomLineBatchCalculatorBackend etc.
+     */
+    public UseGeometricSkyBottomLineCalculation: boolean;
+    /** The skyline and bottom-line batch calculation algorithm to use, if UseGeometricSkyBottomLineCalculation is false.
      *  Note that this can be overridden if AlwaysSetPreferredSkyBottomLineBackendAutomatically is true (which is the default).
      */
     public PreferredSkyBottomLineBatchCalculatorBackend: SkyBottomLineBatchCalculatorBackendType;
@@ -1011,6 +1017,7 @@ export class EngravingRules {
         this.NoteToGraphicalNoteMap = new Dictionary<number, GraphicalNote>();
         this.NoteToGraphicalNoteMapObjectCount = 0;
 
+        this.UseGeometricSkyBottomLineCalculation = true;
         this.SkyBottomLineBatchMinMeasures = 5;
         this.SkyBottomLineWebGLMinMeasures = 80;
         this.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -14,6 +14,7 @@ import { Dictionary } from "typescript-collections";
 import { FontStyles } from "../../Common/Enums";
 import { NoteEnum, AccidentalEnum } from "../../Common/DataObjects/Pitch";
 import { ChordSymbolEnum, CustomChord, DegreesInfo } from "../../MusicalScore/VoiceData/ChordSymbolContainer";
+import { GeometricSkyBottomLineCaches } from "./GeometricSkyBottomLineContext";
 import { GraphicalNote } from "./GraphicalNote";
 import { Note } from "../VoiceData/Note";
 
@@ -571,6 +572,10 @@ export class EngravingRules {
      *  see PreferredSkyBottomLineBatchCalculatorBackend etc.
      */
     public UseGeometricSkyBottomLineCalculation: boolean;
+    /** Caches for the geometric skyline calculation (text measurements, flattened glyph outlines).
+     *  Owned here (per OSMD instance, like NoteToGraphicalNoteMap) instead of statically,
+     *  so that multiple OSMD instances stay independent. */
+    public GeometricSkyBottomLineCaches: GeometricSkyBottomLineCaches;
     /** The skyline and bottom-line batch calculation algorithm to use, if UseGeometricSkyBottomLineCalculation is false.
      *  Note that this can be overridden if AlwaysSetPreferredSkyBottomLineBackendAutomatically is true (which is the default).
      */
@@ -1028,6 +1033,7 @@ export class EngravingRules {
         this.NoteToGraphicalNoteMapObjectCount = 0;
 
         this.UseGeometricSkyBottomLineCalculation = true;
+        this.GeometricSkyBottomLineCaches = new GeometricSkyBottomLineCaches();
         this.SkyBottomLineBatchMinMeasures = 5;
         this.SkyBottomLineWebGLMinMeasures = 80;
         this.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;

--- a/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
+++ b/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
@@ -1,0 +1,896 @@
+import log from "loglevel";
+
+/** Ink extents of a single character, in px for the font it was measured with.
+ *  inkLeft/inkRight are relative to the pen position (inkLeft can be slightly negative,
+ *  e.g. italic overhang, and inkRight can exceed the advance width). */
+interface ICharacterExtents {
+    advance: number;
+    ascent: number;
+    descent: number;
+    inkLeft: number;
+    inkRight: number;
+}
+
+/** Drawing state that can be saved/restored with save()/restore(), mirroring canvas semantics. */
+interface IGeometricContextState {
+    translateX: number;
+    translateY: number;
+    scaleX: number;
+    scaleY: number;
+    lineWidth: number;
+    fillStyle: string;
+    fillTransparent: boolean;
+    strokeStyle: string;
+    strokeTransparent: boolean;
+    font: string;
+}
+
+/**
+ * A virtual VexFlow rendering context that computes the vertical extents (min and max y)
+ * of everything drawn into it, per (pixel) column, instead of rasterizing to a canvas.
+ *
+ * This is used by SkyBottomLineCalculator to calculate the skyline and bottom-line of a measure
+ * geometrically from the same VexFlowMeasure.draw() call that was previously made on a hidden canvas,
+ * without the very expensive CanvasRenderingContext2D.getImageData() call (GPU->CPU transfer)
+ * and without rasterizing/allocating a canvas at all. (see #937)
+ *
+ * It implements the subset of the CanvasRenderingContext2D interface that VexFlow 1.2.93 uses,
+ * plus the extra methods VexFlow adds in Renderer.bolsterCanvasContext() (setFont, setFillStyle,
+ * openGroup, etc., see VexFlow's canvascontext.js).
+ *
+ * Accuracy notes compared to the pixel-based (raster) method:
+ * - Values are exact geometry instead of pixel indices, i.e. not quantized to integers and without
+ *   the up-to-1px anti-aliasing halo of the raster method. Differences are well below 1px (0.1 units).
+ * - Where a shape's edge lies (almost) exactly on a pixel column boundary (e.g. the tangent of a notehead
+ *   ellipse, or a stem edge), the rasterizer can round the sliver of coverage down to nothing, while this
+ *   context includes the column. Conservative, at most one extra pixel column per edge.
+ * - Text is merged from per-character ink extents (probed once per font + character from a tiny canvas,
+ *   see probeCharacterInk()). Font hinting can shift rasterized glyph edges by up to a pixel depending on
+ *   the fractional pen position, which is not predictable; the unrounded extents used here are conservative.
+ * - Completely transparent fills/strokes (e.g. "#00000000" used for invisible elements) are skipped,
+ *   like in the raster method, where the alpha > 0 pixel test ignored them.
+ * - clearRect() (only used by VexFlow's TabNote to erase stave lines behind fret numbers) is a no-op,
+ *   so this context keeps the bottom stave line of tablatures solid, while the raster method saw holes in it,
+ *   which even shifted its relative anchoring of the whole bottom line by ~0.2 units on tab staves.
+ *   The geometric (solid) result is the more correct one.
+ * - The raster method clipped contents above/below its 300px canvas (~10 units above the stave).
+ *   This context has no such limit, which is more correct for extreme cases.
+ * - Drawing is clipped horizontally to [0, width) like on the per-measure canvas of the raster method.
+ * - Dashed/dotted strokes are treated as solid lines (conservative). Miter join spikes of stroked
+ *   multi-segment paths are not modeled (only relevant for sharp angles, which VexFlow doesn't stroke).
+ */
+export class GeometricSkyBottomLineContext {
+    /** Conversion factor pt -> px for font sizes, as used by canvas. */
+    private static readonly PT_TO_PX: number = 4 / 3;
+    /** Fallback font ascent as a fraction of the font size in px, if TextMetrics.actualBoundingBoxAscent is unavailable. */
+    private static readonly FALLBACK_FONT_ASCENT: number = 0.9;
+    /** Fallback font descent as a fraction of the font size in px, if TextMetrics.actualBoundingBoxDescent is unavailable. */
+    private static readonly FALLBACK_FONT_DESCENT: number = 0.25;
+    /** Fallback per-character width as a fraction of the font size in px, if no 2D context is available for measureText. */
+    private static readonly FALLBACK_CHAR_WIDTH: number = 0.6;
+    /** Maximum number of line segments a Bézier curve or arc is flattened into. */
+    private static readonly MAX_FLATTENING_SEGMENTS: number = 64;
+    /** Target length (in px) of the line segments a Bézier curve is flattened into. */
+    private static readonly FLATTENING_SEGMENT_LENGTH: number = 3;
+
+    /** Shared hidden canvas context used only for measureText() (cheap, no pixel readback). */
+    private static textMeasureContext: CanvasRenderingContext2D;
+    private static textMeasureContextCreationFailed: boolean = false;
+    private static measureTextWarningLogged: boolean = false;
+    /** Character ink extents, cached by font + character (see measureCharacter()). */
+    private static characterExtentsCache: Map<string, ICharacterExtents> = new Map<string, ICharacterExtents>();
+    /** Tiny hidden canvas used to probe the exact rasterized ink extents of single characters
+     *  (once per font + character, then cached forever in characterExtentsCache). */
+    private static characterProbeCanvas: HTMLCanvasElement;
+    private static characterProbeContext: CanvasRenderingContext2D;
+    private static characterProbeCreationFailed: boolean = false;
+
+    /** Minimum drawn y per pixel column (the skyline, in device pixels). +Infinity = column untouched. */
+    private minY: Float64Array = new Float64Array(0);
+    /** Maximum drawn y per pixel column (the bottom-line, in device pixels). -Infinity = column untouched. */
+    private maxY: Float64Array = new Float64Array(0);
+    private width: number = 0;
+
+    // current drawing state
+    private translateX: number = 0;
+    private translateY: number = 0;
+    private scaleX: number = 1;
+    private scaleY: number = 1;
+    private currentLineWidth: number = 1;
+    private currentFillStyle: string = "#000000";
+    private fillTransparent: boolean = false;
+    private currentStrokeStyle: string = "#000000";
+    private strokeTransparent: boolean = false;
+    private currentFont: string = "10pt Arial";
+    private stateStack: IGeometricContextState[] = [];
+
+    // current path: flattened line segments in device coordinates, stored as quadruples (x0, y0, x1, y1)
+    private pathSegments: number[] = [];
+    private hasCurrentPoint: boolean = false;
+    private currentX: number = 0;
+    private currentY: number = 0;
+    private subpathStartX: number = 0;
+    private subpathStartY: number = 0;
+
+    /** Set by VexFlow's Renderer.bolsterCanvasContext() pattern, some code accesses ctx.vexFlowCanvasContext. */
+    public vexFlowCanvasContext: GeometricSkyBottomLineContext = this;
+    /** Mimics CanvasRenderingContext2D.canvas (width/height only). Some code checks for its existence. */
+    public canvas: {width: number, height: number} = {width: 0, height: 0};
+    // note: no "svg" property, so VexFlow's "if (ctx.svg)" checks correctly take the canvas branch.
+
+    constructor(width: number = 0, height: number = 300) {
+        this.initialize(width, height);
+    }
+
+    /** Resets the context for a new measure of the given pixel width. */
+    public initialize(width: number, height: number = 300): void {
+        this.width = Math.max(0, Math.floor(width));
+        if (this.minY.length < this.width) {
+            this.minY = new Float64Array(this.width);
+            this.maxY = new Float64Array(this.width);
+        }
+        this.minY.fill(Number.POSITIVE_INFINITY, 0, this.width);
+        this.maxY.fill(Number.NEGATIVE_INFINITY, 0, this.width);
+        this.canvas.width = this.width;
+        this.canvas.height = height;
+        this.translateX = 0;
+        this.translateY = 0;
+        this.scaleX = 1;
+        this.scaleY = 1;
+        this.currentLineWidth = 1;
+        this.setFillStyle("#000000");
+        this.setStrokeStyle("#000000");
+        this.currentFont = "10pt Arial";
+        this.stateStack.length = 0;
+        this.beginPath();
+    }
+
+    /**
+     * Writes the computed extents into the given skyline/bottomline arrays (in device pixels,
+     * indexed by pixel column), in the same format the raster method produced them:
+     * columns where nothing was drawn are left undefined.
+     */
+    public copyExtentsInto(skyLine: number[], bottomLine: number[]): void {
+        for (let x: number = 0; x < this.width; x++) {
+            if (this.minY[x] !== Number.POSITIVE_INFINITY) {
+                skyLine[x] = this.minY[x];
+                bottomLine[x] = this.maxY[x];
+            }
+        }
+    }
+
+    //#region path building
+
+    public beginPath(): void {
+        this.pathSegments.length = 0;
+        this.hasCurrentPoint = false;
+    }
+
+    public moveTo(x: number, y: number): void {
+        const dx: number = this.deviceX(x);
+        const dy: number = this.deviceY(y);
+        if (!isFinite(dx) || !isFinite(dy)) {
+            return; // canvas ignores non-finite coordinates
+        }
+        this.currentX = dx;
+        this.currentY = dy;
+        this.subpathStartX = dx;
+        this.subpathStartY = dy;
+        this.hasCurrentPoint = true;
+    }
+
+    public lineTo(x: number, y: number): void {
+        const dx: number = this.deviceX(x);
+        const dy: number = this.deviceY(y);
+        if (!isFinite(dx) || !isFinite(dy)) {
+            return;
+        }
+        if (!this.hasCurrentPoint) {
+            this.moveTo(x, y);
+            return;
+        }
+        this.pathSegments.push(this.currentX, this.currentY, dx, dy);
+        this.currentX = dx;
+        this.currentY = dy;
+    }
+
+    public quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void {
+        const dcpx: number = this.deviceX(cpx);
+        const dcpy: number = this.deviceY(cpy);
+        const dx: number = this.deviceX(x);
+        const dy: number = this.deviceY(y);
+        if (!isFinite(dcpx) || !isFinite(dcpy) || !isFinite(dx) || !isFinite(dy)) {
+            return;
+        }
+        if (!this.hasCurrentPoint) {
+            this.moveTo(cpx, cpy);
+        }
+        const x0: number = this.currentX;
+        const y0: number = this.currentY;
+        const segments: number = this.flatteningSegments(
+            Math.abs(dcpx - x0) + Math.abs(dx - dcpx) + Math.abs(dcpy - y0) + Math.abs(dy - dcpy));
+        let prevX: number = x0;
+        let prevY: number = y0;
+        for (let i: number = 1; i <= segments; i++) {
+            const t: number = i / segments;
+            const mt: number = 1 - t;
+            const px: number = mt * mt * x0 + 2 * mt * t * dcpx + t * t * dx;
+            const py: number = mt * mt * y0 + 2 * mt * t * dcpy + t * t * dy;
+            this.pathSegments.push(prevX, prevY, px, py);
+            prevX = px;
+            prevY = py;
+        }
+        this.currentX = dx;
+        this.currentY = dy;
+    }
+
+    public bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void {
+        const dcp1x: number = this.deviceX(cp1x);
+        const dcp1y: number = this.deviceY(cp1y);
+        const dcp2x: number = this.deviceX(cp2x);
+        const dcp2y: number = this.deviceY(cp2y);
+        const dx: number = this.deviceX(x);
+        const dy: number = this.deviceY(y);
+        if (!isFinite(dcp1x) || !isFinite(dcp1y) || !isFinite(dcp2x) || !isFinite(dcp2y) || !isFinite(dx) || !isFinite(dy)) {
+            return;
+        }
+        if (!this.hasCurrentPoint) {
+            this.moveTo(cp1x, cp1y);
+        }
+        const x0: number = this.currentX;
+        const y0: number = this.currentY;
+        const segments: number = this.flatteningSegments(
+            Math.abs(dcp1x - x0) + Math.abs(dcp2x - dcp1x) + Math.abs(dx - dcp2x) +
+            Math.abs(dcp1y - y0) + Math.abs(dcp2y - dcp1y) + Math.abs(dy - dcp2y));
+        let prevX: number = x0;
+        let prevY: number = y0;
+        for (let i: number = 1; i <= segments; i++) {
+            const t: number = i / segments;
+            const mt: number = 1 - t;
+            const a: number = mt * mt * mt;
+            const b: number = 3 * mt * mt * t;
+            const c: number = 3 * mt * t * t;
+            const d: number = t * t * t;
+            const px: number = a * x0 + b * dcp1x + c * dcp2x + d * dx;
+            const py: number = a * y0 + b * dcp1y + c * dcp2y + d * dy;
+            this.pathSegments.push(prevX, prevY, px, py);
+            prevX = px;
+            prevY = py;
+        }
+        this.currentX = dx;
+        this.currentY = dy;
+    }
+
+    public arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, antiClockwise: boolean = false): void {
+        const cx: number = this.deviceX(x);
+        const cy: number = this.deviceY(y);
+        const r: number = radius * (Math.abs(this.scaleX) + Math.abs(this.scaleY)) / 2;
+        if (!isFinite(cx) || !isFinite(cy) || !isFinite(r) || r < 0 || !isFinite(startAngle) || !isFinite(endAngle)) {
+            return;
+        }
+        let sweep: number = endAngle - startAngle;
+        if (antiClockwise) {
+            if (sweep <= -2 * Math.PI || sweep > 0) {
+                sweep = sweep % (2 * Math.PI);
+                if (sweep > 0) {
+                    sweep -= 2 * Math.PI;
+                }
+                if (sweep === 0 && endAngle !== startAngle) {
+                    sweep = -2 * Math.PI;
+                }
+            }
+        } else {
+            if (sweep >= 2 * Math.PI || sweep < 0) {
+                sweep = sweep % (2 * Math.PI);
+                if (sweep < 0) {
+                    sweep += 2 * Math.PI;
+                }
+                if (sweep === 0 && endAngle !== startAngle) {
+                    sweep = 2 * Math.PI;
+                }
+            }
+        }
+        const segments: number = Math.min(
+            GeometricSkyBottomLineContext.MAX_FLATTENING_SEGMENTS,
+            Math.max(4, Math.ceil(r * Math.abs(sweep) / 2)));
+        const startX: number = cx + r * Math.cos(startAngle);
+        const startY: number = cy + r * Math.sin(startAngle);
+        // canvas semantics: a line connects the current point to the arc start
+        if (this.hasCurrentPoint) {
+            this.pathSegments.push(this.currentX, this.currentY, startX, startY);
+        } else {
+            this.subpathStartX = startX;
+            this.subpathStartY = startY;
+            this.hasCurrentPoint = true;
+        }
+        let prevX: number = startX;
+        let prevY: number = startY;
+        for (let i: number = 1; i <= segments; i++) {
+            const angle: number = startAngle + sweep * (i / segments);
+            const px: number = cx + r * Math.cos(angle);
+            const py: number = cy + r * Math.sin(angle);
+            this.pathSegments.push(prevX, prevY, px, py);
+            prevX = px;
+            prevY = py;
+        }
+        this.currentX = prevX;
+        this.currentY = prevY;
+    }
+
+    public rect(x: number, y: number, width: number, height: number): void {
+        this.moveTo(x, y);
+        this.lineTo(x + width, y);
+        this.lineTo(x + width, y + height);
+        this.lineTo(x, y + height);
+        this.closePath();
+        this.moveTo(x, y);
+    }
+
+    public closePath(): void {
+        if (this.hasCurrentPoint && (this.currentX !== this.subpathStartX || this.currentY !== this.subpathStartY)) {
+            this.pathSegments.push(this.currentX, this.currentY, this.subpathStartX, this.subpathStartY);
+            this.currentX = this.subpathStartX;
+            this.currentY = this.subpathStartY;
+        }
+    }
+
+    //#endregion
+
+    //#region drawing (merging into the extent arrays)
+
+    /**
+     * For min/max per column, the fill of a closed path has the same extents as its outline:
+     * the topmost/bottommost filled point of a column always lies on the path boundary
+     * (holes like in half note noteheads never contain a column's extremes).
+     */
+    public fill(): void {
+        if (this.fillTransparent) {
+            return;
+        }
+        const segments: number[] = this.pathSegments;
+        for (let i: number = 0; i < segments.length; i += 4) {
+            this.mergeSegment(segments[i], segments[i + 1], segments[i + 2], segments[i + 3]);
+        }
+    }
+
+    public stroke(): void {
+        if (this.strokeTransparent || !(this.currentLineWidth > 0)) {
+            return;
+        }
+        const halfWidth: number = this.currentLineWidth * (Math.abs(this.scaleX) + Math.abs(this.scaleY)) / 4;
+        const segments: number[] = this.pathSegments;
+        for (let i: number = 0; i < segments.length; i += 4) {
+            this.mergeStrokedSegment(segments[i], segments[i + 1], segments[i + 2], segments[i + 3], halfWidth);
+        }
+    }
+
+    public fillRect(x: number, y: number, width: number, height: number): void {
+        if (this.fillTransparent) {
+            return;
+        }
+        let left: number = this.deviceX(x);
+        let top: number = this.deviceY(y);
+        let right: number = this.deviceX(x + width);
+        let bottom: number = this.deviceY(y + height);
+        if (!isFinite(left) || !isFinite(top) || !isFinite(right) || !isFinite(bottom)) {
+            return;
+        }
+        if (right < left) {
+            const tmp: number = left;
+            left = right;
+            right = tmp;
+        }
+        if (bottom < top) {
+            const tmp: number = top;
+            top = bottom;
+            bottom = tmp;
+        }
+        this.mergeColumns(left, right, top, bottom);
+    }
+
+    /** Only used by VexFlow's TabNote to erase the stave lines behind fret numbers,
+     *  which never affects the extents (skyline/bottom-line). Erasing is not supported by this context. */
+    public clearRect(x: number, y: number, width: number, height: number): void {
+        // no-op
+    }
+
+    /**
+     * Merges the ink extents of the text, character by character (a single box for the whole string
+     * would e.g. claim ascender height above lowercase letters, unlike the rasterized text the
+     * raster method saw, which has per-character contours).
+     */
+    public fillText(text: string, x: number, y: number): void {
+        if (this.fillTransparent || !text) {
+            return;
+        }
+        let pen: number = this.deviceX(x);
+        const baseline: number = this.deviceY(y);
+        if (!isFinite(pen) || !isFinite(baseline)) {
+            return;
+        }
+        const absScaleX: number = Math.abs(this.scaleX);
+        const absScaleY: number = Math.abs(this.scaleY);
+        for (const character of text) {
+            const charExtents: ICharacterExtents = this.measureCharacter(character);
+            // note: rasterizers with font hinting can shift glyph edges by up to a pixel depending on
+            // the fractional pen position, which can't be predicted here. The exact (unrounded) edges
+            // are the conservative choice: they never miss ink, at most claiming up to a pixel more.
+            const inkLeft: number = pen + charExtents.inkLeft * absScaleX;
+            const inkRight: number = pen + charExtents.inkRight * absScaleX;
+            if (inkRight > inkLeft) { // e.g. spaces have no ink
+                this.mergeColumns(inkLeft, inkRight,
+                    baseline - charExtents.ascent * absScaleY, baseline + charExtents.descent * absScaleY);
+            }
+            pen += charExtents.advance * absScaleX;
+        }
+    }
+
+    public measureText(text: string): TextMetrics {
+        const metrics: TextMetrics = this.measureTextInternal(text);
+        if (metrics) {
+            return metrics;
+        }
+        if (!GeometricSkyBottomLineContext.measureTextWarningLogged) {
+            GeometricSkyBottomLineContext.measureTextWarningLogged = true;
+            log.info("GeometricSkyBottomLineContext: no 2D context available for measureText, using estimates.");
+        }
+        return {width: this.fontSizeInPixels() * GeometricSkyBottomLineContext.FALLBACK_CHAR_WIDTH * text.length} as TextMetrics;
+    }
+
+    //#endregion
+
+    //#region state
+
+    public save(): void {
+        this.stateStack.push({
+            translateX: this.translateX,
+            translateY: this.translateY,
+            scaleX: this.scaleX,
+            scaleY: this.scaleY,
+            lineWidth: this.currentLineWidth,
+            fillStyle: this.currentFillStyle,
+            fillTransparent: this.fillTransparent,
+            strokeStyle: this.currentStrokeStyle,
+            strokeTransparent: this.strokeTransparent,
+            font: this.currentFont,
+        });
+    }
+
+    public restore(): void {
+        const state: IGeometricContextState = this.stateStack.pop();
+        if (state) {
+            this.translateX = state.translateX;
+            this.translateY = state.translateY;
+            this.scaleX = state.scaleX;
+            this.scaleY = state.scaleY;
+            this.currentLineWidth = state.lineWidth;
+            this.currentFillStyle = state.fillStyle;
+            this.fillTransparent = state.fillTransparent;
+            this.currentStrokeStyle = state.strokeStyle;
+            this.strokeTransparent = state.strokeTransparent;
+            this.currentFont = state.font;
+        }
+    }
+
+    public scale(x: number, y: number): void {
+        this.scaleX *= x;
+        this.scaleY *= y;
+    }
+
+    public translate(x: number, y: number): void {
+        this.translateX += x * this.scaleX;
+        this.translateY += y * this.scaleY;
+    }
+
+    // style setters, both as VexFlow context methods and as canvas properties:
+
+    public setFillStyle(style: string): GeometricSkyBottomLineContext {
+        this.currentFillStyle = style;
+        this.fillTransparent = GeometricSkyBottomLineContext.isTransparent(style);
+        return this;
+    }
+
+    public get fillStyle(): string {
+        return this.currentFillStyle;
+    }
+
+    public set fillStyle(style: string) {
+        this.setFillStyle(style);
+    }
+
+    public setStrokeStyle(style: string): GeometricSkyBottomLineContext {
+        this.currentStrokeStyle = style;
+        this.strokeTransparent = GeometricSkyBottomLineContext.isTransparent(style);
+        return this;
+    }
+
+    public get strokeStyle(): string {
+        return this.currentStrokeStyle;
+    }
+
+    public set strokeStyle(style: string) {
+        this.setStrokeStyle(style);
+    }
+
+    public setLineWidth(width: number): GeometricSkyBottomLineContext {
+        this.currentLineWidth = width;
+        return this;
+    }
+
+    public get lineWidth(): number {
+        return this.currentLineWidth;
+    }
+
+    public set lineWidth(width: number) {
+        this.currentLineWidth = width;
+    }
+
+    public setFont(family: string, size: number, weight: string|number): GeometricSkyBottomLineContext {
+        // same format as VexFlow's CanvasContext.setFont():
+        this.currentFont = (weight || "") + " " + size + "pt " + family;
+        return this;
+    }
+
+    public setRawFont(font: string): GeometricSkyBottomLineContext {
+        this.currentFont = font;
+        return this;
+    }
+
+    public get font(): string {
+        return this.currentFont;
+    }
+
+    public set font(font: string) {
+        this.currentFont = font;
+    }
+
+    //#endregion
+
+    //#region no-ops (irrelevant for extents calculation)
+
+    public clear(): void {
+        this.minY.fill(Number.POSITIVE_INFINITY, 0, this.width);
+        this.maxY.fill(Number.NEGATIVE_INFINITY, 0, this.width);
+    }
+
+    public openGroup(cls?: string, id?: string, attrs?: object): undefined {
+        return undefined; // like on a canvas context: groups only exist in SVG
+    }
+
+    public closeGroup(): void {
+        // no-op
+    }
+
+    public getGroup(): undefined {
+        return undefined;
+    }
+
+    public add(): void {
+        // no-op
+    }
+
+    public setBackgroundFillStyle(style: string): GeometricSkyBottomLineContext {
+        return this; // background is never drawn here
+    }
+
+    public setShadowColor(style: string): GeometricSkyBottomLineContext {
+        return this; // shadows are not used by OSMD
+    }
+
+    public setShadowBlur(blur: number): GeometricSkyBottomLineContext {
+        return this;
+    }
+
+    public setLineCap(capType: string): GeometricSkyBottomLineContext {
+        return this; // butt caps are assumed; round/square caps would add at most lineWidth/2
+    }
+
+    public setLineDash(dash: number[]): GeometricSkyBottomLineContext {
+        return this; // dashed lines are treated as solid (conservative)
+    }
+
+    public set lineCap(capType: string) {
+        // no-op
+    }
+
+    public set lineDash(dash: number[]) {
+        // no-op
+    }
+
+    public glow(): GeometricSkyBottomLineContext {
+        return this;
+    }
+
+    //#endregion
+
+    //#region private helpers
+
+    private deviceX(x: number): number {
+        return x * this.scaleX + this.translateX;
+    }
+
+    private deviceY(y: number): number {
+        return y * this.scaleY + this.translateY;
+    }
+
+    private flatteningSegments(controlPolygonLength: number): number {
+        return Math.min(
+            GeometricSkyBottomLineContext.MAX_FLATTENING_SEGMENTS,
+            Math.max(2, Math.ceil(controlPolygonLength / GeometricSkyBottomLineContext.FLATTENING_SEGMENT_LENGTH)));
+    }
+
+    /** Merges a line segment (in device coordinates) into the extent arrays. */
+    private mergeSegment(x0: number, y0: number, x1: number, y1: number): void {
+        if (x1 < x0) {
+            let tmp: number = x0;
+            x0 = x1;
+            x1 = tmp;
+            tmp = y0;
+            y0 = y1;
+            y1 = tmp;
+        }
+        const firstColumn: number = Math.max(0, Math.floor(x0));
+        const lastColumn: number = Math.min(this.width - 1, Math.floor(x1));
+        if (lastColumn < firstColumn) {
+            return; // outside the measure (horizontal clipping like on the per-measure canvas)
+        }
+        if (x1 - x0 < 1e-7) {
+            // (nearly) vertical segment: a single column
+            const lo: number = Math.min(y0, y1);
+            const hi: number = Math.max(y0, y1);
+            const column: number = firstColumn;
+            if (lo < this.minY[column]) {
+                this.minY[column] = lo;
+            }
+            if (hi > this.maxY[column]) {
+                this.maxY[column] = hi;
+            }
+            return;
+        }
+        const slope: number = (y1 - y0) / (x1 - x0);
+        for (let column: number = firstColumn; column <= lastColumn; column++) {
+            const xa: number = Math.max(x0, column);
+            const xb: number = Math.min(x1, column + 1);
+            const ya: number = y0 + (xa - x0) * slope;
+            const yb: number = y0 + (xb - x0) * slope;
+            let lo: number = ya;
+            let hi: number = yb;
+            if (lo > hi) {
+                const tmp: number = lo;
+                lo = hi;
+                hi = tmp;
+            }
+            if (lo < this.minY[column]) {
+                this.minY[column] = lo;
+            }
+            if (hi > this.maxY[column]) {
+                this.maxY[column] = hi;
+            }
+        }
+    }
+
+    /** Merges a stroked line segment by merging the outline of its (butt-capped) stroke rectangle. */
+    private mergeStrokedSegment(x0: number, y0: number, x1: number, y1: number, halfWidth: number): void {
+        const dx: number = x1 - x0;
+        const dy: number = y1 - y0;
+        const length: number = Math.sqrt(dx * dx + dy * dy);
+        if (length < 1e-7) {
+            // degenerate segment: stroke it as a (cap-less) point with extents in both directions, conservatively
+            this.mergeColumns(x0 - halfWidth, x0 + halfWidth, y0 - halfWidth, y0 + halfWidth);
+            return;
+        }
+        // outline of the stroke rectangle: the segment offset by +/- halfWidth along its normal
+        const normalX: number = -dy / length * halfWidth;
+        const normalY: number = dx / length * halfWidth;
+        this.mergeSegment(x0 + normalX, y0 + normalY, x1 + normalX, y1 + normalY);
+        this.mergeSegment(x1 + normalX, y1 + normalY, x1 - normalX, y1 - normalY);
+        this.mergeSegment(x1 - normalX, y1 - normalY, x0 - normalX, y0 - normalY);
+        this.mergeSegment(x0 - normalX, y0 - normalY, x0 + normalX, y0 + normalY);
+    }
+
+    /** Merges the vertical range [top, bottom] into all columns intersecting [left, right) (device coordinates). */
+    private mergeColumns(left: number, right: number, top: number, bottom: number): void {
+        if (!(right > left)) {
+            return; // zero or negative width: nothing is drawn
+        }
+        const firstColumn: number = Math.max(0, Math.floor(left));
+        const lastColumn: number = Math.min(this.width - 1, Math.ceil(right) - 1);
+        for (let column: number = firstColumn; column <= lastColumn; column++) {
+            if (top < this.minY[column]) {
+                this.minY[column] = top;
+            }
+            if (bottom > this.maxY[column]) {
+                this.maxY[column] = bottom;
+            }
+        }
+    }
+
+    /** Font size in px, parsed from the current font string (e.g. "italic 10pt Arial" or "12px Times"). */
+    private fontSizeInPixels(): number {
+        const match: RegExpMatchArray = this.currentFont?.match(/([0-9.]+)\s*(pt|px)/);
+        if (!match) {
+            return 10 * GeometricSkyBottomLineContext.PT_TO_PX;
+        }
+        const size: number = parseFloat(match[1]);
+        return match[2] === "pt" ? size * GeometricSkyBottomLineContext.PT_TO_PX : size;
+    }
+
+    /** Measures the ink extents of a single character in the current font, cached.
+     *  Uses TextMetrics.actualBoundingBox* (exact ink extents) where available,
+     *  with estimates from the font size as a fallback. */
+    private measureCharacter(character: string): ICharacterExtents {
+        const cacheKey: string = this.currentFont + " " + character;
+        let extents: ICharacterExtents = GeometricSkyBottomLineContext.characterExtentsCache.get(cacheKey);
+        if (extents) {
+            return extents;
+        }
+        const fontSizePx: number = this.fontSizeInPixels();
+        const metrics: TextMetrics = this.measureTextInternal(character);
+        if (metrics) {
+            const advance: number = metrics.width;
+            // most accurate: probe the actual rasterized ink of the character (same rasterizer
+            // the raster method used, including font hinting and side bearings)
+            extents = this.probeCharacterInk(character, advance, fontSizePx);
+            if (!extents && metrics.actualBoundingBoxAscent !== undefined) {
+                extents = {
+                    advance,
+                    ascent: metrics.actualBoundingBoxAscent,
+                    descent: metrics.actualBoundingBoxDescent,
+                    // ink span relative to the pen: [-actualBoundingBoxLeft, actualBoundingBoxRight],
+                    // clamped to the advance box (some environments report slightly off side bearings)
+                    inkLeft: Math.max(0, -metrics.actualBoundingBoxLeft),
+                    inkRight: Math.min(advance, metrics.actualBoundingBoxRight),
+                };
+            }
+            if (!extents) {
+                extents = {
+                    advance,
+                    ascent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_ASCENT,
+                    descent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_DESCENT,
+                    inkLeft: 0,
+                    inkRight: character.trim().length === 0 ? 0 : advance,
+                };
+            }
+        } else {
+            const advance: number = fontSizePx * GeometricSkyBottomLineContext.FALLBACK_CHAR_WIDTH;
+            extents = {
+                advance,
+                ascent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_ASCENT,
+                descent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_DESCENT,
+                inkLeft: 0,
+                inkRight: character.trim().length === 0 ? 0 : advance,
+            };
+        }
+        GeometricSkyBottomLineContext.characterExtentsCache.set(cacheKey, extents);
+        return extents;
+    }
+
+    /** Renders a single character to a small hidden canvas and scans its exact ink extents.
+     *  Only happens once per font + character (see characterExtentsCache); the canvas is tiny
+     *  (a few hundred pixels), so this has none of the performance issues of the per-measure
+     *  getImageData calls of the raster method. Returns undefined if no canvas is available. */
+    private probeCharacterInk(character: string, advance: number, fontSizePx: number): ICharacterExtents {
+        const statics: typeof GeometricSkyBottomLineContext = GeometricSkyBottomLineContext;
+        if (!statics.characterProbeContext && !statics.characterProbeCreationFailed) {
+            try {
+                statics.characterProbeCanvas = document.createElement("canvas");
+                statics.characterProbeContext = statics.characterProbeCanvas.getContext("2d", {willReadFrequently: true}) as CanvasRenderingContext2D;
+            } catch (e) {
+                // e.g. document does not exist (pure node without DOM)
+            }
+            if (!statics.characterProbeContext) {
+                statics.characterProbeCreationFailed = true;
+            }
+        }
+        const context: CanvasRenderingContext2D = statics.characterProbeContext;
+        if (!context) {
+            return undefined;
+        }
+        const padding: number = Math.ceil(fontSizePx); // room for side bearings / italic overhang
+        const width: number = Math.ceil(advance) + 2 * padding;
+        const height: number = Math.ceil(3 * fontSizePx) + 2;
+        const penX: number = padding;
+        const baselineY: number = Math.ceil(2 * fontSizePx);
+        try {
+            const canvas: HTMLCanvasElement = statics.characterProbeCanvas;
+            if (canvas.width < width) {
+                canvas.width = width;
+            }
+            if (canvas.height < height) {
+                canvas.height = height;
+            }
+            context.clearRect(0, 0, canvas.width, canvas.height);
+            context.font = this.currentFont;
+            context.fillStyle = "#000000";
+            context.fillText(character, penX, baselineY);
+            const imageData: ImageData = context.getImageData(0, 0, width, height);
+            const data: Uint8ClampedArray = imageData.data;
+            let minX: number = Number.MAX_SAFE_INTEGER;
+            let maxX: number = -1;
+            let minY: number = Number.MAX_SAFE_INTEGER;
+            let maxY: number = -1;
+            for (let pixelY: number = 0; pixelY < height; pixelY++) {
+                const rowOffset: number = pixelY * width * 4;
+                for (let pixelX: number = 0; pixelX < width; pixelX++) {
+                    if (data[rowOffset + pixelX * 4 + 3] > 0) {
+                        if (pixelX < minX) {
+                            minX = pixelX;
+                        }
+                        if (pixelX > maxX) {
+                            maxX = pixelX;
+                        }
+                        if (pixelY < minY) {
+                            minY = pixelY;
+                        }
+                        if (pixelY > maxY) {
+                            maxY = pixelY;
+                        }
+                    }
+                }
+            }
+            if (maxX < 0) { // no ink, e.g. a space
+                return {advance, ascent: 0, descent: 0, inkLeft: 0, inkRight: 0};
+            }
+            return {
+                advance,
+                ascent: baselineY - minY,
+                descent: maxY + 1 - baselineY,
+                inkLeft: minX - penX,
+                inkRight: maxX + 1 - penX,
+            };
+        } catch (e) {
+            statics.characterProbeCreationFailed = true; // e.g. canvas without 2D rasterizer
+            return undefined;
+        }
+    }
+
+    private measureTextInternal(text: string): TextMetrics {
+        if (!GeometricSkyBottomLineContext.textMeasureContext && !GeometricSkyBottomLineContext.textMeasureContextCreationFailed) {
+            try {
+                const canvas: HTMLCanvasElement = document.createElement("canvas");
+                GeometricSkyBottomLineContext.textMeasureContext = canvas.getContext("2d");
+            } catch (e) {
+                // e.g. document does not exist (pure node without DOM): fall back to estimates
+            }
+            if (!GeometricSkyBottomLineContext.textMeasureContext) {
+                GeometricSkyBottomLineContext.textMeasureContextCreationFailed = true;
+            }
+        }
+        const context: CanvasRenderingContext2D = GeometricSkyBottomLineContext.textMeasureContext;
+        if (!context) {
+            return undefined;
+        }
+        if (context.font !== this.currentFont) {
+            context.font = this.currentFont;
+        }
+        return context.measureText(text);
+    }
+
+    /** Whether a fill/stroke style is completely transparent, i.e. invisible,
+     *  like "#12345600" (8-digit hex with alpha 00, as used by OSMD for invisible elements) or "rgba(0,0,0,0)".
+     *  The raster method ignored these via its alpha > 0 pixel test. */
+    private static isTransparent(style: string): boolean {
+        if (!style || typeof style !== "string") {
+            return false; // unknown style (e.g. gradient object): assume visible
+        }
+        if (style === "none" || style === "transparent") {
+            return true;
+        }
+        if (style[0] === "#") {
+            if (style.length === 9) { // #rrggbbaa
+                return style[7] === "0" && style[8] === "0";
+            }
+            if (style.length === 5) { // #rgba
+                return style[4] === "0";
+            }
+            return false;
+        }
+        const rgbaMatch: RegExpMatchArray = style.match(/^rgba\s*\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\s*\)/i);
+        if (rgbaMatch) {
+            return parseFloat(rgbaMatch[1]) === 0;
+        }
+        return false;
+    }
+
+    //#endregion
+}

--- a/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
+++ b/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
@@ -1,30 +1,5 @@
 import log from "loglevel";
 
-/** Ink extents of a single character, in px for the font it was measured with.
- *  inkLeft/inkRight are relative to the pen position (inkLeft can be slightly negative,
- *  e.g. italic overhang, and inkRight can exceed the advance width). */
-interface ICharacterExtents {
-    advance: number;
-    ascent: number;
-    descent: number;
-    inkLeft: number;
-    inkRight: number;
-}
-
-/** Drawing state that can be saved/restored with save()/restore(), mirroring canvas semantics. */
-interface IGeometricContextState {
-    translateX: number;
-    translateY: number;
-    scaleX: number;
-    scaleY: number;
-    lineWidth: number;
-    fillStyle: string;
-    fillTransparent: boolean;
-    strokeStyle: string;
-    strokeTransparent: boolean;
-    font: string;
-}
-
 /**
  * A virtual VexFlow rendering context that computes the vertical extents (min and max y)
  * of everything drawn into it, per (pixel) column, instead of rasterizing to a canvas.
@@ -61,37 +36,21 @@ interface IGeometricContextState {
  */
 export class GeometricSkyBottomLineContext {
     /** Conversion factor pt -> px for font sizes, as used by canvas. */
-    private static readonly PT_TO_PX: number = 4 / 3;
+    private readonly PT_TO_PX: number = 4 / 3;
     /** Fallback font ascent as a fraction of the font size in px, if TextMetrics.actualBoundingBoxAscent is unavailable. */
-    private static readonly FALLBACK_FONT_ASCENT: number = 0.9;
+    private readonly FALLBACK_FONT_ASCENT: number = 0.9;
     /** Fallback font descent as a fraction of the font size in px, if TextMetrics.actualBoundingBoxDescent is unavailable. */
-    private static readonly FALLBACK_FONT_DESCENT: number = 0.25;
+    private readonly FALLBACK_FONT_DESCENT: number = 0.25;
     /** Fallback per-character width as a fraction of the font size in px, if no 2D context is available for measureText. */
-    private static readonly FALLBACK_CHAR_WIDTH: number = 0.6;
+    private readonly FALLBACK_CHAR_WIDTH: number = 0.6;
     /** Maximum number of line segments a Bézier curve or arc is flattened into. */
-    private static readonly MAX_FLATTENING_SEGMENTS: number = 64;
+    private readonly MAX_FLATTENING_SEGMENTS: number = 64;
     /** Target length (in px) of the line segments a Bézier curve is flattened into. */
-    private static readonly FLATTENING_SEGMENT_LENGTH: number = 3;
+    private readonly FLATTENING_SEGMENT_LENGTH: number = 3;
 
-    /** Shared hidden canvas context used only for measureText() (cheap, no pixel readback). */
-    private static textMeasureContext: CanvasRenderingContext2D;
-    private static textMeasureContextCreationFailed: boolean = false;
-    private static measureTextWarningLogged: boolean = false;
-    /** Character ink extents, cached by font + character (see measureCharacter()). */
-    private static characterExtentsCache: Map<string, ICharacterExtents> = new Map<string, ICharacterExtents>();
-    /** Flattened line segments of glyph outlines (quadruples x0,y0,x1,y1, relative to the glyph
-     *  origin, already scaled and y-inverted), cached per outline (by reference) and scale, see
-     *  drawCachedGlyphOutline(). VexFlow caches the outline arrays on its font glyph entries,
-     *  so they are stable keys that live as long as the font. */
-    private static glyphSegmentsCache: WeakMap<object, Map<number, Float64Array>> =
-        new WeakMap<object, Map<number, Float64Array>>();
-    /** Scratch context used to flatten glyph outlines (reused, see computeGlyphSegments()). */
-    private static glyphSegmentsScratch: GeometricSkyBottomLineContext;
-    /** Tiny hidden canvas used to probe the exact rasterized ink extents of single characters
-     *  (once per font + character, then cached forever in characterExtentsCache). */
-    private static characterProbeCanvas: HTMLCanvasElement;
-    private static characterProbeContext: CanvasRenderingContext2D;
-    private static characterProbeCreationFailed: boolean = false;
+    /** Caches for text measurements and glyph outline flattening, typically owned by EngravingRules
+     *  (one per OSMD instance) so they persist across measures, stafflines and renders. */
+    private readonly caches: GeometricSkyBottomLineCaches;
 
     /** Minimum drawn y per pixel column (the skyline, in device pixels). +Infinity = column untouched. */
     private minY: Float64Array = new Float64Array(0);
@@ -126,7 +85,8 @@ export class GeometricSkyBottomLineContext {
     public canvas: {width: number, height: number} = {width: 0, height: 0};
     // note: no "svg" property, so VexFlow's "if (ctx.svg)" checks correctly take the canvas branch.
 
-    constructor(width: number = 0, height: number = 300) {
+    constructor(width: number = 0, height: number = 300, caches?: GeometricSkyBottomLineCaches) {
+        this.caches = caches ?? new GeometricSkyBottomLineCaches();
         this.initialize(width, height);
     }
 
@@ -299,7 +259,7 @@ export class GeometricSkyBottomLineContext {
             }
         }
         const segments: number = Math.min(
-            GeometricSkyBottomLineContext.MAX_FLATTENING_SEGMENTS,
+            this.MAX_FLATTENING_SEGMENTS,
             Math.max(4, Math.ceil(r * Math.abs(sweep) / 2)));
         const startX: number = cx + r * Math.cos(startAngle);
         const startY: number = cy + r * Math.sin(startAngle);
@@ -438,11 +398,11 @@ export class GeometricSkyBottomLineContext {
         if (metrics) {
             return metrics;
         }
-        if (!GeometricSkyBottomLineContext.measureTextWarningLogged) {
-            GeometricSkyBottomLineContext.measureTextWarningLogged = true;
+        if (!this.caches.measureTextWarningLogged) {
+            this.caches.measureTextWarningLogged = true;
             log.info("GeometricSkyBottomLineContext: no 2D context available for measureText, using estimates.");
         }
-        return {width: this.fontSizeInPixels() * GeometricSkyBottomLineContext.FALLBACK_CHAR_WIDTH * text.length} as TextMetrics;
+        return {width: this.fontSizeInPixels() * this.FALLBACK_CHAR_WIDTH * text.length} as TextMetrics;
     }
 
     /**
@@ -525,7 +485,7 @@ export class GeometricSkyBottomLineContext {
 
     public setFillStyle(style: string): GeometricSkyBottomLineContext {
         this.currentFillStyle = style;
-        this.fillTransparent = GeometricSkyBottomLineContext.isTransparent(style);
+        this.fillTransparent = isTransparent(style);
         return this;
     }
 
@@ -539,7 +499,7 @@ export class GeometricSkyBottomLineContext {
 
     public setStrokeStyle(style: string): GeometricSkyBottomLineContext {
         this.currentStrokeStyle = style;
-        this.strokeTransparent = GeometricSkyBottomLineContext.isTransparent(style);
+        this.strokeTransparent = isTransparent(style);
         return this;
     }
 
@@ -654,8 +614,8 @@ export class GeometricSkyBottomLineContext {
 
     private flatteningSegments(controlPolygonLength: number): number {
         return Math.min(
-            GeometricSkyBottomLineContext.MAX_FLATTENING_SEGMENTS,
-            Math.max(2, Math.ceil(controlPolygonLength / GeometricSkyBottomLineContext.FLATTENING_SEGMENT_LENGTH)));
+            this.MAX_FLATTENING_SEGMENTS,
+            Math.max(2, Math.ceil(controlPolygonLength / this.FLATTENING_SEGMENT_LENGTH)));
     }
 
     /** Merges a line segment (in device coordinates) into the extent arrays. */
@@ -760,24 +720,23 @@ export class GeometricSkyBottomLineContext {
     private fontSizeInPixels(): number {
         const match: RegExpMatchArray = this.currentFont?.match(/([0-9.]+)\s*(pt|px)/);
         if (!match) {
-            return 10 * GeometricSkyBottomLineContext.PT_TO_PX;
+            return 10 * this.PT_TO_PX;
         }
         const size: number = parseFloat(match[1]);
-        return match[2] === "pt" ? size * GeometricSkyBottomLineContext.PT_TO_PX : size;
+        return match[2] === "pt" ? size * this.PT_TO_PX : size;
     }
 
     /** Returns the cached flattened segments for a glyph outline at the given scale,
      *  computing them on first use (see drawCachedGlyphOutline()). */
     private getGlyphSegments(outline: string[], scale: number): Float64Array {
-        const statics: typeof GeometricSkyBottomLineContext = GeometricSkyBottomLineContext;
-        let segmentsByScale: Map<number, Float64Array> = statics.glyphSegmentsCache.get(outline);
+        let segmentsByScale: Map<number, Float64Array> = this.caches.glyphSegments.get(outline);
         if (!segmentsByScale) {
             segmentsByScale = new Map<number, Float64Array>();
-            statics.glyphSegmentsCache.set(outline, segmentsByScale);
+            this.caches.glyphSegments.set(outline, segmentsByScale);
         }
         let segments: Float64Array = segmentsByScale.get(scale);
         if (!segments) {
-            segments = statics.computeGlyphSegments(outline, scale);
+            segments = this.computeGlyphSegments(outline, scale);
             segmentsByScale.set(scale, segments);
         }
         return segments;
@@ -786,11 +745,11 @@ export class GeometricSkyBottomLineContext {
     /** Flattens a glyph outline at the given scale into line segments relative to the glyph origin,
      *  by replaying the outline (the same way VexFlow's Glyph.processOutline does, with y inverted)
      *  into a scratch context's path, so the segments are identical to the normal path commands'. */
-    private static computeGlyphSegments(outline: string[], scale: number): Float64Array {
-        if (!GeometricSkyBottomLineContext.glyphSegmentsScratch) {
-            GeometricSkyBottomLineContext.glyphSegmentsScratch = new GeometricSkyBottomLineContext();
+    private computeGlyphSegments(outline: string[], scale: number): Float64Array {
+        if (!this.caches.glyphSegmentsScratch) {
+            this.caches.glyphSegmentsScratch = new GeometricSkyBottomLineContext(0, 300, this.caches);
         }
-        const scratch: GeometricSkyBottomLineContext = GeometricSkyBottomLineContext.glyphSegmentsScratch;
+        const scratch: GeometricSkyBottomLineContext = this.caches.glyphSegmentsScratch;
         scratch.initialize(0); // only the path is used, nothing is merged
         // replay the outline like VexFlow's processOutline(outline, 0, 0, scale, -scale, ...):
         let i: number = 0;
@@ -829,7 +788,7 @@ export class GeometricSkyBottomLineContext {
      *  with estimates from the font size as a fallback. */
     private measureCharacter(character: string): ICharacterExtents {
         const cacheKey: string = this.currentFont + " " + character;
-        let extents: ICharacterExtents = GeometricSkyBottomLineContext.characterExtentsCache.get(cacheKey);
+        let extents: ICharacterExtents = this.caches.characterExtents.get(cacheKey);
         if (extents) {
             return extents;
         }
@@ -854,23 +813,23 @@ export class GeometricSkyBottomLineContext {
             if (!extents) {
                 extents = {
                     advance,
-                    ascent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_ASCENT,
-                    descent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_DESCENT,
+                    ascent: fontSizePx * this.FALLBACK_FONT_ASCENT,
+                    descent: fontSizePx * this.FALLBACK_FONT_DESCENT,
                     inkLeft: 0,
                     inkRight: character.trim().length === 0 ? 0 : advance,
                 };
             }
         } else {
-            const advance: number = fontSizePx * GeometricSkyBottomLineContext.FALLBACK_CHAR_WIDTH;
+            const advance: number = fontSizePx * this.FALLBACK_CHAR_WIDTH;
             extents = {
                 advance,
-                ascent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_ASCENT,
-                descent: fontSizePx * GeometricSkyBottomLineContext.FALLBACK_FONT_DESCENT,
+                ascent: fontSizePx * this.FALLBACK_FONT_ASCENT,
+                descent: fontSizePx * this.FALLBACK_FONT_DESCENT,
                 inkLeft: 0,
                 inkRight: character.trim().length === 0 ? 0 : advance,
             };
         }
-        GeometricSkyBottomLineContext.characterExtentsCache.set(cacheKey, extents);
+        this.caches.characterExtents.set(cacheKey, extents);
         return extents;
     }
 
@@ -879,19 +838,19 @@ export class GeometricSkyBottomLineContext {
      *  (a few hundred pixels), so this has none of the performance issues of the per-measure
      *  getImageData calls of the raster method. Returns undefined if no canvas is available. */
     private probeCharacterInk(character: string, advance: number, fontSizePx: number): ICharacterExtents {
-        const statics: typeof GeometricSkyBottomLineContext = GeometricSkyBottomLineContext;
-        if (!statics.characterProbeContext && !statics.characterProbeCreationFailed) {
+        const caches: GeometricSkyBottomLineCaches = this.caches;
+        if (!caches.characterProbeContext && !caches.characterProbeCreationFailed) {
             try {
-                statics.characterProbeCanvas = document.createElement("canvas");
-                statics.characterProbeContext = statics.characterProbeCanvas.getContext("2d", {willReadFrequently: true}) as CanvasRenderingContext2D;
+                caches.characterProbeCanvas = document.createElement("canvas");
+                caches.characterProbeContext = caches.characterProbeCanvas.getContext("2d", {willReadFrequently: true}) as CanvasRenderingContext2D;
             } catch (e) {
                 // e.g. document does not exist (pure node without DOM)
             }
-            if (!statics.characterProbeContext) {
-                statics.characterProbeCreationFailed = true;
+            if (!caches.characterProbeContext) {
+                caches.characterProbeCreationFailed = true;
             }
         }
-        const context: CanvasRenderingContext2D = statics.characterProbeContext;
+        const context: CanvasRenderingContext2D = caches.characterProbeContext;
         if (!context) {
             return undefined;
         }
@@ -901,7 +860,7 @@ export class GeometricSkyBottomLineContext {
         const penX: number = padding;
         const baselineY: number = Math.ceil(2 * fontSizePx);
         try {
-            const canvas: HTMLCanvasElement = statics.characterProbeCanvas;
+            const canvas: HTMLCanvasElement = caches.characterProbeCanvas;
             if (canvas.width < width) {
                 canvas.width = width;
             }
@@ -948,24 +907,25 @@ export class GeometricSkyBottomLineContext {
                 inkRight: maxX + 1 - penX,
             };
         } catch (e) {
-            statics.characterProbeCreationFailed = true; // e.g. canvas without 2D rasterizer
+            caches.characterProbeCreationFailed = true; // e.g. canvas without 2D rasterizer
             return undefined;
         }
     }
 
     private measureTextInternal(text: string): TextMetrics {
-        if (!GeometricSkyBottomLineContext.textMeasureContext && !GeometricSkyBottomLineContext.textMeasureContextCreationFailed) {
+        const caches: GeometricSkyBottomLineCaches = this.caches;
+        if (!caches.textMeasureContext && !caches.textMeasureContextCreationFailed) {
             try {
                 const canvas: HTMLCanvasElement = document.createElement("canvas");
-                GeometricSkyBottomLineContext.textMeasureContext = canvas.getContext("2d");
+                caches.textMeasureContext = canvas.getContext("2d");
             } catch (e) {
                 // e.g. document does not exist (pure node without DOM): fall back to estimates
             }
-            if (!GeometricSkyBottomLineContext.textMeasureContext) {
-                GeometricSkyBottomLineContext.textMeasureContextCreationFailed = true;
+            if (!caches.textMeasureContext) {
+                caches.textMeasureContextCreationFailed = true;
             }
         }
-        const context: CanvasRenderingContext2D = GeometricSkyBottomLineContext.textMeasureContext;
+        const context: CanvasRenderingContext2D = caches.textMeasureContext;
         if (!context) {
             return undefined;
         }
@@ -975,31 +935,85 @@ export class GeometricSkyBottomLineContext {
         return context.measureText(text);
     }
 
-    /** Whether a fill/stroke style is completely transparent, i.e. invisible,
-     *  like "#12345600" (8-digit hex with alpha 00, as used by OSMD for invisible elements) or "rgba(0,0,0,0)".
-     *  The raster method ignored these via its alpha > 0 pixel test. */
-    private static isTransparent(style: string): boolean {
-        if (!style || typeof style !== "string") {
-            return false; // unknown style (e.g. gradient object): assume visible
+    //#endregion
+}
+
+/** Whether a fill/stroke style is completely transparent, i.e. invisible,
+ *  like "#12345600" (8-digit hex with alpha 00, as used by OSMD for invisible elements) or "rgba(0,0,0,0)".
+ *  The raster method ignored these via its alpha > 0 pixel test. */
+function isTransparent(style: string): boolean {
+    if (!style || typeof style !== "string") {
+        return false; // unknown style (e.g. gradient object): assume visible
+    }
+    if (style === "none" || style === "transparent") {
+        return true;
+    }
+    if (style[0] === "#") {
+        if (style.length === 9) { // #rrggbbaa
+            return style[7] === "0" && style[8] === "0";
         }
-        if (style === "none" || style === "transparent") {
-            return true;
-        }
-        if (style[0] === "#") {
-            if (style.length === 9) { // #rrggbbaa
-                return style[7] === "0" && style[8] === "0";
-            }
-            if (style.length === 5) { // #rgba
-                return style[4] === "0";
-            }
-            return false;
-        }
-        const rgbaMatch: RegExpMatchArray = style.match(/^rgba\s*\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\s*\)/i);
-        if (rgbaMatch) {
-            return parseFloat(rgbaMatch[1]) === 0;
+        if (style.length === 5) { // #rgba
+            return style[4] === "0";
         }
         return false;
     }
+    const rgbaMatch: RegExpMatchArray = style.match(/^rgba\s*\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\s*\)/i);
+    if (rgbaMatch) {
+        return parseFloat(rgbaMatch[1]) === 0;
+    }
+    return false;
+}
 
-    //#endregion
+/**
+ * Caches and shared helper objects for GeometricSkyBottomLineContext. All cached values are pure
+ * functions of their keys (font + character, glyph outline + scale), so they could in principle be
+ * shared globally - but they are kept as an instanced object (owned by EngravingRules, like e.g.
+ * NoteToGraphicalNoteMap) to avoid mutable static state, so that multiple OSMD instances on one
+ * page stay fully independent (and the caches are freed with the instance).
+ */
+export class GeometricSkyBottomLineCaches {
+    /** Shared hidden canvas context used only for measureText() (cheap, no pixel readback). */
+    public textMeasureContext: CanvasRenderingContext2D;
+    public textMeasureContextCreationFailed: boolean = false;
+    public measureTextWarningLogged: boolean = false;
+    /** Character ink extents, cached by font + character (see measureCharacter()). */
+    public characterExtents: Map<string, ICharacterExtents> = new Map<string, ICharacterExtents>();
+    /** Flattened line segments of glyph outlines (quadruples x0,y0,x1,y1, relative to the glyph
+     *  origin, already scaled and y-inverted), cached per outline (by reference) and scale, see
+     *  drawCachedGlyphOutline(). VexFlow caches the outline arrays on its font glyph entries,
+     *  so they are stable keys that live as long as the font. */
+    public glyphSegments: WeakMap<object, Map<number, Float64Array>> =
+        new WeakMap<object, Map<number, Float64Array>>();
+    /** Scratch context used to flatten glyph outlines (reused, see computeGlyphSegments()). */
+    public glyphSegmentsScratch: GeometricSkyBottomLineContext;
+    /** Tiny hidden canvas used to probe the exact rasterized ink extents of single characters
+     *  (once per font + character, then cached in characterExtents). */
+    public characterProbeCanvas: HTMLCanvasElement;
+    public characterProbeContext: CanvasRenderingContext2D;
+    public characterProbeCreationFailed: boolean = false;
+}
+
+/** Ink extents of a single character, in px for the font it was measured with.
+ *  inkLeft/inkRight are relative to the pen position (inkLeft can be slightly negative,
+ *  e.g. italic overhang, and inkRight can exceed the advance width). */
+interface ICharacterExtents {
+    advance: number;
+    ascent: number;
+    descent: number;
+    inkLeft: number;
+    inkRight: number;
+}
+
+/** Drawing state that can be saved/restored with save()/restore(), mirroring canvas semantics. */
+interface IGeometricContextState {
+    translateX: number;
+    translateY: number;
+    scaleX: number;
+    scaleY: number;
+    lineWidth: number;
+    fillStyle: string;
+    fillTransparent: boolean;
+    strokeStyle: string;
+    strokeTransparent: boolean;
+    font: string;
 }

--- a/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
+++ b/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
@@ -79,6 +79,14 @@ export class GeometricSkyBottomLineContext {
     private static measureTextWarningLogged: boolean = false;
     /** Character ink extents, cached by font + character (see measureCharacter()). */
     private static characterExtentsCache: Map<string, ICharacterExtents> = new Map<string, ICharacterExtents>();
+    /** Flattened line segments of glyph outlines (quadruples x0,y0,x1,y1, relative to the glyph
+     *  origin, already scaled and y-inverted), cached per outline (by reference) and scale, see
+     *  drawCachedGlyphOutline(). VexFlow caches the outline arrays on its font glyph entries,
+     *  so they are stable keys that live as long as the font. */
+    private static glyphSegmentsCache: WeakMap<object, Map<number, Float64Array>> =
+        new WeakMap<object, Map<number, Float64Array>>();
+    /** Scratch context used to flatten glyph outlines (reused, see computeGlyphSegments()). */
+    private static glyphSegmentsScratch: GeometricSkyBottomLineContext;
     /** Tiny hidden canvas used to probe the exact rasterized ink extents of single characters
      *  (once per font + character, then cached forever in characterExtentsCache). */
     private static characterProbeCanvas: HTMLCanvasElement;
@@ -437,6 +445,37 @@ export class GeometricSkyBottomLineContext {
         return {width: this.fontSizeInPixels() * GeometricSkyBottomLineContext.FALLBACK_CHAR_WIDTH * text.length} as TextMetrics;
     }
 
+    /**
+     * Fast path for glyphs, called by VexFlow's (patched) Glyph.renderOutline() instead of issuing
+     * the outline's dozens of path commands: merges the glyph outline's flattened line segments,
+     * cached once per outline + scale (the curve flattening and command parsing are the expensive
+     * part of glyph drawing, and the same glyphs repeat constantly: noteheads, accidentals, ...).
+     * The merged segments are identical to the ones the normal path commands would produce,
+     * so the result is exactly the same.
+     * Returns true if handled (VexFlow then skips the normal path commands).
+     */
+    public drawCachedGlyphOutline(outline: object, scale: number, xPos: number, yPos: number): boolean {
+        if (this.scaleX !== 1 || this.scaleY !== 1) {
+            return false; // segments are cached per glyph scale only: use the normal path commands instead
+        }
+        if (this.fillTransparent) {
+            return true; // invisible glyph (e.g. "#00000000"): nothing to merge, like in fill()
+        }
+        const deviceX: number = this.deviceX(xPos);
+        const deviceY: number = this.deviceY(yPos);
+        if (!isFinite(deviceX) || !isFinite(deviceY) || !isFinite(scale)) {
+            return true; // canvas ignores non-finite coordinates
+        }
+        const segments: Float64Array = this.getGlyphSegments(outline as string[], scale);
+        for (let i: number = 0; i < segments.length; i += 4) {
+            this.mergeSegment(
+                segments[i] + deviceX, segments[i + 1] + deviceY,
+                segments[i + 2] + deviceX, segments[i + 3] + deviceY);
+        }
+        this.beginPath(); // the normal path would have cleared the current path, mirror that
+        return true;
+    }
+
     //#endregion
 
     //#region state
@@ -713,6 +752,64 @@ export class GeometricSkyBottomLineContext {
         }
         const size: number = parseFloat(match[1]);
         return match[2] === "pt" ? size * GeometricSkyBottomLineContext.PT_TO_PX : size;
+    }
+
+    /** Returns the cached flattened segments for a glyph outline at the given scale,
+     *  computing them on first use (see drawCachedGlyphOutline()). */
+    private getGlyphSegments(outline: string[], scale: number): Float64Array {
+        const statics: typeof GeometricSkyBottomLineContext = GeometricSkyBottomLineContext;
+        let segmentsByScale: Map<number, Float64Array> = statics.glyphSegmentsCache.get(outline);
+        if (!segmentsByScale) {
+            segmentsByScale = new Map<number, Float64Array>();
+            statics.glyphSegmentsCache.set(outline, segmentsByScale);
+        }
+        let segments: Float64Array = segmentsByScale.get(scale);
+        if (!segments) {
+            segments = statics.computeGlyphSegments(outline, scale);
+            segmentsByScale.set(scale, segments);
+        }
+        return segments;
+    }
+
+    /** Flattens a glyph outline at the given scale into line segments relative to the glyph origin,
+     *  by replaying the outline (the same way VexFlow's Glyph.processOutline does, with y inverted)
+     *  into a scratch context's path, so the segments are identical to the normal path commands'. */
+    private static computeGlyphSegments(outline: string[], scale: number): Float64Array {
+        if (!GeometricSkyBottomLineContext.glyphSegmentsScratch) {
+            GeometricSkyBottomLineContext.glyphSegmentsScratch = new GeometricSkyBottomLineContext();
+        }
+        const scratch: GeometricSkyBottomLineContext = GeometricSkyBottomLineContext.glyphSegmentsScratch;
+        scratch.initialize(0); // only the path is used, nothing is merged
+        // replay the outline like VexFlow's processOutline(outline, 0, 0, scale, -scale, ...):
+        let i: number = 0;
+        while (i < outline.length) {
+            switch (outline[i++]) {
+                case "m":
+                    scratch.moveTo(Number(outline[i++]) * scale, Number(outline[i++]) * -scale);
+                    break;
+                case "l":
+                    scratch.lineTo(Number(outline[i++]) * scale, Number(outline[i++]) * -scale);
+                    break;
+                case "q": {
+                    const x: number = Number(outline[i++]) * scale;
+                    const y: number = Number(outline[i++]) * -scale;
+                    scratch.quadraticCurveTo(Number(outline[i++]) * scale, Number(outline[i++]) * -scale, x, y);
+                    break;
+                }
+                case "b": {
+                    const x: number = Number(outline[i++]) * scale;
+                    const y: number = Number(outline[i++]) * -scale;
+                    scratch.bezierCurveTo(
+                        Number(outline[i++]) * scale, Number(outline[i++]) * -scale,
+                        Number(outline[i++]) * scale, Number(outline[i++]) * -scale,
+                        x, y);
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+        return Float64Array.from(scratch.pathSegments);
     }
 
     /** Measures the ink extents of a single character in the current font, cached.

--- a/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
+++ b/src/MusicalScore/Graphical/GeometricSkyBottomLineContext.ts
@@ -668,16 +668,22 @@ export class GeometricSkyBottomLineContext {
             y0 = y1;
             y1 = tmp;
         }
-        const firstColumn: number = Math.max(0, Math.floor(x0));
-        const lastColumn: number = Math.min(this.width - 1, Math.floor(x1));
-        if (lastColumn < firstColumn) {
-            return; // outside the measure (horizontal clipping like on the per-measure canvas)
-        }
         if (x1 - x0 < 1e-7) {
-            // (nearly) vertical segment: a single column
+            // (Nearly) vertical segment: a single column.
+            // If it lies exactly on a column boundary, it covers nothing of either column, and the
+            // rasterizer paints nothing - e.g. the end cap of a stroke ending exactly at x = 0,
+            // which occurs for the negative-width staves of some extra graphical measures
+            // (see test_octaveshift_extragraphicalmeasure): claiming the column there would also
+            // poison the "fill empty columns from neighbors" step for such mostly empty measures.
+            if (x0 === Math.trunc(x0)) {
+                return;
+            }
+            const column: number = Math.floor(x0);
+            if (column < 0 || column >= this.width) {
+                return; // outside the measure (horizontal clipping like on the per-measure canvas)
+            }
             const lo: number = Math.min(y0, y1);
             const hi: number = Math.max(y0, y1);
-            const column: number = firstColumn;
             if (lo < this.minY[column]) {
                 this.minY[column] = lo;
             }
@@ -685,6 +691,12 @@ export class GeometricSkyBottomLineContext {
                 this.maxY[column] = hi;
             }
             return;
+        }
+        const firstColumn: number = Math.max(0, Math.floor(x0));
+        // a segment whose right end lies exactly on a column boundary covers nothing of that column:
+        const lastColumn: number = Math.min(this.width - 1, Math.floor(x1 - 1e-9));
+        if (lastColumn < firstColumn) {
+            return; // outside the measure (horizontal clipping like on the per-measure canvas)
         }
         const slope: number = (y1 - y0) / (x1 - x0);
         for (let column: number = firstColumn; column <= lastColumn; column++) {

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1035,7 +1035,16 @@ export abstract class MusicSheetCalculator {
                 }
                 musicSystem.calculateBorders(this.rules);
             }
-            const distance: number = graphicalMusicPage.MusicSystems[0].PositionAndShape.BorderTop;
+            let distance: number = graphicalMusicPage.MusicSystems[0].PositionAndShape.BorderTop;
+            // This shifts all systems of the page (by the skyline-derived BorderTop), i.e. also the
+            // sub-pixel positions the stafflines were snapped/rounded to for consistent staff line
+            // anti-aliasing (see MusicSystemBuilder.snapSystemYToCrispStaffLines):
+            // round to whole pixels to keep them, or to the half-pixel grid if not snapping.
+            if (this.rules.SnapStafflinesToCrispPixels) {
+                distance = Math.round(distance * 10) / 10;
+            } else {
+                distance = Math.round(distance * 20) / 20;
+            }
             for (let idx2: number = 0, len2: number = graphicalMusicPage.MusicSystems.length; idx2 < len2; ++idx2) {
                 const musicSystem: MusicSystem = graphicalMusicPage.MusicSystems[idx2];
                 // let newPosition: PointF2D = new PointF2D(musicSystem.PositionAndShape.RelativePosition.x,

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -761,6 +761,12 @@ export class MusicSystemBuilder {
         measure.PositionAndShape.BorderBottom = this.rules.StaffHeight;
         const width: number = this.rules.MeasureLeftMargin + measure.beginInstructionsWidth + this.rules.MeasureRightMargin;
         measure.PositionAndShape.BorderRight = width;
+        // Set minimumStaffEntriesWidth so stretchMusicSystem uses a correct value (not -1 from the constructor):
+        // an instruction-only measure has no staff entries, all its width is in beginInstructionsWidth.
+        // With -1, stretchMusicSystem subtracted the system's scaling factor from the width, which made
+        // these measures slightly too narrow in normal systems, and gave them negative widths in strongly
+        // stretched systems (e.g. one measure per system, see test_octaveshift_extragraphicalmeasure).
+        measure.minimumStaffEntriesWidth = 0;
         currentSystem.StaffLines[visStaffIdx].Measures.push(measure);
         return width;
     }

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -1173,12 +1173,19 @@ export class MusicSystemBuilder {
                 maxDistance += this.rules.MinSkyBottomDistBetweenStaves;
                 // 3. Take the maximum between previous value and user defined value for staff line minimum distance
                 maxDistance = Math.max(maxDistance, this.rules.StaffHeight + this.rules.MinimumStaffLineDistance);
-                // Round to half pixels (0.05 units), the granularity the pixel-based skyline calculation
-                // produced naturally: this keeps stafflines on consistent sub-pixel y positions, so the
-                // anti-aliased weight of the (1px) staff lines doesn't vary between systems.
-                // (The geometric skyline values are exact instead of pixel-quantized, which would otherwise
-                // propagate arbitrary fractional y positions here. No change for pixel-based values.)
-                maxDistance = Math.round(maxDistance * 20) / 20;
+                if (this.rules.SnapStafflinesToCrispPixels) {
+                    // Round to whole pixels (0.1 units): all stafflines of the system then share the same
+                    // sub-pixel phase, which calculateMusicSystemsRelativePositions snaps to crisp
+                    // staff line rendering for the whole system.
+                    maxDistance = Math.round(maxDistance * 10) / 10;
+                } else {
+                    // Round to half pixels (0.05 units), the granularity the pixel-based skyline calculation
+                    // produced naturally: this keeps stafflines on consistent sub-pixel y positions, so the
+                    // anti-aliased weight of the (1px) staff lines doesn't vary between systems.
+                    // (The geometric skyline values are exact instead of pixel-quantized, which would otherwise
+                    // propagate arbitrary fractional y positions here. No change for pixel-based values.)
+                    maxDistance = Math.round(maxDistance * 20) / 20;
+                }
                 const lowerStafflineYPos: number = maxDistance + musicSystem.StaffLines[i].PositionAndShape.RelativePosition.y;
                 this.updateStaffLinesRelativePosition(musicSystem, i + 1, lowerStafflineYPos);
             }
@@ -1187,6 +1194,22 @@ export class MusicSystemBuilder {
         musicSystem.PositionAndShape.BorderTop = firstStaffLine.PositionAndShape.RelativePosition.y + firstStaffLine.PositionAndShape.BorderTop;
         const lastStaffLine: StaffLine = musicSystem.StaffLines[musicSystem.StaffLines.length - 1];
         musicSystem.PositionAndShape.BorderBottom = lastStaffLine.PositionAndShape.RelativePosition.y + lastStaffLine.PositionAndShape.BorderBottom;
+    }
+
+    /** Snaps a system's y position (in units) so that its staff lines render as crisp single pixel
+     *  rows: the lines are 1px wide (at zoom 1), so their centers need to lie at half-pixel positions
+     *  (a line centered between two pixel rows is anti-aliased over both at half opacity instead).
+     *  The stafflines within the system share the same sub-pixel phase
+     *  (see optimizeDistanceBetweenStaffLines), so snapping the system y aligns all of them.
+     *  Shifts the system by at most half a pixel. No-op if EngravingRules.SnapStafflinesToCrispPixels is off. */
+    protected snapSystemYToCrispStaffLines(musicSystem: MusicSystem, systemY: number): number {
+        if (!this.rules.SnapStafflinesToCrispPixels || !musicSystem.StaffLines[0]) {
+            return systemY;
+        }
+        const firstStafflineY: number = systemY + musicSystem.StaffLines[0].PositionAndShape.RelativePosition.y;
+        // line centers at firstStafflineY * 10 (+ whole pixels): snap to the nearest x.5 pixel position
+        const snappedStafflineY: number = (Math.round(firstStafflineY * 10 - 0.5) + 0.5) / 10;
+        return systemY + snappedStafflineY - firstStafflineY;
     }
 
     /** Calculates the relative Positions of all MusicSystems.
@@ -1258,6 +1281,7 @@ export class MusicSystemBuilder {
                 //         currentYPosition += -currentSystem.PositionAndShape.BorderTop;
                 //     }
                 // }
+                currentYPosition = this.snapSystemYToCrispStaffLines(currentSystem, currentYPosition);
                 const relativePosition: PointF2D = new PointF2D(this.rules.PageLeftMargin + this.rules.SystemLeftMargin,
                                                                 currentYPosition);
                 currentSystem.PositionAndShape.RelativePosition = relativePosition;
@@ -1287,9 +1311,10 @@ export class MusicSystemBuilder {
                 distance = Math.max(distance, this.rules.MinimumDistanceBetweenSystems + prevSystemLastStaffline.StaffHeight);
                 // Round to half pixels for consistent staff line anti-aliasing, see optimizeDistanceBetweenStaffLines:
                 distance = Math.round(distance * 20) / 20;
-                const newYPosition: number =    currentYPosition +
+                let newYPosition: number =      currentYPosition +
                                                 prevSystemLastStaffLineBB.RelativePosition.y +
                                                 distance;
+                newYPosition = this.snapSystemYToCrispStaffLines(currentSystem, newYPosition);
 
                 // calculate the needed height for placing the current system on the page,
                 // to see if it still fits:

--- a/src/MusicalScore/Graphical/MusicSystemBuilder.ts
+++ b/src/MusicalScore/Graphical/MusicSystemBuilder.ts
@@ -1173,6 +1173,12 @@ export class MusicSystemBuilder {
                 maxDistance += this.rules.MinSkyBottomDistBetweenStaves;
                 // 3. Take the maximum between previous value and user defined value for staff line minimum distance
                 maxDistance = Math.max(maxDistance, this.rules.StaffHeight + this.rules.MinimumStaffLineDistance);
+                // Round to half pixels (0.05 units), the granularity the pixel-based skyline calculation
+                // produced naturally: this keeps stafflines on consistent sub-pixel y positions, so the
+                // anti-aliased weight of the (1px) staff lines doesn't vary between systems.
+                // (The geometric skyline values are exact instead of pixel-quantized, which would otherwise
+                // propagate arbitrary fractional y positions here. No change for pixel-based values.)
+                maxDistance = Math.round(maxDistance * 20) / 20;
                 const lowerStafflineYPos: number = maxDistance + musicSystem.StaffLines[i].PositionAndShape.RelativePosition.y;
                 this.updateStaffLinesRelativePosition(musicSystem, i + 1, lowerStafflineYPos);
             }
@@ -1279,6 +1285,8 @@ export class MusicSystemBuilder {
                 distance += this.rules.MinSkyBottomDistBetweenSystems;
 
                 distance = Math.max(distance, this.rules.MinimumDistanceBetweenSystems + prevSystemLastStaffline.StaffHeight);
+                // Round to half pixels for consistent staff line anti-aliasing, see optimizeDistanceBetweenStaffLines:
+                distance = Math.round(distance * 20) / 20;
                 const newYPosition: number =    currentYPosition +
                                                 prevSystemLastStaffLineBB.RelativePosition.y +
                                                 distance;

--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -219,7 +219,10 @@ export class SkyBottomLineCalculator {
         const results: SkyBottomLineCalculationResult[] = [];
 
         // The virtual rendering context, replacing the temporary canvas of the raster method. Reused for all measures.
-        const geometricContext: GeometricSkyBottomLineContext = new GeometricSkyBottomLineContext();
+        // The caches (text measurements, flattened glyph outlines) live in the EngravingRules,
+        // so they persist across stafflines and renders (per OSMD instance, no static state).
+        const geometricContext: GeometricSkyBottomLineContext =
+            new GeometricSkyBottomLineContext(0, 300, this.mRules.GeometricSkyBottomLineCaches);
         // search through all Measures
         for (const measure of this.StaffLineParent.Measures as VexFlowMeasure[]) {
             // must calculate first AbsolutePositions

--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -231,8 +231,17 @@ export class SkyBottomLineCalculator {
                 log.warn("SkyBottomLineCalculator: width not > 0 in measure " + measure.MeasureNumber);
                 width = 50;
             }
-            // the raster method truncated the width to an integer via canvas.width, kept for identical results:
-            width = Math.floor(width);
+            // Mirror the raster method's "canvas.width = width" coercion (HTMLCanvasElement reflection)
+            // for identical results, including its quirks: fractional widths truncate, and negative widths
+            // (which occur for some extra graphical measures, see test_octaveshift_extragraphicalmeasure)
+            // fall back to the default canvas width of 300, so such measures contribute the same
+            // (drawn) entries to the skyline as on the raster path instead of a single empty one.
+            width = Math.trunc(width);
+            if (!isFinite(width)) {
+                width = 0;
+            } else if (width < 0) {
+                width = 300;
+            }
             geometricContext.initialize(width);
 
             // This magic number is an offset from the top image border so that

--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -7,6 +7,7 @@ import log from "loglevel";
 import { BoundingBox } from "./BoundingBox";
 import { SkyBottomLineCalculationResult } from "./SkyBottomLineCalculationResult";
 import { CanvasVexFlowBackend } from "./VexFlow/CanvasVexFlowBackend";
+import { GeometricSkyBottomLineContext } from "./GeometricSkyBottomLineContext";
 /**
  * This class calculates and holds the skyline and bottom line information.
  * It also has functions to update areas of the two lines if new elements are
@@ -104,6 +105,10 @@ export class SkyBottomLineCalculator {
      * This method calculates the Sky- and BottomLines for a StaffLine.
      */
     public calculateLines(): void {
+        if (this.mRules.UseGeometricSkyBottomLineCalculation) {
+            this.calculateLinesGeometric();
+            return;
+        }
         const samplingUnit: number = this.mRules.SamplingUnit;
         const results: SkyBottomLineCalculationResult[] = [];
 
@@ -198,6 +203,74 @@ export class SkyBottomLineCalculator {
                 document.write('<img src="' + img + '"/>');
             }
             tmpCanvas.clear();
+        }
+
+        this.updateLines(results);
+    }
+
+    /**
+     * This method calculates the Sky- and BottomLines for a StaffLine geometrically, from the extents
+     * of the VexFlow draw calls of each measure, instead of drawing each measure on a canvas
+     * and reading back its pixels (see calculateLines()), which is much slower (see #937).
+     * Same flow as calculateLines(), with the canvas replaced by a GeometricSkyBottomLineContext.
+     */
+    private calculateLinesGeometric(): void {
+        const samplingUnit: number = this.mRules.SamplingUnit;
+        const results: SkyBottomLineCalculationResult[] = [];
+
+        // The virtual rendering context, replacing the temporary canvas of the raster method. Reused for all measures.
+        const geometricContext: GeometricSkyBottomLineContext = new GeometricSkyBottomLineContext();
+        // search through all Measures
+        for (const measure of this.StaffLineParent.Measures as VexFlowMeasure[]) {
+            // must calculate first AbsolutePositions
+            measure.PositionAndShape.calculateAbsolutePositionsRecursive(0, 0);
+
+            const vsStaff: any = measure.getVFStave();
+            let width: number = vsStaff.getWidth();
+            if (!(width > 0) && !measure.IsExtraGraphicalMeasure) {
+                log.warn("SkyBottomLineCalculator: width not > 0 in measure " + measure.MeasureNumber);
+                width = 50;
+            }
+            // the raster method truncated the width to an integer via canvas.width, kept for identical results:
+            width = Math.floor(width);
+            geometricContext.initialize(width);
+
+            // This magic number is an offset from the top image border so that
+            // elements above the staffline can be drawn correctly.
+            // (Kept from the raster method for identical side effects. The stave position is set again by the drawer later.)
+            vsStaff.setY(vsStaff.y + 100);
+            const oldMeasureWidth: number = vsStaff.getWidth();
+            // We need to tell the VexFlow stave about the canvas width. This looks
+            // redundant because it should know the canvas but somehow it doesn't.
+            // Maybe I am overlooking something but for now this does the trick
+            vsStaff.setWidth(width);
+            measure.format();
+            vsStaff.setWidth(oldMeasureWidth);
+            try {
+                measure.draw(geometricContext as any);
+                // Vexflow errors can happen here, then our complete rendering loop would halt without catching errors.
+            } catch (ex) {
+                log.warn("SkyBottomLineCalculator.calculateLinesGeometric.draw", ex);
+            }
+
+            const measureArrayLength: number = Math.max(Math.ceil(measure.PositionAndShape.Size.width * samplingUnit), 1);
+            const tmpSkyLine: number[] = new Array(measureArrayLength);
+            const tmpBottomLine: number[] = new Array(measureArrayLength);
+            geometricContext.copyExtentsInto(tmpSkyLine, tmpBottomLine);
+
+            // fill columns where nothing was drawn, like in the raster method:
+            for (let idx: number = 0; idx < tmpSkyLine.length; idx++) {
+                if (tmpSkyLine[idx] === undefined) {
+                    tmpSkyLine[idx] = Math.max(this.findPreviousValidNumber(idx, tmpSkyLine), this.findNextValidNumber(idx, tmpSkyLine));
+                }
+            }
+            for (let idx: number = 0; idx < tmpBottomLine.length; idx++) {
+                if (tmpBottomLine[idx] === undefined) {
+                    tmpBottomLine[idx] = Math.max(this.findPreviousValidNumber(idx, tmpBottomLine), this.findNextValidNumber(idx, tmpBottomLine));
+                }
+            }
+
+            results.push(new SkyBottomLineCalculationResult(tmpSkyLine, tmpBottomLine));
         }
 
         this.updateLines(results);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1844,7 +1844,13 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     const fontSize: number = (textBracket as any).font.size / 10;
 
     if ((<any>textBracket).position === VF.TextBracket.Positions.TOP) {
-      const headroom: number = Math.ceil(parentStaffline.SkyBottomLineCalculator.getSkyLineMinInRange(startX, stopX));
+      // Math.ceil with a small tolerance: the geometric skyline calculation gives exact values where
+      // the pixel-based one snapped to pixels (often exact integers, e.g. a note top exactly 1 unit
+      // above the staff), and without the tolerance, a skyline minimum a fraction of a pixel inside
+      // an integer boundary would lose a whole unit of headroom to the ceil (e.g. ceil(-0.97) = 0,
+      // putting the octave bracket into the note, see test_octaveshift_extragraphicalmeasure).
+      // The tolerance is smaller than the pixel-based values' granularity (0.1), so their results are unchanged.
+      const headroom: number = Math.ceil(parentStaffline.SkyBottomLineCalculator.getSkyLineMinInRange(startX, stopX) - 0.05);
       if (headroom === Infinity) { // will cause Vexflow error
         return;
       }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1887,6 +1887,13 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
 
   protected calculateSkyBottomLines(): void {
     const staffLines: StaffLine[] = CollectionUtil.flat(this.musicSystems.map(musicSystem => musicSystem.StaffLines));
+    if (this.rules.UseGeometricSkyBottomLineCalculation) {
+      // geometric calculation doesn't need batching: no canvas allocation or pixel readback (getImageData) is involved
+      for (const staffLine of staffLines) {
+        staffLine.SkyBottomLineCalculator.calculateLines();
+      }
+      return;
+    }
     //const numMeasures: number = staffLines.map(staffLine => staffLine.Measures.length).reduce((a, b) => a + b, 0);
     let numMeasures: number = 0; // number of graphical measures that are rendered
     for (const staffline of staffLines) {

--- a/src/MusicalScore/Graphical/index.ts
+++ b/src/MusicalScore/Graphical/index.ts
@@ -10,6 +10,7 @@ export * from "./DrawingEnums";
 export * from "./DrawingMode";
 export * from "./DrawingParameters";
 export * from "./EngravingRules";
+export * from "./GeometricSkyBottomLineContext";
 export * from "./GraphicalChordSymbolContainer";
 export * from "./GraphicalComment";
 export * from "./GraphicalContinuousDynamicExpression";

--- a/src/OpenSheetMusicDisplay/OSMDOptions.ts
+++ b/src/OpenSheetMusicDisplay/OSMDOptions.ts
@@ -262,7 +262,13 @@ export interface IOSMDOptions {
      */
     cursorsOptions?: CursorOptions[];
     /**
-     * Defines which skyline and bottom-line batch calculation algorithm to use.
+     * Whether to calculate the skyline and bottom-line geometrically, from the extents of the VexFlow draw calls,
+     * instead of drawing each measure on a hidden canvas and reading back its pixels, which is much slower. Default true.
+     * If set to false, the previous pixel-based calculation is used, see preferredSkyBottomLineBatchCalculatorBackend.
+     */
+    useGeometricSkyBottomLineCalculation?: boolean;
+    /**
+     * Defines which skyline and bottom-line batch calculation algorithm to use, if useGeometricSkyBottomLineCalculation is false.
      */
     preferredSkyBottomLineBatchCalculatorBackend?: SkyBottomLineBatchCalculatorBackendType;
     /**

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -675,6 +675,9 @@ export class OpenSheetMusicDisplay {
                 follow: true
             }];
         }
+        if (options.useGeometricSkyBottomLineCalculation !== undefined) {
+            this.rules.UseGeometricSkyBottomLineCalculation = options.useGeometricSkyBottomLineCalculation;
+        }
         if (options.preferredSkyBottomLineBatchCalculatorBackend !== undefined) {
             this.rules.PreferredSkyBottomLineBatchCalculatorBackend = options.preferredSkyBottomLineBatchCalculatorBackend;
         }

--- a/src/VexFlowPatch/src/glyph.js
+++ b/src/VexFlowPatch/src/glyph.js
@@ -1,0 +1,253 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+
+import { Vex } from './vex';
+import { Element } from './element';
+import { BoundingBoxComputation } from './boundingboxcomputation';
+import { BoundingBox } from './boundingbox';
+import { Font } from './fonts/vexflow_font';
+
+function processOutline(outline, originX, originY, scaleX, scaleY, outlineFns) {
+  let command;
+  let x;
+  let y;
+  let i = 0;
+
+  function nextX() { return originX + outline[i++] * scaleX; }
+  function nextY() { return originY + outline[i++] * scaleY; }
+
+  while (i < outline.length) {
+    command = outline[i++];
+    switch (command) {
+      case 'm':
+      case 'l':
+        outlineFns[command](nextX(), nextY());
+        break;
+      case 'q':
+        x = nextX();
+        y = nextY();
+        outlineFns.q(nextX(), nextY(), x, y);
+        break;
+      case 'b':
+        x = nextX();
+        y = nextY();
+        outlineFns.b(nextX(), nextY(), nextX(), nextY(), x, y);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+export class Glyph extends Element {
+  /* Static methods used to implement loading / unloading of glyphs */
+  static loadMetrics(font, code, cache) {
+    const glyph = font.glyphs[code];
+    if (!glyph) {
+      throw new Vex.RERR('BadGlyph', `Glyph ${code} does not exist in font.`);
+    }
+
+    const x_min = glyph.x_min;
+    const x_max = glyph.x_max;
+    const ha = glyph.ha;
+
+    let outline;
+
+    if (glyph.o) {
+      if (cache) {
+        if (glyph.cached_outline) {
+          outline = glyph.cached_outline;
+        } else {
+          outline = glyph.o.split(' ');
+          glyph.cached_outline = outline;
+        }
+      } else {
+        if (glyph.cached_outline) delete glyph.cached_outline;
+        outline = glyph.o.split(' ');
+      }
+
+      return {
+        x_min,
+        x_max,
+        ha,
+        outline,
+      };
+    } else {
+      throw new Vex.RERR('BadGlyph', `Glyph ${code} has no outline defined.`);
+    }
+  }
+
+  /**
+   * A quick and dirty static glyph renderer. Renders glyphs from the default
+   * font defined in Vex.Flow.Font.
+   *
+   * @param {!Object} ctx The canvas context.
+   * @param {number} x_pos X coordinate.
+   * @param {number} y_pos Y coordinate.
+   * @param {number} point The point size to use.
+   * @param {string} val The glyph code in Vex.Flow.Font.
+   * @param {boolean} nocache If set, disables caching of font outline.
+   */
+  static renderGlyph(ctx, x_pos, y_pos, point, val, nocache) {
+    const scale = point * 72.0 / (Font.resolution * 100.0);
+    const metrics = Glyph.loadMetrics(Font, val, !nocache);
+    Glyph.renderOutline(ctx, metrics.outline, scale, x_pos, y_pos);
+  }
+
+  static renderOutline(ctx, outline, scale, x_pos, y_pos) {
+    // VexFlowPatch: fast path for rendering contexts that can consume glyph outlines directly
+    // (with caching), instead of receiving the outline's path commands one by one.
+    // Used by OSMD's GeometricSkyBottomLineContext for the skyline/bottomline calculation.
+    if (ctx.drawCachedGlyphOutline && ctx.drawCachedGlyphOutline(outline, scale, x_pos, y_pos)) {
+      return;
+    }
+    ctx.beginPath();
+    ctx.moveTo(x_pos, y_pos);
+    processOutline(outline, x_pos, y_pos, scale, -scale, {
+      m: ctx.moveTo.bind(ctx),
+      l: ctx.lineTo.bind(ctx),
+      q: ctx.quadraticCurveTo.bind(ctx),
+      b: ctx.bezierCurveTo.bind(ctx),
+    });
+    ctx.fill();
+  }
+
+  static getOutlineBoundingBox(outline, scale, x_pos, y_pos) {
+    const bboxComp = new BoundingBoxComputation();
+
+    processOutline(outline, x_pos, y_pos, scale, -scale, {
+      m: bboxComp.addPoint.bind(bboxComp),
+      l: bboxComp.addPoint.bind(bboxComp),
+      q: bboxComp.addQuadraticCurve.bind(bboxComp),
+      b: bboxComp.addBezierCurve.bind(bboxComp),
+    });
+
+    return new BoundingBox(
+      bboxComp.x1,
+      bboxComp.y1,
+      bboxComp.width(),
+      bboxComp.height()
+    );
+  }
+
+  /**
+   * @constructor
+   */
+  constructor(code, point, options) {
+    super();
+    this.setAttribute('type', 'Glyph');
+
+    this.code = code;
+    this.point = point;
+    this.options = {
+      cache: true,
+      font: Font,
+    };
+
+    this.metrics = null;
+    this.x_shift = 0;
+    this.y_shift = 0;
+
+    this.originShift = {
+      x: 0,
+      y: 0,
+    };
+
+    if (options) {
+      this.setOptions(options);
+    } else {
+      this.reset();
+    }
+  }
+
+  setOptions(options) {
+    Vex.Merge(this.options, options);
+    this.reset();
+  }
+
+  setPoint(point) { this.point = point; return this; }
+  setStave(stave) { this.stave = stave; return this; }
+  setXShift(x_shift) { this.x_shift = x_shift; return this; }
+  setYShift(y_shift) { this.y_shift = y_shift; return this; }
+
+  reset() {
+    this.scale = this.point * 72 / (this.options.font.resolution * 100);
+    this.metrics = Glyph.loadMetrics(
+      this.options.font,
+      this.code,
+      this.options.cache
+    );
+    this.bbox = Glyph.getOutlineBoundingBox(
+      this.metrics.outline,
+      this.scale,
+      0,
+      0
+    );
+  }
+
+  getMetrics() {
+    if (!this.metrics) {
+      throw new Vex.RuntimeError('BadGlyph', `Glyph ${this.code} is not initialized.`);
+    }
+
+    return {
+      x_min: this.metrics.x_min * this.scale,
+      x_max: this.metrics.x_max * this.scale,
+      width: this.bbox.getW(),
+      height: this.bbox.getH(),
+    };
+  }
+
+  setOriginX(x) {
+    const { bbox } = this;
+    const originX = Math.abs(bbox.getX() / bbox.getW());
+    const xShift = (x - originX) * bbox.getW();
+    this.originShift.x = -xShift;
+  }
+
+  setOriginY(y) {
+    const { bbox } = this;
+    const originY = Math.abs(bbox.getY() / bbox.getH());
+    const yShift = (y - originY) * bbox.getH();
+    this.originShift.y = -yShift;
+  }
+
+  setOrigin(x, y) {
+    this.setOriginX(x);
+    this.setOriginY(y);
+  }
+
+  render(ctx, x, y) {
+    if (!this.metrics) {
+      throw new Vex.RuntimeError('BadGlyph', `Glyph ${this.code} is not initialized.`);
+    }
+
+    const outline = this.metrics.outline;
+    const scale = this.scale;
+
+    this.setRendered();
+    this.applyStyle(ctx);
+    Glyph.renderOutline(ctx, outline, scale, x + this.originShift.x, y + this.originShift.y);
+    this.restoreStyle(ctx);
+  }
+
+  renderToStave(x) {
+    this.checkContext();
+
+    if (!this.metrics) {
+      throw new Vex.RuntimeError('BadGlyph', `Glyph ${this.code} is not initialized.`);
+    }
+
+    if (!this.stave) {
+      throw new Vex.RuntimeError('GlyphError', 'No valid stave');
+    }
+
+    const outline = this.metrics.outline;
+    const scale = this.scale;
+
+    this.setRendered();
+    this.applyStyle();
+    Glyph.renderOutline(this.context, outline, scale,
+      x + this.x_shift, this.stave.getYForGlyphs() + this.y_shift);
+    this.restoreStyle();
+  }
+}

--- a/test/MusicalScore/Graphical/GeometricSkyBottomLine_Test.ts
+++ b/test/MusicalScore/Graphical/GeometricSkyBottomLine_Test.ts
@@ -157,8 +157,10 @@ describe("GeometricSkyBottomLineCalculation", () => {
     });
 
     it("agrees with the raster calculation on the first render with extra graphical measures", async function (): Promise<void> {
-        // extra graphical measures can have negative widths on the first render, which the raster method
-        // ran through canvas.width coercion - the geometric calculation has to mirror that (#937)
+        // extra graphical measures used to get negative widths in stretched systems (fixed in
+        // MusicSystemBuilder.addExtraInstructionMeasure); the raster method ran such widths through
+        // canvas.width coercion, which the geometric calculation mirrors as defense against any
+        // remaining source of invalid widths (#937)
         this.timeout(30000);
         await compareGeometricWithRaster("test_octaveshift_extragraphicalmeasure.musicxml",
             { firstRender: true, newSystemAttribute: true });

--- a/test/MusicalScore/Graphical/GeometricSkyBottomLine_Test.ts
+++ b/test/MusicalScore/Graphical/GeometricSkyBottomLine_Test.ts
@@ -54,17 +54,31 @@ describe("GeometricSkyBottomLineCalculation", () => {
         return "";
     }
 
+    interface ICompareOptions {
+        /** Capture the very first render after load (like the actual rendering pipeline) instead of a
+         *  settled re-render. Some state (e.g. extra graphical measure widths) differs on the first render. */
+        firstRender?: boolean;
+        /** Sets EngravingRules.NewSystemAtXMLNewSystemAttribute, e.g. for test_octaveshift_extragraphicalmeasure. */
+        newSystemAttribute?: boolean;
+    }
+
     /** Fresh load + a settle render with the geometric method, then one captured render with the given method.
      *  The settle render's skylines feed into some element placements of the next render (pre-existing re-render
      *  behavior, independent of the skyline method), so both captures must start from identical input state:
-     *  a fresh load and a settle render that uses the same (geometric) method for both. */
-    async function capturedRender(osmd: OpenSheetMusicDisplay, score: Document, geometric: boolean): Promise<ICapturedLine[]> {
-        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+     *  a fresh load and a settle render that uses the same (geometric) method for both.
+     *  With options.firstRender, the settle render is skipped and the first render is captured instead
+     *  (fresh loads at the same render index are also identical input states). */
+    async function capturedRender(osmd: OpenSheetMusicDisplay, score: Document, geometric: boolean,
+                                  options: ICompareOptions): Promise<ICapturedLine[]> {
+        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = options.firstRender ? geometric : true;
         osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
         osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 9999999; // use the non-batched raster path
+        osmd.EngravingRules.NewSystemAtXMLNewSystemAttribute = !!options.newSystemAttribute;
         await osmd.load(score);
-        osmd.render(); // settle render (the first render after load also differs slightly from re-renders)
-        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = geometric;
+        if (!options.firstRender) {
+            osmd.render(); // settle render (the first render after load also differs slightly from re-renders)
+            osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = geometric;
+        }
         capture = [];
         osmd.render();
         const result: ICapturedLine[] = capture;
@@ -75,12 +89,12 @@ describe("GeometricSkyBottomLineCalculation", () => {
         return result;
     }
 
-    async function compareGeometricWithRaster(filename: string): Promise<void> {
+    async function compareGeometricWithRaster(filename: string, options: ICompareOptions = {}): Promise<void> {
         const score: Document = TestUtils.getScore(filename);
         const div: HTMLElement = TestUtils.getDivElement(document);
         const osmd: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div, { autoResize: false });
-        const geometric: ICapturedLine[] = await capturedRender(osmd, score, true);
-        const raster: ICapturedLine[] = await capturedRender(osmd, score, false);
+        const geometric: ICapturedLine[] = await capturedRender(osmd, score, true, options);
+        const raster: ICapturedLine[] = await capturedRender(osmd, score, false, options);
 
         expect(geometric.length, "number of stafflines").to.equal(raster.length);
         expect(geometric.length, "number of stafflines").to.be.greaterThan(0);
@@ -140,5 +154,13 @@ describe("GeometricSkyBottomLineCalculation", () => {
     it("agrees with the raster calculation for tablature with effects", async function (): Promise<void> {
         this.timeout(30000);
         await compareGeometricWithRaster("OSMD_Function_Test_Tablature_Alleffects.musicxml");
+    });
+
+    it("agrees with the raster calculation on the first render with extra graphical measures", async function (): Promise<void> {
+        // extra graphical measures can have negative widths on the first render, which the raster method
+        // ran through canvas.width coercion - the geometric calculation has to mirror that (#937)
+        this.timeout(30000);
+        await compareGeometricWithRaster("test_octaveshift_extragraphicalmeasure.musicxml",
+            { firstRender: true, newSystemAttribute: true });
     });
 });

--- a/test/MusicalScore/Graphical/GeometricSkyBottomLine_Test.ts
+++ b/test/MusicalScore/Graphical/GeometricSkyBottomLine_Test.ts
@@ -1,0 +1,144 @@
+import { expect } from "chai";
+import { OpenSheetMusicDisplay } from "../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
+import { SkyBottomLineCalculator } from "../../../src/MusicalScore/Graphical/SkyBottomLineCalculator";
+import { TestUtils } from "../../Util/TestUtils";
+
+/** Compares the geometric skyline/bottom-line calculation (GeometricSkyBottomLineContext)
+ *  with the pixel-based (raster) calculation. The two should agree within a small tolerance:
+ *  differences come from anti-aliasing/font hinting (sub-pixel) in the raster method,
+ *  see GeometricSkyBottomLineContext for details. */
+describe("GeometricSkyBottomLineCalculation", () => {
+    interface ICapturedLine { sky: number[], bottom: number[] }
+    // capture the lines directly after they are calculated (before later layout steps update them),
+    // by wrapping SkyBottomLineCalculator.updateLines, which both calculation methods call with their results.
+    let capture: ICapturedLine[];
+    const originalUpdateLines: any = (SkyBottomLineCalculator.prototype as any).updateLines;
+
+    before((): void => {
+        (SkyBottomLineCalculator.prototype as any).updateLines = function (results: any): void {
+            originalUpdateLines.call(this, results);
+            if (capture) {
+                capture.push({ sky: [...this.SkyLine], bottom: [...this.BottomLine] });
+            }
+        };
+    });
+
+    after((): void => {
+        (SkyBottomLineCalculator.prototype as any).updateLines = originalUpdateLines;
+    });
+
+    /** Describes the measure at a given staffline (by capture order) and skyline index, for failure messages. */
+    function describeMeasureAt(osmd: OpenSheetMusicDisplay, stafflineIndex: number, skylineIndex: number): string {
+        try {
+            const xUnits: number = skylineIndex / osmd.EngravingRules.SamplingUnit;
+            let currentIndex: number = 0;
+            for (const page of osmd.GraphicSheet.MusicPages) {
+                for (const system of page.MusicSystems) {
+                    for (const staffLine of system.StaffLines) {
+                        if (currentIndex++ !== stafflineIndex) {
+                            continue;
+                        }
+                        for (const measure of staffLine.Measures) {
+                            const x: number = measure.PositionAndShape.RelativePosition.x;
+                            if (xUnits >= x && xUnits < x + measure.PositionAndShape.Size.width) {
+                                return ` = x ${xUnits.toFixed(1)} units, measure ${measure.MeasureNumber}`;
+                            }
+                        }
+                        return ` = x ${xUnits.toFixed(1)} units, no measure`;
+                    }
+                }
+            }
+        } catch (e) {
+            // diagnostics only
+        }
+        return "";
+    }
+
+    /** Fresh load + a settle render with the geometric method, then one captured render with the given method.
+     *  The settle render's skylines feed into some element placements of the next render (pre-existing re-render
+     *  behavior, independent of the skyline method), so both captures must start from identical input state:
+     *  a fresh load and a settle render that uses the same (geometric) method for both. */
+    async function capturedRender(osmd: OpenSheetMusicDisplay, score: Document, geometric: boolean): Promise<ICapturedLine[]> {
+        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+        osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 9999999; // use the non-batched raster path
+        await osmd.load(score);
+        osmd.render(); // settle render (the first render after load also differs slightly from re-renders)
+        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = geometric;
+        capture = [];
+        osmd.render();
+        const result: ICapturedLine[] = capture;
+        capture = undefined;
+        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+        osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;
+        osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 5;
+        return result;
+    }
+
+    async function compareGeometricWithRaster(filename: string): Promise<void> {
+        const score: Document = TestUtils.getScore(filename);
+        const div: HTMLElement = TestUtils.getDivElement(document);
+        const osmd: OpenSheetMusicDisplay = new OpenSheetMusicDisplay(div, { autoResize: false });
+        const geometric: ICapturedLine[] = await capturedRender(osmd, score, true);
+        const raster: ICapturedLine[] = await capturedRender(osmd, score, false);
+
+        expect(geometric.length, "number of stafflines").to.equal(raster.length);
+        expect(geometric.length, "number of stafflines").to.be.greaterThan(0);
+        let valuesCompared: number = 0;
+        let sumAbsoluteDifference: number = 0;
+        let valuesAboveHalfUnit: number = 0;
+        let worstInfo: string = "";
+        let worstDifference: number = 0;
+        for (let i: number = 0; i < geometric.length; i++) {
+            expect(geometric[i].sky.length, `skyline length of staffline ${i}`).to.equal(raster[i].sky.length);
+            for (const part of ["sky", "bottom"]) {
+                const geometricValues: number[] = (geometric[i] as never)[part];
+                const rasterValues: number[] = (raster[i] as never)[part];
+                for (let j: number = 0; j < geometricValues.length; j++) {
+                    if (isNaN(geometricValues[j]) || isNaN(rasterValues[j])) {
+                        continue;
+                    }
+                    const difference: number = Math.abs(geometricValues[j] - rasterValues[j]);
+                    valuesCompared++;
+                    sumAbsoluteDifference += difference;
+                    if (difference > 0.5) {
+                        valuesAboveHalfUnit++;
+                        if (difference > worstDifference) {
+                            worstDifference = difference;
+                            const measureInfo: string = describeMeasureAt(osmd, i, j);
+                            worstInfo = ` (worst: ${part} staffline ${i} index ${j}${measureInfo}:`
+                                + ` geometric ${geometricValues[j].toFixed(2)} vs raster ${rasterValues[j].toFixed(2)})`;
+                        }
+                    }
+                }
+            }
+        }
+        expect(valuesCompared).to.be.greaterThan(0);
+        const meanAbsoluteDifference: number = sumAbsoluteDifference / valuesCompared;
+        // tolerances: sub-pixel differences are expected (the raster method quantizes to pixels and includes
+        // the anti-aliasing halo, which e.g. Firefox spreads up to ~0.1 units wider than Chrome).
+        // A missing element class would push the mean far beyond these bounds.
+        expect(meanAbsoluteDifference, "mean abs difference (units) between geometric and raster lines" + worstInfo).to.be.below(0.15);
+        expect(valuesAboveHalfUnit / valuesCompared, "fraction of values differing by more than 0.5 units" + worstInfo).to.be.below(0.005);
+    }
+
+    it("agrees with the raster calculation for OSMD_function_test_all", async function (): Promise<void> {
+        this.timeout(30000);
+        await compareGeometricWithRaster("OSMD_function_test_all.xml");
+    });
+
+    it("agrees with the raster calculation for chord symbols", async function (): Promise<void> {
+        this.timeout(30000);
+        await compareGeometricWithRaster("OSMD_function_test_chord_symbols.musicxml");
+    });
+
+    it("agrees with the raster calculation for a one-line (percussion) staff", async function (): Promise<void> {
+        this.timeout(30000);
+        await compareGeometricWithRaster("OSMD_function_test_drumset.musicxml");
+    });
+
+    it("agrees with the raster calculation for tablature with effects", async function (): Promise<void> {
+        this.timeout(30000);
+        await compareGeometricWithRaster("OSMD_Function_Test_Tablature_Alleffects.musicxml");
+    });
+});

--- a/test/performance/compareImages.mjs
+++ b/test/performance/compareImages.mjs
@@ -1,0 +1,93 @@
+// Compares two directories of rendered PNGs (baseline vs new) pixel-wise.
+// Usage: node test/performance/compareImages.mjs <dirA> <dirB> [diffThreshold] [maxDiffImages]
+// Writes red-overlay diff images for the worst offenders next to dirB as *_DIFF.png.
+import FS from "fs";
+import Path from "path";
+import canvasPkg from "canvas";
+
+const dirA = process.argv[2] || "export/ab_base";
+const dirB = process.argv[3] || "export/ab_new";
+const channelThreshold = parseInt(process.argv[4] || "24", 10); // channel delta to count a pixel as different
+const maxDiffImages = parseInt(process.argv[5] || "12", 10);
+
+const filesA = new Set(FS.readdirSync(dirA).filter(f => f.endsWith(".png")));
+const filesB = new Set(FS.readdirSync(dirB).filter(f => f.endsWith(".png")));
+const common = [...filesA].filter(f => filesB.has(f)).sort();
+const onlyA = [...filesA].filter(f => !filesB.has(f));
+const onlyB = [...filesB].filter(f => !filesA.has(f));
+if (onlyA.length) { console.log(`only in ${dirA}: ${onlyA.length} files: ${onlyA.slice(0, 5).join(", ")}…`); }
+if (onlyB.length) { console.log(`only in ${dirB}: ${onlyB.length} files: ${onlyB.slice(0, 5).join(", ")}…`); }
+
+const results = [];
+let identicalBytes = 0;
+for (const file of common) {
+    const bufA = FS.readFileSync(Path.join(dirA, file));
+    const bufB = FS.readFileSync(Path.join(dirB, file));
+    if (bufA.equals(bufB)) {
+        identicalBytes++;
+        continue;
+    }
+    const imgA = await canvasPkg.loadImage(bufA);
+    const imgB = await canvasPkg.loadImage(bufB);
+    if (imgA.width !== imgB.width || imgA.height !== imgB.height) {
+        results.push({ file, dims: `${imgA.width}x${imgA.height} vs ${imgB.width}x${imgB.height}`, diffPixels: Infinity });
+        continue;
+    }
+    const w = imgA.width, h = imgA.height;
+    const cA = canvasPkg.createCanvas(w, h); const xA = cA.getContext("2d"); xA.drawImage(imgA, 0, 0);
+    const cB = canvasPkg.createCanvas(w, h); const xB = cB.getContext("2d"); xB.drawImage(imgB, 0, 0);
+    const dataA = xA.getImageData(0, 0, w, h).data;
+    const dataB = xB.getImageData(0, 0, w, h).data;
+    let diffPixels = 0;
+    let minX = w, maxX = -1, minY = h, maxY = -1;
+    for (let i = 0; i < dataA.length; i += 4) {
+        if (Math.abs(dataA[i] - dataB[i]) > channelThreshold
+            || Math.abs(dataA[i + 1] - dataB[i + 1]) > channelThreshold
+            || Math.abs(dataA[i + 2] - dataB[i + 2]) > channelThreshold
+            || Math.abs(dataA[i + 3] - dataB[i + 3]) > channelThreshold) {
+            diffPixels++;
+            const p = i / 4; const x = p % w; const y = Math.floor(p / w);
+            if (x < minX) { minX = x; } if (x > maxX) { maxX = x; }
+            if (y < minY) { minY = y; } if (y > maxY) { maxY = y; }
+        }
+    }
+    results.push({ file, diffPixels, total: w * h, region: maxX >= 0 ? `x${minX}-${maxX} y${minY}-${maxY}` : "-" });
+}
+
+results.sort((a, b) => b.diffPixels - a.diffPixels);
+console.log(`\n${common.length} common files; ${identicalBytes} byte-identical; ${results.length} differing:`);
+for (const r of results) {
+    if (r.dims) {
+        console.log(`  ${r.file}: DIMENSIONS DIFFER ${r.dims}`);
+    } else {
+        console.log(`  ${r.file}: ${r.diffPixels} px (${(100 * r.diffPixels / r.total).toFixed(4)}%) region ${r.region}`);
+    }
+}
+
+// write red-overlay diffs for the worst
+let written = 0;
+for (const r of results) {
+    if (written >= maxDiffImages || r.dims || r.diffPixels === 0) { continue; }
+    const imgA = await canvasPkg.loadImage(Path.join(dirA, r.file));
+    const imgB = await canvasPkg.loadImage(Path.join(dirB, r.file));
+    const w = imgA.width, h = imgA.height;
+    const c = canvasPkg.createCanvas(w, h); const ctx = c.getContext("2d");
+    ctx.drawImage(imgB, 0, 0);
+    const cA = canvasPkg.createCanvas(w, h); const xA = cA.getContext("2d"); xA.drawImage(imgA, 0, 0);
+    const dataA = xA.getImageData(0, 0, w, h).data;
+    const imgDataB = ctx.getImageData(0, 0, w, h);
+    const dataB = imgDataB.data;
+    for (let i = 0; i < dataA.length; i += 4) {
+        if (Math.abs(dataA[i] - dataB[i]) > channelThreshold
+            || Math.abs(dataA[i + 1] - dataB[i + 1]) > channelThreshold
+            || Math.abs(dataA[i + 2] - dataB[i + 2]) > channelThreshold
+            || Math.abs(dataA[i + 3] - dataB[i + 3]) > channelThreshold) {
+            dataB[i] = 255; dataB[i + 1] = 0; dataB[i + 2] = 0; dataB[i + 3] = 255;
+        }
+    }
+    ctx.putImageData(imgDataB, 0, 0);
+    const out = Path.join(dirB, r.file.replace(/\.png$/, "_DIFF.png"));
+    FS.writeFileSync(out, c.toBuffer("image/png"));
+    written++;
+}
+if (written) { console.log(`\nwrote ${written} *_DIFF.png overlays into ${dirB}`); }

--- a/test/performance/runVisualAB.sh
+++ b/test/performance/runVisualAB.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Visual A/B: renders the full sample corpus with the working tree ("new") and with src/ changes
+# stashed (baseline, e.g. develop, "base"), then compares all images pixel-wise.
+# Run from the repository root: bash test/performance/runVisualAB.sh
+# Output: export/ab_new/, export/ab_base/, export/ab_compare.log (+ *_DIFF.png overlays in ab_new).
+set -e
+cd "$(git rev-parse --show-toplevel)"
+
+STASHED=0
+cleanup() {
+    if [ "$STASHED" = "1" ]; then
+        echo "!!! failure while src/ was stashed - restoring stashed changes..."
+        git stash pop || echo "!!! 'git stash pop' failed, restore manually (see git stash list: visualAB-temp)"
+    fi
+}
+trap cleanup ERR
+
+echo "=== building + rendering NEW (working tree) ==="
+npx webpack --config webpack.dev.js > /dev/null
+cp build/opensheetmusicdisplay.js build/opensheetmusicdisplay.min.js
+node ./test/Util/generateImages_browserless.mjs ../../build ./test/data ./export/ab_new png 0 0 all --osmdtesting > export/ab_new.log 2>&1
+
+echo "=== stashing src changes, building + rendering BASELINE ==="
+git stash push -m "visualAB-temp" -- src/
+STASHED=1
+npx webpack --config webpack.dev.js > /dev/null
+cp build/opensheetmusicdisplay.js build/opensheetmusicdisplay.min.js
+node ./test/Util/generateImages_browserless.mjs ../../build ./test/data ./export/ab_base png 0 0 all --osmdtesting > export/ab_base.log 2>&1
+
+echo "=== restoring working tree + rebuilding ==="
+git stash pop
+STASHED=0
+npx webpack --config webpack.dev.js > /dev/null
+cp build/opensheetmusicdisplay.js build/opensheetmusicdisplay.min.js
+
+echo "=== comparing ==="
+node test/performance/compareImages.mjs export/ab_base export/ab_new 24 12 > export/ab_compare.log 2>&1 || true
+echo "=== done, see export/ab_compare.log ==="

--- a/test/performance/skylineBench.mjs
+++ b/test/performance/skylineBench.mjs
@@ -1,0 +1,125 @@
+// Benchmark: osmd.render() total time and skyline-phase time, geometric vs raster calculations.
+// Note: node-canvas getImageData is CPU-backed; in browsers (GPU canvases) the raster path pays an
+// additional GPU->CPU sync penalty, so real-world raster numbers are typically worse than here.
+// Usage: node test/performance/skylineBench.mjs [runsPerMode]
+import FS from "fs";
+import jsdom from "jsdom";
+import OSMD from "../../build/opensheetmusicdisplay.min.js";
+
+const RUNS = parseInt(process.argv[2] || "3", 10);
+const SAMPLES = [
+    "OSMD_function_test_all.xml",
+    "Beethoven_AnDieFerneGeliebte.xml",
+    "MuzioClementi_SonatinaOpus36No3_Part1.xml",
+    "JohannSebastianBach_PraeludiumInCDur_BWV846_1.xml",
+    "ScottJoplin_The_Entertainer.xml",
+    "JosephHaydn_ConcertanteCello.xml",
+    "ActorPreludeSample.xml",
+];
+
+const dom = new jsdom.JSDOM("<!DOCTYPE html></html>");
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLAnchorElement = dom.window.HTMLAnchorElement;
+global.XMLHttpRequest = dom.window.XMLHttpRequest;
+global.DOMParser = dom.window.DOMParser;
+global.Node = dom.window.Node;
+global.Canvas = dom.window.Canvas;
+
+const div = document.createElement("div");
+document.body.appendChild(div);
+Object.defineProperties(window.HTMLElement.prototype, {
+    offsetLeft: { get: function () { return 0; } },
+    offsetTop: { get: function () { return 0; } },
+    offsetHeight: { get: function () { return 32767; } },
+    offsetWidth: { get: function () { return 1080; } }
+});
+
+const osmd = new OSMD.OpenSheetMusicDisplay(div, { autoResize: false, backend: "svg", pageFormat: "Endless" });
+osmd.setLogLevel("warn");
+
+// wrap the skyline phase for timing
+let skylineMs = 0;
+const calcProto = OSMD.VexFlowMusicSheetCalculator.prototype;
+const origCalcSkyBottomLines = calcProto.calculateSkyBottomLines;
+calcProto.calculateSkyBottomLines = function () {
+    const t0 = performance.now();
+    origCalcSkyBottomLines.call(this);
+    skylineMs += performance.now() - t0;
+};
+
+const MODES = {
+    geo: (r) => { r.UseGeometricSkyBottomLineCalculation = true; },
+    single: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 9999999;
+    },
+    batch: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 2;
+        r.PreferredSkyBottomLineBatchCalculatorBackend = 0; // Plain
+    },
+};
+
+function median(values) {
+    const sorted = [...values].sort((a, b) => a - b);
+    return sorted[Math.floor(sorted.length / 2)];
+}
+
+const rows = [];
+for (const sample of SAMPLES) {
+    let loadParameter = FS.readFileSync("test/data/" + sample);
+    if (sample.endsWith(".mxl")) { loadParameter = await OSMD.MXLHelper.MXLtoXMLstring(loadParameter); }
+    else { loadParameter = loadParameter.toString(); }
+    await osmd.load(loadParameter, sample);
+    osmd.render(); // warmup + builds graphic
+    let numMeasures = 0;
+    let numStaffLines = 0;
+    for (const page of osmd.graphic.MusicPages) {
+        for (const system of page.MusicSystems) {
+            for (const staffLine of system.StaffLines) {
+                numStaffLines++;
+                numMeasures += staffLine.Measures.length;
+            }
+        }
+    }
+    const result = { sample, numMeasures, numStaffLines, modes: {} };
+    for (const [modeName, applyMode] of Object.entries(MODES)) {
+        applyMode(osmd.EngravingRules);
+        osmd.render(); // mode warmup
+        const totals = [];
+        const skylines = [];
+        for (let i = 0; i < RUNS; i++) {
+            skylineMs = 0;
+            const t0 = performance.now();
+            osmd.render();
+            totals.push(performance.now() - t0);
+            skylines.push(skylineMs);
+        }
+        result.modes[modeName] = { total: median(totals), skyline: median(skylines) };
+        // restore defaults
+        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+        osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;
+        osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 5;
+    }
+    rows.push(result);
+    const g = result.modes.geo, s = result.modes.single, b = result.modes.batch;
+    console.log(`${sample} (${numMeasures} measures, ${numStaffLines} stafflines)`);
+    console.log(`  geo:    total ${g.total.toFixed(1)}ms, skyline ${g.skyline.toFixed(1)}ms (${(100 * g.skyline / g.total).toFixed(1)}%)`);
+    console.log(`  single: total ${s.total.toFixed(1)}ms, skyline ${s.skyline.toFixed(1)}ms (${(100 * s.skyline / s.total).toFixed(1)}%)`
+        + ` -> total x${(s.total / g.total).toFixed(2)}, skyline x${(s.skyline / g.skyline).toFixed(1)}`);
+    console.log(`  batch:  total ${b.total.toFixed(1)}ms, skyline ${b.skyline.toFixed(1)}ms (${(100 * b.skyline / b.total).toFixed(1)}%)`
+        + ` -> total x${(b.total / g.total).toFixed(2)}, skyline x${(b.skyline / g.skyline).toFixed(1)}`);
+}
+
+console.log("\n==== SUMMARY (median of " + RUNS + " runs; speedup factors are raster/geometric) ====");
+console.log("sample | measures | geo total | geo skyline | single total (x) | batch total (x) | skyline x(single) | skyline x(batch)");
+for (const r of rows) {
+    const g = r.modes.geo, s = r.modes.single, b = r.modes.batch;
+    console.log(`${r.sample} | ${r.numMeasures} | ${g.total.toFixed(0)}ms | ${g.skyline.toFixed(1)}ms`
+        + ` | ${s.total.toFixed(0)}ms (x${(s.total / g.total).toFixed(2)}) | ${b.total.toFixed(0)}ms (x${(b.total / g.total).toFixed(2)})`
+        + ` | x${(s.skyline / g.skyline).toFixed(1)} | x${(b.skyline / g.skyline).toFixed(1)}`);
+}

--- a/test/performance/skylineBenchBrowser.html
+++ b/test/performance/skylineBenchBrowser.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>OSMD skyline benchmark: geometric vs raster (browser)</title>
+<style>
+    body { font-family: sans-serif; margin: 16px; }
+    table { border-collapse: collapse; margin: 12px 0; }
+    td, th { border: 1px solid #999; padding: 4px 10px; text-align: right; }
+    td:first-child, th:first-child { text-align: left; }
+    #osmdContainer { width: 1080px; border: 1px solid #ddd; height: 250px; overflow: auto; opacity: 0.6; }
+    #status { font-weight: bold; margin: 8px 0; }
+</style>
+<!-- serve from the repo root, e.g.: npx http-server -p 8081 .   then open http://localhost:8081/test/performance/skylineBenchBrowser.html -->
+<script src="../../build/opensheetmusicdisplay.min.js"></script>
+</head>
+<body>
+<h2>OSMD skyline benchmark: geometric vs raster getImageData (real browser)</h2>
+<div id="status">loading…</div>
+<div id="results"></div>
+<div id="osmdContainer"></div>
+<script>
+const OSMD = window.opensheetmusicdisplay;
+const RUNS = 3;
+const SAMPLES = [
+    "OSMD_function_test_all.xml",
+    "Beethoven_AnDieFerneGeliebte.xml",
+    "MuzioClementi_SonatinaOpus36No3_Part1.xml",
+    "JohannSebastianBach_PraeludiumInCDur_BWV846_1.xml",
+    "ScottJoplin_The_Entertainer.xml",
+    "JosephHaydn_ConcertanteCello.xml",
+    "ActorPreludeSample.xml",
+];
+const MODES = {
+    geo: (r) => { r.UseGeometricSkyBottomLineCalculation = true; },
+    rasterSingle: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 9999999;
+    },
+    rasterBatchPlain: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 2;
+        r.PreferredSkyBottomLineBatchCalculatorBackend = 0; // Plain
+    },
+    rasterBatchWebGL: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 2;
+        r.PreferredSkyBottomLineBatchCalculatorBackend = 1; // WebGL
+    },
+};
+
+// time the skyline phase by wrapping calculateSkyBottomLines
+let skylineMs = 0;
+const calcProto = OSMD.VexFlowMusicSheetCalculator.prototype;
+const origCalc = calcProto.calculateSkyBottomLines;
+calcProto.calculateSkyBottomLines = function () {
+    const t0 = performance.now();
+    origCalc.call(this);
+    skylineMs += performance.now() - t0;
+};
+
+const median = (a) => [...a].sort((x, y) => x - y)[Math.floor(a.length / 2)];
+const status = (s) => { document.getElementById("status").textContent = s; };
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function run() {
+    const container = document.getElementById("osmdContainer");
+    const osmd = new OSMD.OpenSheetMusicDisplay(container, { autoResize: false, backend: "svg", pageFormat: "Endless" });
+    osmd.setLogLevel("warn");
+    const rows = [];
+    for (const sample of SAMPLES) {
+        let xml;
+        try {
+            xml = await (await fetch("../data/" + sample)).text();
+        } catch (e) {
+            console.warn("could not fetch " + sample, e);
+            continue;
+        }
+        const row = { sample, modes: {} };
+        for (const [modeName, applyMode] of Object.entries(MODES)) {
+            status(`${sample} — ${modeName} …`);
+            await sleep(30); // let the status render
+            applyMode(osmd.EngravingRules);
+            await osmd.load(xml, sample);
+            osmd.render(); // settle
+            const totals = [], skylines = [];
+            for (let i = 0; i < RUNS; i++) {
+                skylineMs = 0;
+                const t0 = performance.now();
+                osmd.render();
+                totals.push(performance.now() - t0);
+                skylines.push(skylineMs);
+            }
+            row.modes[modeName] = { total: median(totals), skyline: median(skylines) };
+            osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+            osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;
+            osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 5;
+        }
+        rows.push(row);
+        renderTable(rows);
+    }
+    status("done. (medians of " + RUNS + " runs; ratios are vs geometric)");
+}
+
+function renderTable(rows) {
+    let html = "<table><tr><th>sample</th><th>geo total</th><th>geo skyline</th>"
+        + "<th>single total</th><th>batchPlain total</th><th>batchWebGL total</th>"
+        + "<th>skyline single</th><th>skyline batchPlain</th><th>skyline batchWebGL</th></tr>";
+    for (const r of rows) {
+        const g = r.modes.geo;
+        const f = (m) => m ? `${m.total.toFixed(0)}ms (x${(m.total / g.total).toFixed(2)})` : "-";
+        const fs = (m) => m ? `${m.skyline.toFixed(1)}ms (x${(m.skyline / g.skyline).toFixed(1)})` : "-";
+        html += `<tr><td>${r.sample}</td><td>${g.total.toFixed(0)}ms</td><td>${g.skyline.toFixed(1)}ms</td>`
+            + `<td>${f(r.modes.rasterSingle)}</td><td>${f(r.modes.rasterBatchPlain)}</td><td>${f(r.modes.rasterBatchWebGL)}</td>`
+            + `<td>${fs(r.modes.rasterSingle)}</td><td>${fs(r.modes.rasterBatchPlain)}</td><td>${fs(r.modes.rasterBatchWebGL)}</td></tr>`;
+    }
+    html += "</table>";
+    document.getElementById("results").innerHTML = html;
+}
+
+run();
+</script>
+</body>
+</html>

--- a/test/performance/skylineBenchDetail.mjs
+++ b/test/performance/skylineBenchDetail.mjs
@@ -1,0 +1,86 @@
+// Breakdown of the skyline phase: format() vs measure.draw() vs rest, per mode.
+// Usage: node test/performance/skylineBenchDetail.mjs [sample1,sample2,...]
+import FS from "fs";
+import jsdom from "jsdom";
+import OSMD from "../../build/opensheetmusicdisplay.min.js";
+
+const SAMPLES = (process.argv[2] || "MuzioClementi_SonatinaOpus36No3_Part1.xml,Beethoven_AnDieFerneGeliebte.xml,ActorPreludeSample.xml").split(",");
+
+const dom = new jsdom.JSDOM("<!DOCTYPE html></html>");
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLAnchorElement = dom.window.HTMLAnchorElement;
+global.XMLHttpRequest = dom.window.XMLHttpRequest;
+global.DOMParser = dom.window.DOMParser;
+global.Node = dom.window.Node;
+global.Canvas = dom.window.Canvas;
+const div = document.createElement("div");
+document.body.appendChild(div);
+Object.defineProperties(window.HTMLElement.prototype, {
+    offsetLeft: { get: function () { return 0; } },
+    offsetTop: { get: function () { return 0; } },
+    offsetHeight: { get: function () { return 32767; } },
+    offsetWidth: { get: function () { return 1080; } }
+});
+const osmd = new OSMD.OpenSheetMusicDisplay(div, { autoResize: false, backend: "svg", pageFormat: "Endless" });
+osmd.setLogLevel("warn");
+
+let inSkyline = false;
+let skylineMs = 0, formatMs = 0, drawMs = 0;
+const calcProto = OSMD.VexFlowMusicSheetCalculator.prototype;
+const origCalc = calcProto.calculateSkyBottomLines;
+calcProto.calculateSkyBottomLines = function () {
+    inSkyline = true;
+    const t0 = performance.now();
+    origCalc.call(this);
+    skylineMs += performance.now() - t0;
+    inSkyline = false;
+};
+for (const [proto, name, accumulate] of [
+    [OSMD.VexFlowMeasure.prototype, "format", (ms) => { formatMs += ms; }],
+    [OSMD.VexFlowMeasure.prototype, "draw", (ms) => { drawMs += ms; }],
+    [OSMD.VexFlowMultiRestMeasure?.prototype, "draw", (ms) => { drawMs += ms; }],
+]) {
+    if (!proto) { continue; }
+    const orig = proto[name];
+    proto[name] = function (...args) {
+        if (!inSkyline) { return orig.apply(this, args); }
+        const t0 = performance.now();
+        const result = orig.apply(this, args);
+        accumulate(performance.now() - t0);
+        return result;
+    };
+}
+
+const MODES = {
+    geo: (r) => { r.UseGeometricSkyBottomLineCalculation = true; },
+    single: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 9999999;
+    },
+};
+
+for (const sample of SAMPLES) {
+    let loadParameter = FS.readFileSync("test/data/" + sample);
+    if (sample.endsWith(".mxl")) { loadParameter = await OSMD.MXLHelper.MXLtoXMLstring(loadParameter); }
+    else { loadParameter = loadParameter.toString(); }
+    await osmd.load(loadParameter, sample);
+    osmd.render(); // warmup
+    console.log(sample);
+    for (const [modeName, applyMode] of Object.entries(MODES)) {
+        applyMode(osmd.EngravingRules);
+        osmd.render(); // mode warmup
+        skylineMs = 0; formatMs = 0; drawMs = 0;
+        const t0 = performance.now();
+        osmd.render();
+        const total = performance.now() - t0;
+        const rest = skylineMs - formatMs - drawMs;
+        console.log(`  ${modeName}: total ${total.toFixed(1)}ms | skyline ${skylineMs.toFixed(1)}ms`
+            + ` = format ${formatMs.toFixed(1)} + draw ${drawMs.toFixed(1)} + rest ${rest.toFixed(1)}`);
+        osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+        osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;
+        osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 5;
+    }
+}

--- a/test/performance/skylineDrill.mjs
+++ b/test/performance/skylineDrill.mjs
@@ -1,0 +1,197 @@
+// Drill-down: shows where geo and single-raster skylines diverge in one sample, mapped to measures,
+// and dumps the geometric draw calls that touched the divergent columns.
+// Usage: node test/performance/skylineDrill.mjs <sampleFilename> [threshold]
+import FS from "fs";
+import jsdom from "jsdom";
+import OSMD from "../../build/opensheetmusicdisplay.min.js";
+
+const sample = process.argv[2] || "OSMD_function_test_all.xml";
+const threshold = parseFloat(process.argv[3] || "0.2");
+const extraWarmups = parseInt(process.argv[4] || "0", 10);
+
+const dom = new jsdom.JSDOM("<!DOCTYPE html></html>");
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLAnchorElement = dom.window.HTMLAnchorElement;
+global.XMLHttpRequest = dom.window.XMLHttpRequest;
+global.DOMParser = dom.window.DOMParser;
+global.Node = dom.window.Node;
+global.Canvas = dom.window.Canvas;
+
+const div = document.createElement("div");
+document.body.appendChild(div);
+const width = 1080;
+const height = 32767;
+Object.defineProperties(window.HTMLElement.prototype, {
+    offsetLeft: { get: function () { return 0; } },
+    offsetTop: { get: function () { return 0; } },
+    offsetHeight: { get: function () { return height; } },
+    offsetWidth: { get: function () { return width; } }
+});
+
+const osmd = new OSMD.OpenSheetMusicDisplay(div, { autoResize: false, backend: "svg", pageFormat: "Endless" });
+osmd.setLogLevel("warn");
+
+// ---- capture hook (updateLines) ----
+let capture = null;
+function installUpdateLinesHook() {
+    const calculator = osmd.graphic.MusicPages[0].MusicSystems[0].StaffLines[0].SkyBottomLineCalculator;
+    const proto = Object.getPrototypeOf(calculator);
+    const orig = proto.updateLines;
+    proto.updateLines = function (results) {
+        orig.call(this, results);
+        if (capture) {
+            const measures = this.StaffLineParent.Measures.map(m => ({
+                number: m.MeasureNumber,
+                x: m.PositionAndShape.RelativePosition.x,
+                w: m.PositionAndShape.Size.width,
+            }));
+            capture.push({ sky: Array.from(this.SkyLine), bottom: Array.from(this.BottomLine), measures });
+        }
+    };
+}
+
+// ---- draw-call log hook (GeometricSkyBottomLineContext) ----
+let drawLog = null; // array of per-measure call arrays; a new entry is started by each initialize(width>0)
+function installContextHook() {
+    const proto = OSMD.GeometricSkyBottomLineContext.prototype;
+    const origInit = proto.initialize;
+    proto.initialize = function (w, h) {
+        if (drawLog !== null && w > 0) { drawLog.push({ width: Math.floor(w), calls: [] }); }
+        return origInit.call(this, w, h);
+    };
+    for (const methodName of ["fill", "stroke"]) {
+        const orig = proto[methodName];
+        proto[methodName] = function () {
+            if (drawLog !== null && drawLog.length > 0 && this.pathSegments.length > 0) {
+                let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+                const s = this.pathSegments;
+                for (let i = 0; i < s.length; i += 2) {
+                    if (s[i] < minX) { minX = s[i]; }
+                    if (s[i] > maxX) { maxX = s[i]; }
+                    if (s[i + 1] < minY) { minY = s[i + 1]; }
+                    if (s[i + 1] > maxY) { maxY = s[i + 1]; }
+                }
+                drawLog[drawLog.length - 1].calls.push({
+                    m: methodName, minX, maxX, minY, maxY,
+                    lw: methodName === "stroke" ? this.currentLineWidth : undefined,
+                    style: methodName === "stroke" ? this.currentStrokeStyle : this.currentFillStyle,
+                });
+            }
+            return orig.call(this);
+        };
+    }
+    const origFillRect = proto.fillRect;
+    proto.fillRect = function (x, y, w, h) {
+        if (drawLog !== null && drawLog.length > 0) {
+            drawLog[drawLog.length - 1].calls.push({ m: "fillRect", minX: x, maxX: x + w, minY: y, maxY: y + h, style: this.currentFillStyle });
+        }
+        return origFillRect.call(this, x, y, w, h);
+    };
+    const origFillText = proto.fillText;
+    proto.fillText = function (t, x, y) {
+        if (drawLog !== null && drawLog.length > 0) {
+            drawLog[drawLog.length - 1].calls.push({ m: "fillText", text: t, minX: x, maxX: x, minY: y, maxY: y, font: this.currentFont });
+        }
+        return origFillText.call(this, t, x, y);
+    };
+}
+
+// per mode: fresh load + settle render with a FIXED method (geometric), then one captured render with
+// the mode under test, so both modes' capture renders start from identical input state
+// (the settle render's skylines feed into some element placements of the next render).
+async function render(geo) {
+    osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+    osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+    osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 9999999;
+    await osmd.load(loadParameter, sample);
+    osmd.render(); // settle render
+    for (let i = 0; i < extraWarmups; i++) { osmd.render(); }
+    osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = geo;
+    capture = [];
+    if (geo) { drawLog = []; }
+    osmd.render();
+    const result = { capture, drawLog };
+    capture = null;
+    drawLog = null;
+    return result;
+}
+
+let loadParameter = FS.readFileSync("test/data/" + sample);
+if (sample.endsWith(".mxl")) {
+    loadParameter = await OSMD.MXLHelper.MXLtoXMLstring(loadParameter);
+} else {
+    loadParameter = loadParameter.toString();
+}
+await osmd.load(loadParameter, sample);
+osmd.render();
+installUpdateLinesHook();
+installContextHook();
+const geoResult = await render(true);
+const geo = geoResult.capture;
+const log = geoResult.drawLog;
+const single = (await render(false)).capture;
+
+const samplingUnit = osmd.EngravingRules.SamplingUnit;
+// global measure ordinal base per staffline (for drawLog lookup)
+const measureOrdinalBase = [];
+let ordinal = 0;
+for (const g of geo) { measureOrdinalBase.push(ordinal); ordinal += g.measures.length; }
+if (ordinal !== log.length) {
+    console.log(`NOTE: drawLog has ${log.length} measures, captures have ${ordinal} (alignment may be off)`);
+}
+
+for (let i = 0; i < geo.length; i++) {
+    const g = geo[i], s = single[i];
+    const len = Math.min(g.sky.length, s.sky.length);
+    const clusters = [];
+    for (const part of ["sky", "bottom"]) {
+        let current = null;
+        for (let j = 0; j < len; j++) {
+            const va = g[part][j], vb = s[part][j];
+            const d = (Number.isNaN(va) || Number.isNaN(vb)) ? 0 : Math.abs(va - vb);
+            if (d > threshold) {
+                if (current && current.part === part && j === current.to + 1) {
+                    current.to = j;
+                    if (d > current.maxDiff) { current.maxDiff = d; current.geoVal = va; current.singleVal = vb; current.maxAt = j; }
+                } else {
+                    current = { part, from: j, to: j, maxDiff: d, geoVal: va, singleVal: vb, maxAt: j };
+                    clusters.push(current);
+                }
+            }
+        }
+    }
+    if (clusters.length === 0) { continue; }
+    console.log(`staffline ${i}:`);
+    for (const c of clusters) {
+        const xUnits = c.maxAt / samplingUnit;
+        const measureIndex = g.measures.findIndex(m => xUnits >= m.x && xUnits < m.x + m.w);
+        const measure = g.measures[measureIndex];
+        console.log(`  ${c.part} idx ${c.from}-${c.to} (x=${(c.from / samplingUnit).toFixed(1)}-${(c.to / samplingUnit).toFixed(1)}u)`
+            + ` maxDiff=${c.maxDiff.toFixed(2)} geo=${c.geoVal?.toFixed(2)} raster=${c.singleVal?.toFixed(2)}`
+            + ` -> measure ${measure ? measure.number : "?"} (globalOrdinal ${measureOrdinalBase[i] + measureIndex},`
+            + ` localPx ${((c.maxAt / samplingUnit - (measure?.x ?? 0)) * 10).toFixed(0)})`);
+        if (!measure) { continue; }
+        // dump geometric draw calls overlapping the divergent columns (in measure-local device px)
+        const localFrom = (c.from / samplingUnit - measure.x) * 10 - 2;
+        const localTo = ((c.to + 1) / samplingUnit - measure.x) * 10 + 2;
+        const entry = log[measureOrdinalBase[i] + measureIndex];
+        if (!entry) { continue; }
+        if (Math.abs(entry.width - Math.floor(measure.w * 10)) > 1) {
+            console.log(`    (drawLog alignment mismatch: entry width ${entry.width} vs measure ${Math.floor(measure.w * 10)})`);
+        }
+        for (const call of entry.calls) {
+            const xOverlap = call.maxX >= localFrom && call.minX <= localTo;
+            const textNear = call.m === "fillText" && call.minX >= localFrom - 20 && call.minX <= localTo + 20;
+            if (xOverlap || textNear) {
+                if (call.m === "fillText") {
+                    console.log(`    fillText "${call.text}" at x=${call.minX.toFixed(1)} y=${call.minY.toFixed(1)} font="${call.font}"`);
+                } else {
+                    console.log(`    ${call.m} x=[${call.minX.toFixed(1)}, ${call.maxX.toFixed(1)}] y=[${call.minY.toFixed(1)}, ${call.maxY.toFixed(1)}]`
+                        + (call.lw !== undefined ? ` lw=${call.lw}` : "") + ` style=${call.style}`);
+                }
+            }
+        }
+    }
+}

--- a/test/performance/skylineDrill.mjs
+++ b/test/performance/skylineDrill.mjs
@@ -32,6 +32,9 @@ Object.defineProperties(window.HTMLElement.prototype, {
 
 const osmd = new OSMD.OpenSheetMusicDisplay(div, { autoResize: false, backend: "svg", pageFormat: "Endless" });
 osmd.setLogLevel("warn");
+if (process.env.NEWSYSTEM_RULE) { // e.g. for test_octaveshift_extragraphicalmeasure, like generateImages --osmdtesting
+    osmd.EngravingRules.NewSystemAtXMLNewSystemAttribute = true;
+}
 
 // ---- capture hook (updateLines) ----
 let capture = null;

--- a/test/performance/skylineParity.mjs
+++ b/test/performance/skylineParity.mjs
@@ -1,17 +1,20 @@
-// Temporary validation harness: compares skyline/bottomline arrays between the geometric calculation
+// Validation harness: compares skyline/bottomline arrays between the geometric calculation
 // (GeometricSkyBottomLineContext) and the pixel-based (raster) calculations, for all test samples.
 // The arrays are captured directly after SkyBottomLineCalculator.updateLines(), i.e. before later layout
 // steps (lyrics, dynamics, ...) modify them, isolating the calculator difference.
 // Values are in OSMD units (1 unit = 1 staff space = 10px). Differences < ~0.1 units are expected
 // (raster quantizes to pixels and includes the anti-aliasing halo, geometric is exact).
 //
-// Usage: node test/performance/skylineParity.mjs [filterRegex] [maxSamples] [--with-batch]
+// Usage: node test/performance/skylineParity.mjs [filterRegex] [maxSamples] [--with-batch] [--first-render]
+// --first-render compares the very first render after load (what the visual pipeline produces)
+// instead of a settled re-render; some state (e.g. extra graphical measure widths) differs there.
 import FS from "fs";
 import jsdom from "jsdom";
 import OSMD from "../../build/opensheetmusicdisplay.min.js";
 
 const args = process.argv.slice(2).filter(a => !a.startsWith("--"));
 const withBatch = process.argv.includes("--with-batch");
+const firstRender = process.argv.includes("--first-render");
 const filterRegex = args[0] && args[0] !== "all" ? args[0] : "";
 const maxSamples = args[1] ? parseInt(args[1], 10) : Infinity;
 
@@ -89,11 +92,19 @@ const modeNames = withBatch ? ["geo", "single", "batch"] : ["geo", "single"];
 // with the mode under test. The settle render's skyline values feed into some element placements of
 // the next render (pre-existing re-render behavior, independent of this comparison), so the settle
 // must use the same method for all modes to give every capture render identical input state.
+// With --first-render, the settle render is skipped and the capture comes from the very first render
+// after a fresh load (per mode) - this is what the actual visual rendering pipeline does, and some
+// state (e.g. extra graphical measure widths) only occurs on the first render.
 async function capturedModeRender(modeName, loadParameter, sampleName) {
-    MODES.geo(osmd.EngravingRules);
-    await osmd.load(loadParameter, sampleName);
-    osmd.render(); // settle render (first render after load also differs slightly from re-renders)
-    MODES[modeName](osmd.EngravingRules);
+    if (firstRender) {
+        MODES[modeName](osmd.EngravingRules);
+        await osmd.load(loadParameter, sampleName);
+    } else {
+        MODES.geo(osmd.EngravingRules);
+        await osmd.load(loadParameter, sampleName);
+        osmd.render(); // settle render (first render after load also differs slightly from re-renders)
+        MODES[modeName](osmd.EngravingRules);
+    }
     capture = [];
     osmd.render();
     const result = capture;

--- a/test/performance/skylineParity.mjs
+++ b/test/performance/skylineParity.mjs
@@ -1,0 +1,238 @@
+// Temporary validation harness: compares skyline/bottomline arrays between the geometric calculation
+// (GeometricSkyBottomLineContext) and the pixel-based (raster) calculations, for all test samples.
+// The arrays are captured directly after SkyBottomLineCalculator.updateLines(), i.e. before later layout
+// steps (lyrics, dynamics, ...) modify them, isolating the calculator difference.
+// Values are in OSMD units (1 unit = 1 staff space = 10px). Differences < ~0.1 units are expected
+// (raster quantizes to pixels and includes the anti-aliasing halo, geometric is exact).
+//
+// Usage: node test/performance/skylineParity.mjs [filterRegex] [maxSamples] [--with-batch]
+import FS from "fs";
+import jsdom from "jsdom";
+import OSMD from "../../build/opensheetmusicdisplay.min.js";
+
+const args = process.argv.slice(2).filter(a => !a.startsWith("--"));
+const withBatch = process.argv.includes("--with-batch");
+const filterRegex = args[0] && args[0] !== "all" ? args[0] : "";
+const maxSamples = args[1] ? parseInt(args[1], 10) : Infinity;
+
+const dom = new jsdom.JSDOM("<!DOCTYPE html></html>");
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLAnchorElement = dom.window.HTMLAnchorElement;
+global.XMLHttpRequest = dom.window.XMLHttpRequest;
+global.DOMParser = dom.window.DOMParser;
+global.Node = dom.window.Node;
+global.Canvas = dom.window.Canvas;
+
+const div = document.createElement("div");
+div.id = "browserlessDiv";
+document.body.appendChild(div);
+const width = 1080;
+const height = 32767;
+div.width = width;
+div.height = height;
+div.setAttribute("width", width);
+div.setAttribute("height", height);
+div.setAttribute("offsetWidth", width);
+Object.defineProperties(window.HTMLElement.prototype, {
+    offsetLeft: { get: function () { return 0; } },
+    offsetTop: { get: function () { return 0; } },
+    offsetHeight: { get: function () { return height; } },
+    offsetWidth: { get: function () { return width; } }
+});
+
+const osmd = new OSMD.OpenSheetMusicDisplay(div, {
+    autoResize: false,
+    backend: "svg",
+    pageFormat: "Endless"
+});
+osmd.setLogLevel("warn");
+
+// ---- capture hook ----
+let capture = null; // when set to an array, every updateLines() result is pushed into it
+let hookInstalled = false;
+function installHook() {
+    if (hookInstalled) { return; }
+    const calculator = osmd.graphic.MusicPages[0]?.MusicSystems[0]?.StaffLines[0]?.SkyBottomLineCalculator;
+    if (!calculator) { return; }
+    const proto = Object.getPrototypeOf(calculator);
+    const orig = proto.updateLines;
+    proto.updateLines = function (results) {
+        orig.call(this, results);
+        if (capture) {
+            capture.push({ sky: Array.from(this.SkyLine), bottom: Array.from(this.BottomLine) });
+        }
+    };
+    hookInstalled = true;
+}
+
+const MODES = {
+    geo: (r) => {
+        r.UseGeometricSkyBottomLineCalculation = true;
+    },
+    single: (r) => { // per-staffline raster path (what the geometric code mirrors)
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 9999999;
+    },
+    batch: (r) => { // batched Plain raster path (the production default for >= 5 measures)
+        r.UseGeometricSkyBottomLineCalculation = false;
+        r.AlwaysSetPreferredSkyBottomLineBackendAutomatically = false;
+        r.SkyBottomLineBatchMinMeasures = 2;
+        r.PreferredSkyBottomLineBatchCalculatorBackend = 0; // Plain
+    },
+};
+const modeNames = withBatch ? ["geo", "single", "batch"] : ["geo", "single"];
+
+// Per mode: fresh load + a settle render with a FIXED method (geometric), then one captured render
+// with the mode under test. The settle render's skyline values feed into some element placements of
+// the next render (pre-existing re-render behavior, independent of this comparison), so the settle
+// must use the same method for all modes to give every capture render identical input state.
+async function capturedModeRender(modeName, loadParameter, sampleName) {
+    MODES.geo(osmd.EngravingRules);
+    await osmd.load(loadParameter, sampleName);
+    osmd.render(); // settle render (first render after load also differs slightly from re-renders)
+    MODES[modeName](osmd.EngravingRules);
+    capture = [];
+    osmd.render();
+    const result = capture;
+    capture = null;
+    // restore defaults
+    osmd.EngravingRules.UseGeometricSkyBottomLineCalculation = true;
+    osmd.EngravingRules.AlwaysSetPreferredSkyBottomLineBackendAutomatically = true;
+    osmd.EngravingRules.SkyBottomLineBatchMinMeasures = 5;
+    return result;
+}
+
+// ---- comparison ----
+function compareCaptures(a, b) {
+    const stats = {
+        stafflineCountMismatch: a.length !== b.length,
+        lengthMismatches: 0,
+        nanMismatches: 0,
+        total: 0,
+        above02: 0,
+        above05: 0,
+        sumAbs: 0,
+        maxSky: 0,
+        maxBottom: 0,
+        maxStaffline: -1,
+        maxIndex: -1,
+    };
+    const n = Math.min(a.length, b.length);
+    for (let i = 0; i < n; i++) {
+        const sa = a[i], sb = b[i];
+        if (sa.sky.length !== sb.sky.length) { stats.lengthMismatches++; }
+        const len = Math.min(sa.sky.length, sb.sky.length);
+        for (let j = 0; j < len; j++) {
+            for (const part of ["sky", "bottom"]) {
+                const va = sa[part][j], vb = sb[part][j];
+                const aNaN = Number.isNaN(va) || va === undefined;
+                const bNaN = Number.isNaN(vb) || vb === undefined;
+                if (aNaN || bNaN) {
+                    if (aNaN !== bNaN) { stats.nanMismatches++; }
+                    continue;
+                }
+                const d = Math.abs(va - vb);
+                stats.total++;
+                stats.sumAbs += d;
+                if (d > 0.2) { stats.above02++; }
+                if (d > 0.5) { stats.above05++; }
+                const maxKey = part === "sky" ? "maxSky" : "maxBottom";
+                if (d > stats[maxKey]) {
+                    stats[maxKey] = d;
+                    if (d >= Math.max(stats.maxSky, stats.maxBottom)) {
+                        stats.maxStaffline = i;
+                        stats.maxIndex = j;
+                    }
+                }
+            }
+        }
+    }
+    return stats;
+}
+
+function fmt(stats) {
+    const mean = stats.total ? (stats.sumAbs / stats.total) : 0;
+    let s = `maxSky=${stats.maxSky.toFixed(3)} maxBot=${stats.maxBottom.toFixed(3)} mean=${mean.toFixed(4)}`
+        + ` >0.2u=${stats.above02} >0.5u=${stats.above05}`;
+    if (stats.stafflineCountMismatch) { s += " STAFFLINE-COUNT-MISMATCH"; }
+    if (stats.lengthMismatches) { s += ` LEN-MISMATCH=${stats.lengthMismatches}`; }
+    if (stats.nanMismatches) { s += ` NaN-MISMATCH=${stats.nanMismatches}`; }
+    return s;
+}
+
+// ---- main ----
+const sampleDir = "test/data";
+let samples = FS.readdirSync(sampleDir).filter(f => f.match(/^.*(([.]xml)|([.]musicxml)|([.]mxl))$/));
+if (filterRegex) { samples = samples.filter(f => f.match(filterRegex)); }
+samples = samples.slice(0, maxSamples);
+console.log(`comparing ${modeNames.join(" vs ")} for ${samples.length} samples`);
+
+const report = {};
+let failed = 0;
+const aggregate = { geoVsSingle: { maxSky: 0, maxBottom: 0, above05: 0, above02: 0, total: 0, sumAbs: 0 } };
+for (const sample of samples) {
+    let loadParameter = FS.readFileSync(sampleDir + "/" + sample);
+    try {
+        if (sample.endsWith(".mxl")) {
+            loadParameter = await OSMD.MXLHelper.MXLtoXMLstring(loadParameter);
+        } else {
+            loadParameter = loadParameter.toString();
+        }
+        if (!hookInstalled) {
+            await osmd.load(loadParameter, sample);
+            osmd.render(); // throwaway render to get a calculator instance for the hook
+            installHook();
+            // self-consistency check: the same mode captured from two fresh loads must be identical
+            for (const modeName of modeNames) {
+                const c1 = await capturedModeRender(modeName, loadParameter, sample);
+                const c2 = await capturedModeRender(modeName, loadParameter, sample);
+                const selfStats = compareCaptures(c1, c2);
+                if (selfStats.maxSky > 0 || selfStats.maxBottom > 0 || selfStats.stafflineCountMismatch) {
+                    console.log(`WARNING: ${modeName} render not self-consistent: ${fmt(selfStats)}`);
+                }
+            }
+        }
+        const captures = {};
+        for (const modeName of modeNames) {
+            captures[modeName] = await capturedModeRender(modeName, loadParameter, sample);
+        }
+        const geoVsSingle = compareCaptures(captures.geo, captures.single);
+        let line = `${sample} [${captures.geo.length} stafflines] geo~single: ${fmt(geoVsSingle)}`;
+        report[sample] = { geoVsSingle };
+        if (withBatch) {
+            const singleVsBatch = compareCaptures(captures.single, captures.batch);
+            line += ` | single~batch(noise): ${fmt(singleVsBatch)}`;
+            report[sample].singleVsBatch = singleVsBatch;
+        }
+        console.log(line);
+        const agg = aggregate.geoVsSingle;
+        agg.maxSky = Math.max(agg.maxSky, geoVsSingle.maxSky);
+        agg.maxBottom = Math.max(agg.maxBottom, geoVsSingle.maxBottom);
+        agg.above02 += geoVsSingle.above02;
+        agg.above05 += geoVsSingle.above05;
+        agg.total += geoVsSingle.total;
+        agg.sumAbs += geoVsSingle.sumAbs;
+    } catch (ex) {
+        failed++;
+        console.log(`${sample} FAILED: ${ex.message?.split("\n")[0]}`);
+    }
+}
+
+const agg = aggregate.geoVsSingle;
+console.log("\n==== AGGREGATE geo~single ====");
+console.log(`samples: ${samples.length - failed} ok, ${failed} failed to load/render`);
+console.log(`values compared: ${agg.total}, mean abs diff: ${(agg.sumAbs / Math.max(1, agg.total)).toFixed(5)} units`);
+console.log(`max sky diff: ${agg.maxSky.toFixed(3)}, max bottom diff: ${agg.maxBottom.toFixed(3)} units`);
+console.log(`values >0.2u: ${agg.above02} (${(100 * agg.above02 / Math.max(1, agg.total)).toFixed(3)}%), >0.5u: ${agg.above05}`);
+const worst = Object.entries(report)
+    .sort((a, b) => Math.max(b[1].geoVsSingle.maxSky, b[1].geoVsSingle.maxBottom) - Math.max(a[1].geoVsSingle.maxSky, a[1].geoVsSingle.maxBottom))
+    .slice(0, 12);
+console.log("\nworst samples (geo~single):");
+for (const [name, r] of worst) {
+    console.log(`  ${name}: ${fmt(r.geoVsSingle)}`);
+}
+FS.writeFileSync("export/skylineParity.json", JSON.stringify(report, null, 1));
+console.log("\ndetails written to export/skylineParity.json");


### PR DESCRIPTION
See #1681 (text copied):

# ~1.8× faster rendering (1.5–2.3×): skylines are now calculated geometrically, without getImageData

**TL;DR:** `osmd.render()` is now **~1.8× faster on average** (×1.5–×2.3 depending on the score) in real browsers - a large orchestral score drops from **1.6s to 0.7s**.
The skyline calculation, previously the biggest performance cost, is **2–4× faster** (up to 7× vs the WebGL backend on short scores), while producing layouts almost identical to before to within a twentieth of a pixel on average.
As a bonus, staff lines now always render crisp instead of varying in apparent weight from system to system, as they snap to crisp subpixel position.

## Why rendering was slow

To place graphical elements like lyrics, dynamics and ornaments while avoiding collisions and to space systems, OSMD computes a *skyline* and *bottom-line* for every staffline: the upper and lower point/line of everything drawn in it.
Since 2017, this worked by brute force ([#937](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/937)):

1. draw every measure a second time onto a hidden canvas,
2. read **all of its pixels** back with `getImageData()`,
3. scan every pixel column for the topmost and bottommost ink.

Step 2 is the problematic one: on GPU-accelerated canvases, `getImageData()` stalls the pipeline and copies the framebuffer back to the CPU — for every measure of the sheet. Profiling showed the skyline pass taking up to ~96% of render time.

And there was no way around this other than not using `getImageData()` (and thus not getting the necessary pixel data), except using WebGL shaders, which are basically just a fancier and sometimes slightly faster way to `getImageData()`.

The later batch and WebGL backends made the readback cheaper, but still rasterized, transferred and scanned every pixel — and rebuilt the entire WebGL pipeline (context, shader compilation) on **every** render, including every zoom step and resize.

<img width="1964" height="394" alt="image" src="https://github.com/user-attachments/assets/a25e4866-1af5-4caa-8359-63ee0c50ad90" />

*Skyline (red), bottomline (blue)*

## What changed

The trick: **VexFlow still "draws" every measure — but onto math instead of pixels.**

The new `GeometricSkyBottomLineContext` is a virtual rendering context that implements the canvas interface VexFlow draws through (~30 methods).
Instead of rasterizing, it computes the per-column vertical extents ("skyline") directly from the draw commands:

- Bézier curves are flattened with closed-form extents; for per-column min/max, a filled path's contour equals its outline's — so no fill-rule rasterization is needed (holes like in half-note noteheads never contain a column's extremes).
- Strokes are dilated by their line width, arcs flattened, transparent ("invisible") elements skipped exactly like the pixel test skipped them.
- Text is measured per character, with each character's exact ink extents probed **once** from a tiny canvas and cached forever (per font + character).
- Glyphs — the bulk of all drawing — go through a fast path: their outline is parsed and flattened **once per glyph + scale** and cached as ready-to-merge segments, instead of re-processing ~30–80 outline commands on every notehead, accidental and clef ([VexFlowPatch hook](../src/VexFlowPatch/src/glyph.js), exact to the live path within float rounding).

**Because the *actual* VexFlow draw calls are intercepted, element coverage is automatic and complete** — no per-element placement formulas that could drift from real rendering behavior. No canvas is allocated, nothing is rasterized, no pixels travel between GPU and CPU.

## Numbers (real Chrome, medians; "before" = the backend OSMD's auto-selection used)

| score | measures | before | now | speedup | skyline phase speedup |
|---|---|---|---|---|---|
| OSMD function test all | 42 | 60ms | 30ms | **×2.0** | ×4.4 |
| Beethoven, An die ferne Geliebte | 45 | 47ms | 30ms | **×1.6** | ×3.2 |
| Bach, Praeludium in C (WTK I) | 70 | 139ms | 87ms | **×1.6** | ×2.2 |
| Clementi, Sonatina Op. 36 No. 3 | 128 | 276ms | 146ms | **×1.9** | ×2.8 |
| Joplin, The Entertainer | 184 | 289ms | 193ms | **×1.5** | ×2.0 |
| Haydn, Cello Concertante | 315 | 755ms | 422ms | **×1.8** | ×3.0 |
| Actor, Prelude (huge sample, full orchestra) | 1219 | **1644ms** | **716ms** | **×2.3** | ×4.0 |

Average ×1.8, range ×1.5–×2.3. The gains are largest at the extremes: short scores no longer pay batch/WebGL setup overhead (up to ×7 on the skyline phase), and large scores no longer pay per-measure readbacks. What remains of render time is mostly VexFlow's note formatting and the actual (visible) drawing — different battles, for another day.

You can test this yourself in your browser, see test/performance/README.md.

## How we know the layouts are still correct

The skyline values feed every placement decision, so correctness was treated as seriously as speed:

- **the actual VexFlow draw calls are intercepted** by a virtual Vexflow context, making coverage automatic and complete
- **Numeric comparison** of both methods over all 271 renderable test scores: of **1,185,624** skyline/bottom-line values, the mean difference is **0.0047 units (~0.05px)**; only 0.009% differ by more than half a unit — all of them single-sample, conservative edge cases of the pixel method's anti-aliasing/rounding, each class investigated and documented in the code.
- **Visual A/B** over the full sample corpus: no collisions, no element-level changes — only sub-pixel system shifts.
- A new karma regression test compares both methods in Chrome **and** Firefox on every CI run.
- visual regression test checked by human eyes (multiple times, a couple times the full ~280 sample set, which actually spotted a regression the machine missed)

## Bonus fixes found along the way

Staring at skylines this hard surfaced some long-standing quirks, now fixed:

- **Crisp staff lines, always** (`EngravingRules.SnapStafflinesToCrispPixels`, default on): staffline positions used to land on arbitrary sub-pixel offsets, so the 1px staff lines rendered as a crisp dark row in some systems and as two blurry half-gray rows in others — and this could flip with any tiny layout change. Systems are now snapped (by at most half a pixel) so staff lines always render crisp, in every system, at every release.
- **Extra instruction measures** (mid-piece key/rhythm changes) had inherited a `-1` sentinel width and could end up with *negative* widths in stretched systems, cutting the staffline short — e.g. visible with one-measure-per-system rendering.
- Content more than ~10 units above/below a staff was silently invisible to the old skyline (clipped by its 300px canvas); the geometric calculation has no such limit.

## Compatibility

- Enabled by default: `EngravingRules.UseGeometricSkyBottomLineCalculation = true` (or `IOSMDOptions.useGeometricSkyBottomLineCalculation`).
- Setting it to `false` restores the previous pixel-based calculation unchanged (per-staffline, batched Plain and WebGL backends), as an escape hatch.
- Layouts can shift by sub-pixel amounts compared to previous releases (the skylines are now exact instead of pixel-quantized); visual regression baselines need one re-bless.

## Tooling

The branch also adds `test/performance/` with the tools used here, for future performance work: browser + node benchmarks of all four skyline methods, the numeric parity harness (checking skyline values are correct / almost same as plain or WebGL results etc) with per-measure drill-down, and a full-corpus visual A/B comparison script - see its README in test/performance/README.md.

---

The original idea for this was my own (calculating extents/skyline from Vexflow draw and layout functions), and Claude 4.8 on max effort when prompted in this direction then found a neat, similar approach and implementation. It would have probably taken weeks to find this on one's own.
(I had tried this before with 4.6 or 4.7 on high or so, and it didn't find it. 4.8 on max is incredible.
It takes a long time to think, but that's completely worth it for high-impact fundamental issues like this one)

For the longest time, I didn't think it was possible to get around the slow `getImageData` usage, or only by rewriting the whole layouting system and reverse engineering Vexflow's placements a priori (which is actually a possible follow-up we can try in some cases).
I'm so happy that after the very technical performance improvement with shaders and WebGL, which are hard to improve and whose performance differs between systems (on some systems, it was faster without using shaders),
we now don't need to use shaders at all anymore, and we have a new, more elegant system that is also faster.
And there are still a few neat things I'd like to try to improve performance further, as mentioned.

This will be released in OSMD 2.0.0, I hope you all enjoy the performance improvement, especially on mobile devices!