### PR TITLE
Add lazy/incremental rendering option (renderNext API) to render scores "line by line"

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -89,6 +89,12 @@
                             <label>Follow Cursor</label>
                         </div>
                     </div>
+                    <div class="item" style="margin-top: 5px;">
+                        <div class="ui toggle checkbox">
+                            <input type="checkbox" name="public" id="incremental-checkbox">
+                            <label>Incremental rendering (load on scroll)</label>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -94,6 +94,7 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
         nextCursorBtn,
         resetCursorBtn,
         followCursorCheckbox,
+        incrementalCheckbox,
         showCursorBtn,
         hideCursorBtn,
         debugReRenderBtn,
@@ -233,6 +234,7 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
         nextCursorBtn = document.getElementById("next-cursor-btn");
         resetCursorBtn = document.getElementById("reset-cursor-btn");
         followCursorCheckbox = document.getElementById("follow-cursor-checkbox");
+        incrementalCheckbox = document.getElementById("incremental-checkbox");
         showCursorBtn = document.getElementById("show-cursor-btn");
         hideCursorBtn = document.getElementById("hide-cursor-btn");
         debugReRenderBtn = document.getElementById("debug-re-render-btn");
@@ -614,6 +616,11 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
                 openSheetMusicDisplay.FollowCursor = !openSheetMusicDisplay.FollowCursor;
             }
         }
+        if (incrementalCheckbox) {
+            incrementalCheckbox.onchange = function () {
+                renderAndScrollBack(); // re-render in the newly selected mode (incremental on, full off)
+            }
+        }
         hideCursorBtn.addEventListener("click", function () {
             if (openSheetMusicDisplay.cursor) {
                 openSheetMusicDisplay.cursor.hide();
@@ -667,6 +674,14 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
      * If you just call render() instead of renderAndScrollBack(),
      *   it will scroll you back to the top of the page, even if you were scrolled to the bottom before. */
     function renderAndScrollBack() {
+        if (incrementalCheckbox && incrementalCheckbox.checked) {
+            // Incremental ("system by system") rendering: paint the first batch now and append more as the
+            //   user scrolls toward the not-yet-rendered edge (page bottom, or the right edge for a single
+            //   horizontal staffline). Faster first paint on large scores. Re-entrant: render()/load()/resize
+            //   route back here and restart the session cleanly. A normal render() resets it (see OSMD).
+            openSheetMusicDisplay.enableIncrementalRenderingOnScroll();
+            return; // starts fresh at the top; nothing to scroll back to
+        }
         const previousScrollY = window.scrollY;
         const previousScrollHeight = document.body.scrollHeight; // height of page
         const previousScrollYPercent = previousScrollY / previousScrollHeight;
@@ -1024,6 +1039,9 @@ import { TransposeCalculator } from '../src/Plugins/Transpose/TransposeCalculato
      *   rendering issues with unicode and transparency).
      */
     async function createPdf(pdfName, scale, exportMode) {
+        // If an incremental render is mid-flight, finish it first: PDF export reads the backend SVG, which
+        //   otherwise only holds the batches scrolled into view so far. No-op for a normal/complete render.
+        openSheetMusicDisplay.renderRemaining();
         if (scale === undefined) {
             scale = 2;
         }

--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -505,6 +505,10 @@ export class EngravingRules {
     public RenderCopyright: boolean;
     public RenderPartNames: boolean;
     public RenderPartAbbreviations: boolean;
+    /** Internal cache-gate for lazy (renderAppend) rendering: when true, the lazy reuse caches (skyline)
+     *  are active. Set by OpenSheetMusicDisplay.renderAppend() and forced false by a normal render(), so
+     *  the caches never affect a non-lazy render. Not a user toggle. */
+    public LazyConsistentGraphic: boolean;
     /** Whether two render system labels on page 2+. This doesn't affect the default endless PageFormat. */
     public RenderSystemLabelsAfterFirstPage: boolean;
     public RenderFingerings: boolean;
@@ -1009,6 +1013,7 @@ export class EngravingRules {
         this.RenderCopyright = false;
         this.RenderPartNames = true;
         this.RenderPartAbbreviations = true;
+        this.LazyConsistentGraphic = false;
         this.RenderSystemLabelsAfterFirstPage = true;
         this.RenderFingerings = true;
         this.RenderMeasureNumbers = true;

--- a/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
+++ b/src/MusicalScore/Graphical/GraphicalMusicSheet.ts
@@ -1015,8 +1015,13 @@ export class GraphicalMusicSheet {
             const nextSystemLeftBorderTimeStamp: number = nextStaffEntry.parentMeasure.parentSourceMeasure.AbsoluteTimestamp.RealValue;
             let fraction: number;
             let interpolatedXPosition: number;
-            if (currentTimeStamp < nextSystemLeftBorderTimeStamp && previousStaffEntryMusicSystem.StaffLines[0]) {
-                // previousStaffEntryMusicSystem.StaffLines[0]: fix for drawing range set (previous system not rendered)
+            // .StaffLines[0] guards: a MusicSystem can be present in the graphic but not rendered (empty
+            //   StaffLines) when a draw range is set or under lazy rendering (and transiently mid-relayout),
+            //   in which case GetLeft/RightBorderAbsoluteXPosition would dereference an undefined StaffLines[0].
+            //   Position the cursor in whichever of the two systems is actually rendered.
+            if ((currentTimeStamp < nextSystemLeftBorderTimeStamp || !nextStaffEntryMusicSystem.StaffLines[0])
+                && previousStaffEntryMusicSystem.StaffLines[0]) {
+                // previous (rendered) system; clamps to its right border once the timestamp reaches the next system
                 currentMusicSystem = previousStaffEntryMusicSystem;
                 const previousStaffEntryPositionX: number = previousStaffEntry.PositionAndShape.AbsolutePosition.x;
                 const previousSystemRightBorderX: number = currentMusicSystem.GetRightBorderAbsoluteXPosition();
@@ -1024,7 +1029,8 @@ export class GraphicalMusicSheet {
                     (nextSystemLeftBorderTimeStamp - previousStaffEntry.getAbsoluteTimestamp().RealValue);
                 fraction = Math.min(1, Math.max(0, fraction));
                 interpolatedXPosition = previousStaffEntryPositionX + fraction * (previousSystemRightBorderX - previousStaffEntryPositionX);
-            } else {
+            } else if (nextStaffEntryMusicSystem.StaffLines[0]) {
+                // next (rendered) system
                 currentMusicSystem = nextStaffEntryMusicSystem;
                 const nextStaffEntryPositionX: number = nextStaffEntry.PositionAndShape.AbsolutePosition.x;
                 const nextSystemLeftBorderX: number = currentMusicSystem.GetLeftBorderAbsoluteXPosition();
@@ -1032,6 +1038,12 @@ export class GraphicalMusicSheet {
                     (nextStaffEntry.getAbsoluteTimestamp().RealValue - nextSystemLeftBorderTimeStamp);
                 fraction = Math.min(1, Math.max(0, fraction));
                 interpolatedXPosition = nextSystemLeftBorderX + fraction * (nextStaffEntryPositionX - nextSystemLeftBorderX);
+            } else {
+                // Neither system is rendered (timestamp outside the lazily-rendered range): no on-screen
+                //   position -- fall back to the previous staff entry's own x without crashing. The cursor's
+                //   caller positions harmlessly and a later render repositions it once the system is drawn.
+                currentMusicSystem = previousStaffEntryMusicSystem;
+                interpolatedXPosition = previousStaffEntry.PositionAndShape.AbsolutePosition.x;
             }
             return [interpolatedXPosition, currentMusicSystem];
         }

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -94,6 +94,11 @@ export abstract class MusicSheetCalculator {
     protected graphicalMusicSheet: GraphicalMusicSheet;
     protected rules: EngravingRules;
     protected musicSystems: MusicSystem[];
+    /** Lazy rendering: cache of computed sky/bottom lines, keyed per staff line by its system's
+     *  measure range + staff index. A growing-prefix batch re-runs the (expensive) skyline pass over the
+     *  whole prefix; this lets stable interior systems reuse the lines computed in an earlier batch instead
+     *  of re-measuring them. Only used when EngravingRules.LazyConsistentGraphic; cleared per lazy session. */
+    protected skyBottomLineCache: Map<string, { sky: number[], bottom: number[] }> = new Map();
 
     private abstractNotImplementedErrorMessage: string = "abstract, not implemented";
 
@@ -301,6 +306,24 @@ export abstract class MusicSheetCalculator {
         // transform Relative to Absolute Positions
         //This is called for each measure in calculate music systems (calculateLines -> calculateSkyBottomLines)
         GraphicalMusicSheet.transformRelativeToAbsolutePosition(this.graphicalMusicSheet);
+    }
+
+    /** Drop the lazy sky/bottom-line reuse cache (call when starting a fresh lazy session). */
+    public clearSkyBottomLineCache(): void {
+        this.skyBottomLineCache.clear();
+    }
+
+    /** Stable per-staff-line key for the lazy sky/bottom-line cache: the system's measure range pins the
+     *  system (systems partition the measures), the staff index picks the line within it. Returns undefined
+     *  for a staff line with no usable measures (so it is never cached/reused). */
+    protected skyBottomLineCacheKey(staffLine: StaffLine, staffIndexInSystem: number): string {
+        const measures: GraphicalMeasure[] = staffLine.Measures;
+        const first: GraphicalMeasure = measures[0];
+        const last: GraphicalMeasure = measures[measures.length - 1];
+        if (!first || !last) {
+            return undefined;
+        }
+        return first.MeasureNumber + ":" + last.MeasureNumber + ":" + staffIndexInSystem;
     }
 
     public calculateXLayout(graphicalMusicSheet: GraphicalMusicSheet, maxInstrNameLabelLength: number): void {
@@ -3700,6 +3723,8 @@ export abstract class MusicSheetCalculator {
             }
             // second Underscore in the endStaffLine until endStaffEntry (if endStaffEntry isn't the first StaffEntry of the StaffLine))
             if (endStaffEntry.parentMeasure.ParentStaffLine && endStaffEntry.parentMeasure.staffEntries &&
+                // the end staffline's first measure can be missing when it isn't laid out (e.g. a lazy/incremental render batch)
+                endStaffLine.Measures[0]?.staffEntries[0] &&
                 !(endStaffEntry === endStaffEntry.parentMeasure.staffEntries[0] &&
                 endStaffEntry.parentMeasure === endStaffEntry.parentMeasure.ParentStaffLine.Measures[0])) {
                 const secondStartX: number = endStaffLine.Measures[0].staffEntries[0].PositionAndShape.RelativePosition.x;

--- a/src/MusicalScore/Graphical/MusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/MusicSheetDrawer.ts
@@ -51,6 +51,27 @@ export abstract class MusicSheetDrawer {
     public skyLineVisible: boolean = false;
     public bottomLineVisible: boolean = false;
 
+    /** Lazy rendering: when >= 0, drawPage() draws only the systems of (the first) page whose
+     *  index is within [LazyDrawSystemsFromIndex, LazyDrawSystemsToIndexExcl), leaving the
+     *  already-drawn systems above untouched in the shared backend. -1 (default) draws every system.
+     *  Set by OpenSheetMusicDisplay.renderAppend() before each appended batch; reset to -1 after. */
+    public LazyDrawSystemsFromIndex: number = -1;
+    public LazyDrawSystemsToIndexExcl: number = Number.POSITIVE_INFINITY;
+    /** Lazy horizontal rendering (RenderSingleHorizontalStaffline): draw only graphical objects whose right
+     *  edge x (in OSMD units) lies in (LazyDrawFromXUnits, LazyDrawToXUnits] -- the measures and spanning
+     *  elements that first entered the drawn frontier this batch. ±Infinity (default) draws everything.
+     *  Set by OpenSheetMusicDisplay.renderAppendGrowingHorizontal() per batch; reset after. */
+    public LazyDrawFromXUnits: number = Number.NEGATIVE_INFINITY;
+    public LazyDrawToXUnits: number = Number.POSITIVE_INFINITY;
+    /** Lazy horizontal rendering: when true, drawPage() skips the page-level labels (title/credits). They are
+     *  drawn once, on the final batch, when the page has reached its full width and they sit at their final
+     *  (re-centered) positions -- drawing them earlier would place them under a still-growing page. */
+    public LazySkipPageLabels: boolean = false;
+    /** Lazy horizontal rendering: when true, drawLabel() ignores the x-window gate. Scoped (set/restored) to
+     *  the page-label loop in drawPage(), since those labels span the full page width and must all be drawn
+     *  even though their left edges lie behind the final batch's frontier. */
+    public LazyForcePageLabels: boolean = false;
+
     protected rules: EngravingRules;
     protected graphicalMusicSheet: GraphicalMusicSheet;
     protected textMeasurer: ITextMeasurer;
@@ -144,7 +165,30 @@ export abstract class MusicSheetDrawer {
         throw new Error("not implemented");
     }
 
+    /** Lazy horizontal rendering: whether an object with this bounding box falls in the current draw
+     *  x-window (its right edge first entered the drawn frontier this batch). True when not lazy-horizontal. */
+    protected lazyDrawsAtX(rightXUnits: number): boolean {
+        if (this.LazyDrawFromXUnits === Number.NEGATIVE_INFINITY && this.LazyDrawToXUnits === Number.POSITIVE_INFINITY) {
+            return true;
+        }
+        return rightXUnits > this.LazyDrawFromXUnits && rightXUnits <= this.LazyDrawToXUnits;
+    }
+    protected lazyDrawsObject(psh: BoundingBox): boolean {
+        return this.lazyDrawsAtX(psh.AbsolutePosition.x + psh.BorderRight);
+    }
+    /** Lazy horizontal rendering: whether to draw the once-only left-edge system elements (instrument braces
+     *  and group brackets). True for non-lazy and for the first lazy-horizontal batch, which owns the left edge
+     *  (LazyDrawFromXUnits is -Infinity); false for continuation batches, so a single-system score's brace
+     *  isn't redrawn on top of itself every batch. (Vertical lazy keeps the x-window at ±Infinity and draws
+     *  each system's brace once via the per-system gate, so this stays true there.) */
+    protected lazyDrawsLeftEdgeOnce(): boolean {
+        return this.LazyDrawFromXUnits === Number.NEGATIVE_INFINITY;
+    }
+
     public drawLabel(graphicalLabel: GraphicalLabel, layer: number): Node {
+        if (!this.LazyForcePageLabels && !this.lazyDrawsObject(graphicalLabel.PositionAndShape)) {
+            return undefined;
+        }
         if (!this.isVisible(graphicalLabel.PositionAndShape)) {
             return undefined;
         }
@@ -381,6 +425,10 @@ export abstract class MusicSheetDrawer {
     protected drawStaffLine(staffLine: StaffLine): void {
         for (const measure of staffLine.Measures) {
             this.drawMeasure(measure);
+            if (measure.parentSourceMeasure) {
+                measure.parentSourceMeasure.WasRendered = true; // simplification
+                // parentSourceMeasure can be undefined for implicit measure (e.g. time signature change at end of staffline)
+            }
         }
 
         if (this.rules.RenderLyrics) {
@@ -512,15 +560,30 @@ export abstract class MusicSheetDrawer {
             return;
         }
 
-        for (const system of page.MusicSystems) {
+        const lazySelective: boolean = this.LazyDrawSystemsFromIndex >= 0;
+        for (let sysIdx: number = 0; sysIdx < page.MusicSystems.length; sysIdx++) {
+            // Lazy: skip systems already drawn in a previous batch (below FromIndex) and the
+            // deferred last system of this batch (at/above ToIndexExcl), so each system is drawn once,
+            // in its final stable position. See OpenSheetMusicDisplay.renderAppend().
+            if (lazySelective && (sysIdx < this.LazyDrawSystemsFromIndex || sysIdx >= this.LazyDrawSystemsToIndexExcl)) {
+                continue;
+            }
+            const system: MusicSystem = page.MusicSystems[sysIdx];
             if (this.isVisible(system.PositionAndShape)) {
                 this.drawMusicSystem(system);
             }
         }
-        if (page === page.Parent.MusicPages[0]) {
+        // The title/credits block belongs to the first system's batch only; a lazy continuation batch
+        // (FromIndex > 0) must not redraw it on top of the already-drawn block.
+        if (page === page.Parent.MusicPages[0] && !(lazySelective && this.LazyDrawSystemsFromIndex > 0) && !this.LazySkipPageLabels) {
+            // Page labels span the full page width and are drawn once, in full. Under lazy-horizontal this is
+            // the final batch; open the x-window so labels left of its frontier aren't dropped. No-op otherwise.
+            const savedForcePageLabels: boolean = this.LazyForcePageLabels;
+            this.LazyForcePageLabels = true;
             for (const label of page.Labels) {
                 label.SVGNode = this.drawLabel(label, <number>GraphicalLayers.Notes);
             }
+            this.LazyForcePageLabels = savedForcePageLabels;
         }
         // Draw bounding boxes for debug purposes. This has to be at the end because only
         // then all the calculations and recalculations are done

--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -225,39 +225,10 @@ export class SkyBottomLineCalculator {
             new GeometricSkyBottomLineContext(0, 300, this.mRules.GeometricSkyBottomLineCaches);
         // search through all Measures
         for (const measure of this.StaffLineParent.Measures as VexFlowMeasure[]) {
-            // must calculate first AbsolutePositions
-            measure.PositionAndShape.calculateAbsolutePositionsRecursive(0, 0);
-
-            const vsStaff: any = measure.getVFStave();
-            let width: number = vsStaff.getWidth();
-            if (!(width > 0) && !measure.IsExtraGraphicalMeasure) {
-                log.warn("SkyBottomLineCalculator: width not > 0 in measure " + measure.MeasureNumber);
-                width = 50;
-            }
-            // Mirror the raster method's "canvas.width = width" coercion (HTMLCanvasElement reflection)
-            // for identical results, including its quirks: fractional widths truncate, and negative widths
-            // (which occur for some extra graphical measures, see test_octaveshift_extragraphicalmeasure)
-            // fall back to the default canvas width of 300, so such measures contribute the same
-            // (drawn) entries to the skyline as on the raster path instead of a single empty one.
-            width = Math.trunc(width);
-            if (!isFinite(width)) {
-                width = 0;
-            } else if (width < 0) {
-                width = 300;
-            }
+            // Prepare the measure (normalize positions, format at the skyline-canvas width). Extracted so
+            // the lazy skyline reuse can replay these exact side effects without re-measuring extents.
+            const width: number = this.prepareMeasureForGeometricSkyline(measure);
             geometricContext.initialize(width);
-
-            // This magic number is an offset from the top image border so that
-            // elements above the staffline can be drawn correctly.
-            // (Kept from the raster method for identical side effects. The stave position is set again by the drawer later.)
-            vsStaff.setY(vsStaff.y + 100);
-            const oldMeasureWidth: number = vsStaff.getWidth();
-            // We need to tell the VexFlow stave about the canvas width. This looks
-            // redundant because it should know the canvas but somehow it doesn't.
-            // Maybe I am overlooking something but for now this does the trick
-            vsStaff.setWidth(width);
-            measure.format();
-            vsStaff.setWidth(oldMeasureWidth);
             try {
                 measure.draw(geometricContext as any);
                 // Vexflow errors can happen here, then our complete rendering loop would halt without catching errors.
@@ -286,6 +257,63 @@ export class SkyBottomLineCalculator {
         }
 
         this.updateLines(results);
+    }
+
+    /** The per-measure side effects the geometric skyline calc applies before measuring extents: normalize
+     *  absolute positions, bump the stave Y, and format the measure at the truncated skyline-canvas width.
+     *  Later layout passes read this state (the VexFlow formatter is not idempotent), so the lazy skyline
+     *  reuse must replay it via applyGeometricSkylineSideEffectsOnly. Returns the skyline-canvas width. */
+    private prepareMeasureForGeometricSkyline(measure: VexFlowMeasure): number {
+        // must calculate first AbsolutePositions
+        measure.PositionAndShape.calculateAbsolutePositionsRecursive(0, 0);
+
+        const vsStaff: any = measure.getVFStave();
+        let width: number = vsStaff.getWidth();
+        if (!(width > 0) && !measure.IsExtraGraphicalMeasure) {
+            log.warn("SkyBottomLineCalculator: width not > 0 in measure " + measure.MeasureNumber);
+            width = 50;
+        }
+        // Mirror the raster method's "canvas.width = width" coercion (HTMLCanvasElement reflection)
+        // for identical results, including its quirks: fractional widths truncate, and negative widths
+        // (which occur for some extra graphical measures, see test_octaveshift_extragraphicalmeasure)
+        // fall back to the default canvas width of 300, so such measures contribute the same
+        // (drawn) entries to the skyline as on the raster path instead of a single empty one.
+        width = Math.trunc(width);
+        if (!isFinite(width)) {
+            width = 0;
+        } else if (width < 0) {
+            width = 300;
+        }
+
+        // This magic number is an offset from the top image border so that
+        // elements above the staffline can be drawn correctly.
+        // (Kept from the raster method for identical side effects. The stave position is set again by the drawer later.)
+        vsStaff.setY(vsStaff.y + 100);
+        const oldMeasureWidth: number = vsStaff.getWidth();
+        // We need to tell the VexFlow stave about the canvas width. This looks
+        // redundant because it should know the canvas but somehow it doesn't.
+        // Maybe I am overlooking something but for now this does the trick
+        vsStaff.setWidth(width);
+        measure.format();
+        vsStaff.setWidth(oldMeasureWidth);
+        return width;
+    }
+
+    /** Replay the geometric skyline calc's per-measure side effects WITHOUT the expensive extent
+     *  measurement, so lazy rendering can reuse cached sky/bottom lines while leaving the measures in the exact
+     *  state a normal render would. (calculateLinesGeometric does correctNotePositions inside measure.draw;
+     *  here we call it directly since the draw is skipped.) No-op for the non-default raster skyline path. */
+    public applyGeometricSkylineSideEffectsOnly(): void {
+        if (!this.mRules.UseGeometricSkyBottomLineCalculation) {
+            return;
+        }
+        for (const measure of this.StaffLineParent.Measures as VexFlowMeasure[]) {
+            if (!measure) {
+                continue;
+            }
+            this.prepareMeasureForGeometricSkyline(measure);
+            measure.correctNotePositions();
+        }
     }
 
     public updateSkyLineWithLine(start: PointF2D, end: PointF2D, value: number): void {
@@ -452,6 +480,14 @@ export class SkyBottomLineCalculator {
      */
     public resetBottomLineInRange(startIndex: number, endIndex: number): void {
         this.setInRange(this.BottomLine, startIndex, endIndex);
+    }
+
+    /** Replace the sky- and bottom-line arrays directly (lazy rendering reuses the
+     *  previously-computed lines of stable interior systems instead of re-measuring them; see
+     *  VexFlowMusicSheetCalculator.calculateSkyBottomLines). */
+    public setLinesDirectly(skyLine: number[], bottomLine: number[]): void {
+        this.mSkyLine = skyLine;
+        this.mBottomLine = bottomLine;
     }
 
     /**

--- a/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/CanvasVexFlowBackend.ts
@@ -34,16 +34,19 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
         //     document.getElementById("osmdCanvasVexFlowBackendCanvas" + this.graphicalMusicPage.PageNumber)?.style.height, 10);
     }
 
-    public initialize(container: HTMLElement, zoom: number): void {
+    public initialize(container: HTMLElement, zoom: number, id: string = undefined): void {
         this.zoom = zoom;
         this.canvas = document.createElement("canvas");
         if (!this.graphicalMusicPage) {
             this.graphicalMusicPage = new GraphicalMusicPage(undefined);
             this.graphicalMusicPage.PageNumber = 1;
         }
-        this.canvas.id = "osmdCanvasVexFlowBackendCanvas" + this.graphicalMusicPage.PageNumber; // needed to extract image buffer from js
+        if (!id) {
+            id = this.graphicalMusicPage.PageNumber.toString();
+        }
+        this.canvas.id = "osmdCanvasVexFlowBackendCanvas" + id; // needed to extract image buffer from js
         this.inner = document.createElement("div");
-        this.inner.id = "osmdCanvasPage" + this.graphicalMusicPage.PageNumber;
+        this.inner.id = "osmdCanvasPage" + id;
         this.inner.style.position = "relative";
         this.canvas.style.zIndex = "0";
         this.inner.appendChild(this.canvas);
@@ -97,6 +100,33 @@ export class CanvasVexFlowBackend extends VexFlowBackend {
             this.zoom = 1; // remove
             this.ctx.fillRect(0, 0, (this.canvas as any).width / this.zoom, (this.canvas as any).height / this.zoom);
             this.ctx.restore();
+        }
+    }
+
+    /** Resizing a canvas clears its bitmap. Lazy/incremental rendering grows the canvas as it appends
+     *  batches, so snapshot the current pixels and redraw them after resizing. For a normal render the
+     *  canvas is still empty here, so this is effectively a no-op. */
+    public resize(width: number, height: number): void {
+        const canvas: any = this.canvas;
+        let snapshot: any;
+        if (canvas && canvas.width > 0 && canvas.height > 0) {
+            snapshot = document.createElement("canvas");
+            snapshot.width = canvas.width;
+            snapshot.height = canvas.height;
+            snapshot.getContext("2d").drawImage(canvas, 0, 0);
+        }
+        super.resize(width, height);
+        if (snapshot) {
+            const ctx2d: any = canvas.getContext("2d");
+            ctx2d.save();
+            ctx2d.setTransform(1, 0, 0, 1, 0, 0); // work in raw device pixels
+            if (this.rules.PageBackgroundColor) {
+                // the grown (transparent) area below the preserved content needs the page background
+                ctx2d.fillStyle = this.rules.PageBackgroundColor;
+                ctx2d.fillRect(0, snapshot.height, canvas.width, canvas.height - snapshot.height);
+            }
+            ctx2d.drawImage(snapshot, 0, 0); // restore the previously rendered batches at the top
+            ctx2d.restore();
         }
     }
 

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowBackend.ts
@@ -26,7 +26,7 @@ export abstract class VexFlowBackend {
   public width: number; // read-only
   public height: number; // read-only
 
-  public abstract initialize(container: HTMLElement, zoom: number): void;
+  public abstract initialize(container: HTMLElement, zoom: number, id?: string): void;
 
   public getInnerElement(): HTMLElement {
     return this.inner;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -2005,7 +2005,57 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
   }
 
   protected calculateSkyBottomLines(): void {
-    const staffLines: StaffLine[] = CollectionUtil.flat(this.musicSystems.map(musicSystem => musicSystem.StaffLines));
+    const allStaffLines: StaffLine[] = CollectionUtil.flat(this.musicSystems.map(musicSystem => musicSystem.StaffLines));
+
+    // Lazy rendering: reuse the sky/bottom lines of stable interior systems computed in an
+    // earlier growing-prefix batch, and only (re)compute the rest. The skyline pass is the dominant layout
+    // cost; on a big score this turns the per-batch O(prefix) re-measure into O(new systems). The FIRST
+    // system and the LAST system of the prefix are never cached/reused: empirically their lines change as
+    // the prefix grows (first system) or as the last, unstretched system later becomes stretched/interior.
+    // Only the geometric skyline path's side effects are replayable for reuse (see
+    // SkyBottomLineCalculator.applyGeometricSkylineSideEffectsOnly); the raster path computes everything.
+    const lazyCache: boolean = this.rules.LazyConsistentGraphic && this.rules.UseGeometricSkyBottomLineCalculation;
+    const staffLinesToCompute: StaffLine[] = lazyCache ? [] : allStaffLines;
+    const toCache: { key: string, staffLine: StaffLine }[] = [];
+    if (lazyCache) {
+      const lastSystemIndex: number = this.musicSystems.length - 1;
+      for (let si: number = 0; si < this.musicSystems.length; si++) {
+        const cacheable: boolean = si !== 0 && si !== lastSystemIndex;
+        const systemStaffLines: StaffLine[] = this.musicSystems[si].StaffLines;
+        for (let li: number = 0; li < systemStaffLines.length; li++) {
+          const staffLine: StaffLine = systemStaffLines[li];
+          const key: string = this.skyBottomLineCacheKey(staffLine, li);
+          const cached: { sky: number[], bottom: number[] } = key ? this.skyBottomLineCache.get(key) : undefined;
+          if (cached) {
+            // Replay the skyline calc's per-measure side effects (the VexFlow formatter is not idempotent,
+            // so skipping them would shift later passes by ~1px), then reuse the verified byte-identical
+            // cached lines instead of re-measuring extents (the expensive part).
+            staffLine.SkyBottomLineCalculator.applyGeometricSkylineSideEffectsOnly();
+            staffLine.SkyBottomLineCalculator.setLinesDirectly(cached.sky.slice(), cached.bottom.slice());
+          } else {
+            staffLinesToCompute.push(staffLine);
+            if (cacheable && key) {
+              toCache.push({ key, staffLine });
+            }
+          }
+        }
+      }
+    }
+
+    this.computeSkyBottomLinesFor(staffLinesToCompute);
+
+    for (const entry of toCache) {
+      this.skyBottomLineCache.set(entry.key, { sky: entry.staffLine.SkyLine.slice(), bottom: entry.staffLine.BottomLine.slice() });
+    }
+  }
+
+  /** Compute (not reuse) the sky/bottom lines for the given staff lines: geometric, or the batched /
+   *  per-staff-line path. This is the original calculateSkyBottomLines body, extracted so the lazy reuse
+   *  path can feed it just the staff lines that actually need computing. */
+  private computeSkyBottomLinesFor(staffLines: StaffLine[]): void {
+    if (staffLines.length === 0) {
+      return;
+    }
     if (this.rules.UseGeometricSkyBottomLineCalculation) {
       // geometric calculation doesn't need batching: no canvas allocation or pixel readback (getImageData) is involved
       for (const staffLine of staffLines) {
@@ -2013,7 +2063,6 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       }
       return;
     }
-    //const numMeasures: number = staffLines.map(staffLine => staffLine.Measures.length).reduce((a, b) => a + b, 0);
     let numMeasures: number = 0; // number of graphical measures that are rendered
     for (const staffline of staffLines) {
       for (const measure of staffline.Measures) {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetDrawer.ts
@@ -19,6 +19,8 @@ import { GraphicalLyricEntry } from "../GraphicalLyricEntry";
 import { VexFlowStaffLine } from "./VexFlowStaffLine";
 import { StaffLine } from "../StaffLine";
 import { GraphicalSlur } from "../GraphicalSlur";
+import { GraphicalNote } from "../GraphicalNote";
+import { GraphicalMeasure } from "../GraphicalMeasure";
 import { PlacementEnum } from "../../VoiceData/Expressions/AbstractExpression";
 import { GraphicalInstantaneousTempoExpression } from "../GraphicalInstantaneousTempoExpression";
 import { GraphicalInstantaneousDynamicExpression } from "../GraphicalInstantaneousDynamicExpression";
@@ -141,6 +143,12 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
 
     private drawSlurs(vfstaffLine: VexFlowStaffLine, absolutePos: PointF2D): void {
         for (const graphicalSlur of vfstaffLine.GraphicalSlurs) {
+            // lazy horizontal: gate by the slur's actual note x-positions (forward-stable), not its bezier
+            // points. Cross-staff slurs recompute their bezier here (at draw time) and can be degenerate in a
+            // partial layout, so a bezier-based gate would let them slip into several batches at once.
+            if (!this.lazyDrawsSlur(graphicalSlur)) {
+                continue;
+            }
             if (graphicalSlur.slur.isCrossed()) {
                 if (!this.rules.RenderSlursAcrossStaves) {
                     continue; // cross-staff slurs disabled (supplementary to RenderSlurs)
@@ -154,6 +162,33 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
             }
             this.drawSlur(graphicalSlur, absolutePos);
         }
+    }
+
+    /** Lazy horizontal rendering: whether a slur belongs in this batch's draw x-window, based on the absolute
+     *  x of its start/end notes (forward-stable as the prefix grows). Returns true when not lazy-horizontal, or
+     *  when the notes can't be located (don't suppress). See drawSlurs() for why we avoid the bezier points. */
+    private lazyDrawsSlur(graphicalSlur: GraphicalSlur): boolean {
+        if (this.LazyDrawFromXUnits === Number.NEGATIVE_INFINITY && this.LazyDrawToXUnits === Number.POSITIVE_INFINITY) {
+            return true;
+        }
+        let rightX: number = Number.NEGATIVE_INFINITY;
+        const startGNote: GraphicalNote = this.rules.GNote(graphicalSlur.slur.StartNote);
+        const endGNote: GraphicalNote = this.rules.GNote(graphicalSlur.slur.EndNote);
+        if (startGNote) {
+            rightX = Math.max(rightX, startGNote.PositionAndShape.AbsolutePosition.x);
+        }
+        if (endGNote) {
+            rightX = Math.max(rightX, endGNote.PositionAndShape.AbsolutePosition.x);
+        }
+        // Fallback (e.g. a slur continuing from another staffline where GNote is unavailable): the slur's
+        // graphical staff entries are always present and forward-stable, and bound its x-extent.
+        for (const staffEntry of graphicalSlur.staffEntries) {
+            rightX = Math.max(rightX, staffEntry.PositionAndShape.AbsolutePosition.x + staffEntry.PositionAndShape.BorderRight);
+        }
+        if (rightX === Number.NEGATIVE_INFINITY) {
+            return true; // couldn't locate the slur at all; don't suppress it
+        }
+        return this.lazyDrawsAtX(rightX);
     }
 
     private drawGlissandi(vfStaffLine: VexFlowStaffLine, absolutePos: PointF2D): void {
@@ -183,6 +218,7 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     }
 
     private drawSlur(graphicalSlur: GraphicalSlur, abs: PointF2D): void {
+        // lazy horizontal: the x-window gate is applied in drawSlurs() by note position (see lazyDrawsSlur)
         const curvePointsInPixels: PointF2D[] = [];
         // 1) create inner or original curve:
         const p1: PointF2D = new PointF2D(graphicalSlur.bezierStartPt.x + abs.x, graphicalSlur.bezierStartPt.y + abs.y);
@@ -225,6 +261,9 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     }
 
     protected drawMeasure(measure: VexFlowMeasure): void {
+        if (!this.lazyDrawsObject(measure.PositionAndShape)) {
+            return; // lazy horizontal: this measure is outside the batch's draw x-window
+        }
         measure.setAbsoluteCoordinates(
             measure.PositionAndShape.AbsolutePosition.x * unitInPixels,
             measure.PositionAndShape.AbsolutePosition.y * unitInPixels
@@ -671,6 +710,9 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     }
 
     protected drawInstrumentBrace(brace: GraphicalObject, system: MusicSystem): void {
+        if (!this.lazyDrawsLeftEdgeOnce()) {
+            return; // lazy horizontal: the brace is a once-only left-edge element, drawn with the first batch
+        }
         const ctx: Vex.IRenderContext = this.backend.getContext();
         ctx.openGroup("brace");
         // Draw InstrumentBrackets at beginning of line
@@ -680,6 +722,9 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     }
 
     protected drawGroupBracket(bracket: GraphicalObject, system: MusicSystem): void {
+        if (!this.lazyDrawsLeftEdgeOnce()) {
+            return; // lazy horizontal: the group bracket is a once-only left-edge element (first batch only)
+        }
         const ctx: Vex.IRenderContext = this.backend.getContext();
         ctx.openGroup("bracket");
         // Draw InstrumentBrackets at beginning of line
@@ -688,9 +733,26 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         ctx.closeGroup();
     }
 
+    /** Lazy horizontal rendering: whether a spanning element (octave shift, pedal, vibrato, hairpin) belongs
+     *  in this batch's draw x-window. It is drawn in the batch where its END MEASURE's right edge first enters
+     *  the frontier -- i.e. once its whole span is laid out and stable (same rule as the measure itself).
+     *  Returns true when not lazy-horizontal, or when the end measure is unknown (don't suppress). */
+    private lazyDrawsSpanToMeasure(endMeasure: GraphicalMeasure): boolean {
+        if (this.LazyDrawFromXUnits === Number.NEGATIVE_INFINITY && this.LazyDrawToXUnits === Number.POSITIVE_INFINITY) {
+            return true;
+        }
+        if (!endMeasure) {
+            return true; // can't determine the span's end; don't suppress it
+        }
+        return this.lazyDrawsObject(endMeasure.PositionAndShape);
+    }
+
     protected drawOctaveShifts(staffLine: StaffLine): void {
         for (const graphicalOctaveShift of staffLine.OctaveShifts) {
             if (graphicalOctaveShift) {
+                if (!this.lazyDrawsSpanToMeasure(graphicalOctaveShift.endMeasure)) {
+                    continue; // lazy horizontal: span not yet fully in the frontier
+                }
                 const vexFlowOctaveShift: VexFlowOctaveShift = graphicalOctaveShift as VexFlowOctaveShift;
                 const ctx: Vex.IRenderContext = this.backend.getContext();
                 const textBracket: VF.TextBracket = vexFlowOctaveShift.getTextBracket();
@@ -711,6 +773,9 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         for (const graphicalPedal of staffLine.Pedals) {
             if (graphicalPedal) {
                 const vexFlowPedal: VexFlowPedal = graphicalPedal as VexFlowPedal;
+                if (!this.lazyDrawsSpanToMeasure(vexFlowPedal.endMeasure)) {
+                    continue; // lazy horizontal: span not yet fully in the frontier
+                }
                 const ctx: Vex.IRenderContext = this.backend.getContext();
                 const pedalMarking: Vex.Flow.PedalMarking = vexFlowPedal.getPedalMarking();
                 (pedalMarking as any).render_options.color = this.rules.DefaultColorMusic;
@@ -724,6 +789,10 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
         for (const graphicalWavyLine of staffLine.WavyLines) {
             if (graphicalWavyLine) {
                 const vexFlowVibratoBracket: VexFlowVibratoBracket = graphicalWavyLine as VexFlowVibratoBracket;
+                const wavyEndMeasure: GraphicalMeasure = vexFlowVibratoBracket.endVfVoiceEntry?.parentStaffEntry?.parentMeasure;
+                if (!this.lazyDrawsSpanToMeasure(wavyEndMeasure)) {
+                    continue; // lazy horizontal: span not yet fully in the frontier
+                }
                 const ctx: Vex.IRenderContext = this.backend.getContext();
                 const vfVibratoBracket: Vex.Flow.VibratoBracket = vexFlowVibratoBracket.getVibratoBracket();
                 (vfVibratoBracket as any).setContext(ctx);
@@ -775,8 +844,11 @@ export class VexFlowMusicSheetDrawer extends MusicSheetDrawer {
     protected drawContinuousDynamic(graphicalExpression: VexFlowContinuousDynamicExpression): void {
         if (graphicalExpression.IsVerbal) {
             const label: GraphicalLabel = graphicalExpression.Label;
-            label.SVGNode = this.drawLabel(label, <number>GraphicalLayers.Notes);
+            label.SVGNode = this.drawLabel(label, <number>GraphicalLayers.Notes); // x-window gated inside drawLabel
         } else {
+            if (!this.lazyDrawsSpanToMeasure(graphicalExpression.EndMeasure)) {
+                return; // lazy horizontal: hairpin not yet fully in the frontier
+            }
             for (const line of graphicalExpression.Lines) {
                 const start: PointF2D = new PointF2D(graphicalExpression.ParentStaffLine.PositionAndShape.AbsolutePosition.x + line.Start.x,
                                                      graphicalExpression.ParentStaffLine.PositionAndShape.AbsolutePosition.y + line.Start.y);

--- a/src/MusicalScore/VoiceData/SourceMeasure.ts
+++ b/src/MusicalScore/VoiceData/SourceMeasure.ts
@@ -110,6 +110,10 @@ export class SourceMeasure {
     private rules: EngravingRules;
     private tempoInBPM: number;
     private verticalMeasureList: GraphicalMeasure[]; // useful, see GraphicalMusicSheet.GetGraphicalFromSourceStaffEntry
+    /** Whether this measure was drawn in the last render. Set by the drawer (and the incremental/lazy
+     *  render path) per drawn measure, reset to false at the start of each render(). Lets callers tell which
+     *  measures are currently on-screen, e.g. under a draw range or incremental rendering. */
+    public WasRendered: boolean = false;
 
     public get MeasureNumber(): number {
         return this.measureNumber;

--- a/src/OpenSheetMusicDisplay/Cursor.ts
+++ b/src/OpenSheetMusicDisplay/Cursor.ts
@@ -109,6 +109,13 @@ export class Cursor {
     let startMeasureIndex: number = this.rules.MinMeasureToDrawIndex;
     startMeasureIndex = Math.min(startMeasureIndex, lastSheetMeasureIndex);
     let endMeasureIndex: number = this.rules.MaxMeasureToDrawIndex;
+    if (this.rules.LazyConsistentGraphic) {
+      // Under lazy rendering MaxMeasureToDrawIndex is only the current (growing) frontier, not a fixed
+      //   draw range, so clamp the cursor to the whole sheet: it can step across the entire score and is
+      //   positioned lazily (update() no-ops where not yet rendered; a later batch repositions it once
+      //   that measure is drawn). Playback already seeks by timestamp and is unaffected by this range.
+      endMeasureIndex = lastSheetMeasureIndex;
+    }
     endMeasureIndex = Math.min(endMeasureIndex, lastSheetMeasureIndex);
 
     if (this.openSheetMusicDisplay.Sheet && this.openSheetMusicDisplay.Sheet.SourceMeasures.length > startMeasureIndex) {

--- a/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
+++ b/src/OpenSheetMusicDisplay/OpenSheetMusicDisplay.ts
@@ -21,6 +21,9 @@ import { AbstractExpression } from "../MusicalScore/VoiceData/Expressions/Abstra
 import { Dictionary } from "typescript-collections";
 import { AutoColorSet } from "../MusicalScore/Graphical/DrawingEnums";
 import { GraphicalMusicPage } from "../MusicalScore/Graphical/GraphicalMusicPage";
+import { MusicSystem } from "../MusicalScore/Graphical/MusicSystem";
+import { GraphicalMeasure } from "../MusicalScore/Graphical/GraphicalMeasure";
+import { SourceMeasure } from "../MusicalScore/VoiceData/SourceMeasure";
 import { MusicPartManagerIterator } from "../MusicalScore/MusicParts/MusicPartManagerIterator";
 import { ITransposeCalculator } from "../MusicalScore/Interfaces/ITransposeCalculator";
 import { NoteEnum } from "../Common/DataObjects/Pitch";
@@ -31,6 +34,44 @@ import { TemposCalculator } from "../MusicalScore/ScoreIO/MusicSymbolModules/Tem
  * It can display MusicXML sheet music files in an HTML element container.<br>
  * After the constructor, use load() and render() to load and render a MusicXML file.
  */
+/** Options for {@link OpenSheetMusicDisplay.renderNext} (incremental, "system by system" rendering). */
+export interface IRenderNextOptions {
+    /** Target number of visual measures to advance per batch (a multi-rest counts as ONE -- it renders as a
+     *  single GraphicalMeasure). Defaults to 8. This is a TARGET, not an exact count: a batch always ends on a
+     *  whole music-system (line) boundary, so the system the measure count lands inside is deferred to the next
+     *  batch (and a batch always renders at least one whole system). The measures actually drawn may therefore
+     *  be somewhat fewer or more than this -- e.g. 8 lands part-way into a system, so only the complete systems
+     *  before it are drawn; or if 8 doesn't fill one system, the layout extends until one whole system is ready.
+     *  To see what was actually rendered, read the returned {@link IRenderNextResult}: `renderedMeasures` (total
+     *  visual measures drawn so far, cumulative) and `lastRenderedMeasure` (the GraphicalMeasures at the last
+     *  drawn measure position). Ignored when `systems` is set (and applicable). */
+    measures?: number;
+    /** How many whole music systems (lines) to render in this batch, instead of advancing by `measures`.
+     *  Each batch then ends exactly on a system boundary. Takes precedence over `measures` when > 0.
+     *  VERTICAL ONLY: a single horizontal staffline (RenderSingleHorizontalStaffline) is one system, so
+     *  `systems` is ignored there and rendering falls back to `measures`. */
+    systems?: number;
+}
+
+/** Progress returned by {@link OpenSheetMusicDisplay.renderNext}. Measure counts are visual (a multi-rest
+ *  counts as one). */
+export interface IRenderNextResult {
+    /** True once the last measure of the sheet has been rendered -- no more batches remain. */
+    done: boolean;
+    /** Visual measures rendered so far, cumulative across batches. */
+    renderedMeasures: number;
+    /** Total visual measures in the sheet. */
+    totalMeasures: number;
+    /** The last measure position rendered so far (highest measure index): all its GraphicalMeasures, one per
+     *  staff/instrument (e.g. 3 for a voice + piano score). Empty if nothing has been rendered yet. They
+     *  share one source measure -- reach it and its number/index via any element's `.parentSourceMeasure` and
+     *  `.parentSourceMeasure.measureListIndex` (0-based). */
+    lastRenderedMeasure: GraphicalMeasure[];
+    /** The next measure position not yet rendered (the frontier): all its GraphicalMeasures (one per staff),
+     *  or empty once `done`. Same `.parentSourceMeasure` / `.parentSourceMeasure.measureListIndex` accessors. */
+    nextUnrenderedMeasure: GraphicalMeasure[];
+}
+
 export class OpenSheetMusicDisplay {
     protected version: string = "1.9.9-dev"; // getter: this.Version
     // at release, bump version and change to -release, afterwards to -dev again
@@ -225,11 +266,53 @@ export class OpenSheetMusicDisplay {
         }
     }
 
+    /** Lazy rendering (LazyConsistentGraphic): number of systems already drawn into the shared
+     *  backend across prior batches. Greedy layout is *usually* forward-stable, so the next batch skips
+     *  redrawing these and draws from this index -- but some scores re-position earlier systems as the
+     *  prefix grows, so each batch verifies the drawn systems against lazyDrawnSystemY and redraws from
+     *  the topmost one that moved (reconciliation). */
+    private lazyDrawnSystemCount: number = 0;
+    /** Lazy rendering: the absolute Y (in units) each already-drawn system [index] was drawn at,
+     *  used to detect when a later batch's full-prefix layout moves an earlier system (forward-stability
+     *  is not universal) so it can be redrawn at its corrected position. */
+    private lazyDrawnSystemY: number[] = [];
+    /** Lazy HORIZONTAL rendering (RenderSingleHorizontalStaffline): number of graphical measures already
+     *  drawn into the shared SVG (left-to-right). The next batch draws from here, deferring the prefix's
+     *  last measure (it carries an end-barline until it becomes interior), like the vertical path defers
+     *  its last system. */
+    private lazyDrawnHMeasureCount: number = 0;
+
+    /** Lazy HORIZONTAL: for a multi-staff score, lay the whole score out ONCE on the first batch and reuse that
+     *  final layout for every batch (only the drawn x-window grows). A growing partial re-layout would route
+     *  slurs/ties along each batch's boundary skyline and size the inter-staff gap to the prefix's max
+     *  clearance -- so lower stafflines would drift down batch to batch. A single horizontal staffline always
+     *  fits one SVG, so the full layout is safe; only the (expensive) DRAW stays lazy. Single-staff scores keep
+     *  the growing layout (lazy layout + draw; nothing below the top line to drift). */
+    private lazyHReuseLayout: boolean = false;
+
+    /** Incremental rendering ({@link renderNext}): whether a session is in progress (started, not yet reset). */
+    private lazyIncrementalActive: boolean = false;
+    /** Incremental rendering: source-measure index where the next batch continues (the drawn frontier). */
+    private lazyNextSourceIndex: number = 0;
+    /** Incremental rendering: the draw-measure range the lazy layout mutates, saved on begin and restored on
+     *  reset, so a later normal render() isn't left limited to the last batch's draw range. */
+    private lazySavedMinMeasureToDrawIndex: number = 0;
+    private lazySavedMaxMeasureToDrawIndex: number = 0;
+    /** Incremental rendering: the scroll listener + its target, while enableIncrementalRenderingOnScroll() is on. */
+    private lazyScrollHandler: (() => void) | undefined;
+    private lazyScrollTarget: HTMLElement | Window | undefined;
+
     /** Render the loaded music sheet to the container. */
     public render(): void {
         if (!this.graphic) {
             throw new Error("OSMD: load() needs to be called before render()");
         }
+        // A full render() supersedes any incremental render in progress: abandon it and restore the
+        // draw-measure range it mutated, so this render isn't limited to the last batch.
+        this.resetIncrementalRendering();
+        // A normal (non-lazy) render never uses the lazy reuse caches; force the gate off so a prior
+        // lazy session can't make them affect this render (they aren't cleared for normal renders).
+        this.rules.LazyConsistentGraphic = false;
         this.drawer?.clear(); // clear canvas before setting width
         // this.graphic.GetCalculator.clearSystemsAndMeasures(); // maybe?
         // this.graphic.GetCalculator.clearRecreatedObjects();
@@ -285,6 +368,10 @@ export class OpenSheetMusicDisplay {
         }
 
         this.drawer.setZoom(this.zoom);
+
+        for (const measure of this.sheet.SourceMeasures) {
+            measure.WasRendered = false;
+        }
         // Finally, draw
         this.drawer.drawSheet(this.graphic);
 
@@ -299,6 +386,583 @@ export class OpenSheetMusicDisplay {
         this.zoomUpdated = false;
         this.rules.RenderCount++;
         //console.log("[OSMD] render finished");
+    }
+
+    /** Internal range-based engine behind {@link renderNext} (the public incremental API). Lays out the
+     *  whole prefix [0..toMeasureIndex] and APPENDS the newly-stable source measures below previously
+     *  rendered batches, without clearing the container, so a large score renders "system by system".
+     *  clearFirst=true starts a fresh session (clears prior content, resets the counters). Returns the
+     *  source-measure index at which the next batch should continue. fromMeasureIndex is informational --
+     *  the drawn frontier is tracked internally. Targets the endless vertical-scroll format and
+     *  RenderSingleHorizontalStaffline. `targetNewSystems`, if set, draws that many whole systems this batch
+     *  (vertical path only; ignored for the single horizontal staffline, which is one system). */
+    private renderAppend(fromMeasureIndex: number, toMeasureIndex: number, clearFirst: boolean = false,
+                         targetNewSystems?: number): number {
+        if (!this.graphic) {
+            throw new Error("OSMD: load() needs to be called before renderNext()");
+        }
+        // Lazy rendering lays out the whole prefix [0..toMeasureIndex] into one growing, globally-consistent
+        // graphic and draws only the newly-stable systems (renderAppendGrowing). LazyConsistentGraphic gates
+        // that path's reuse caches; a normal render() forces it off so the caches never affect a non-lazy render.
+        this.rules.LazyConsistentGraphic = true;
+        if (this.rules.RenderSingleHorizontalStaffline) {
+            // Single horizontal staffline: one system growing to the RIGHT; draw only the newly-entered measures.
+            return this.renderAppendGrowingHorizontal(fromMeasureIndex, toMeasureIndex, clearFirst);
+        }
+        return this.renderAppendGrowing(fromMeasureIndex, toMeasureIndex, clearFirst, targetNewSystems);
+    }
+
+    /**
+     * Incrementally render the loaded sheet one batch at a time, appending each batch so a large score
+     * paints progressively ("system by system") instead of blocking on a full render(). The first call --
+     * or the first after load(), render() or resetIncrementalRendering() -- starts a fresh session: it
+     * clears the container and lays the score out from the first measure. Each later call appends the next
+     * batch. Returns progress; once `done` is true the whole sheet is rendered and further calls are no-ops.
+     *
+     * Pair with {@link enableIncrementalRenderingOnScroll} for scroll-to-load, or {@link renderRemaining}
+     * to finish synchronously (e.g. before PDF/image export). Works for the endless vertical-scroll page
+     * format and for RenderSingleHorizontalStaffline (one staffline scrolling right).
+     *
+     * @param options batch options; defaults to 8 visual measures (a multi-rest counts as one). Pass
+     *   `systems` instead to advance by whole music systems (vertical only); see {@link IRenderNextOptions}.
+     */
+    public renderNext(options?: IRenderNextOptions): IRenderNextResult {
+        if (!this.graphic) {
+            throw new Error("OSMD: load() needs to be called before renderNext()");
+        }
+        const batchMeasures: number = Math.max(1, options?.measures ?? 8);
+        // `systems` (vertical only) advances the frontier by whole music systems instead of measures. A single
+        // horizontal staffline is one system, so it ignores `systems` and uses `measures`.
+        const systemsOpt: number = options?.systems ?? 0;
+        const targetNewSystems: number = systemsOpt > 0 && !this.rules.RenderSingleHorizontalStaffline
+            ? Math.max(1, Math.floor(systemsOpt)) : undefined;
+        const lastSheetMeasureIndex: number = this.sheet.SourceMeasures.length - 1;
+        const totalMeasures: number = this.visualMeasureCount(0, this.sheet.SourceMeasures.length);
+
+        const begin: boolean = !this.lazyIncrementalActive;
+        if (begin) {
+            this.beginIncrementalRendering();
+        }
+        if (this.lazyNextSourceIndex > lastSheetMeasureIndex) {
+            return {
+                done: true, renderedMeasures: totalMeasures, totalMeasures,
+                lastRenderedMeasure: this.graphicalMeasuresAtOrBefore(lastSheetMeasureIndex), nextUnrenderedMeasure: []
+            };
+        }
+
+        const fromMeasureIndex: number = this.lazyNextSourceIndex;
+        // In systems mode, seed the layout at the current frontier and let renderAppendGrowing grow it to
+        // exactly `targetNewSystems` whole systems; otherwise advance the frontier by the visual-measure count.
+        const toMeasureIndex: number = targetNewSystems !== undefined
+            ? fromMeasureIndex
+            : this.visualBatchEndIndex(fromMeasureIndex, batchMeasures);
+        this.lazyNextSourceIndex = this.renderAppend(fromMeasureIndex, toMeasureIndex, begin, targetNewSystems);
+
+        const done: boolean = this.lazyNextSourceIndex > lastSheetMeasureIndex;
+        const renderedMeasures: number = done ? totalMeasures : this.visualMeasureCount(0, this.lazyNextSourceIndex);
+        return {
+            done, renderedMeasures, totalMeasures,
+            lastRenderedMeasure: this.graphicalMeasuresAtOrBefore(this.lazyNextSourceIndex - 1),
+            nextUnrenderedMeasure: done ? [] : this.graphicalMeasuresAtOrBefore(this.lazyNextSourceIndex)
+        };
+    }
+
+    /**
+     * Finish an in-progress incremental render synchronously: render all remaining measures at once. Useful
+     * before PDF/image export or printing, which need every system, not just the ones scrolled into view.
+     * No-op if no incremental render is in progress, or it is already complete.
+     */
+    public renderRemaining(): void {
+        if (!this.lazyIncrementalActive) {
+            return;
+        }
+        const total: number = this.sheet.SourceMeasures.length;
+        let guard: number = 0;
+        while (!this.IncrementalRenderingComplete && guard++ < total + 2) {
+            const before: number = this.lazyNextSourceIndex;
+            this.renderNext({ measures: total }); // one big batch -> final batch -> done
+            if (this.lazyNextSourceIndex <= before) {
+                break; // safety: no forward progress
+            }
+        }
+    }
+
+    /** Whether an incremental render ({@link renderNext}) is in progress (started and not yet reset). */
+    public get IncrementalRenderingActive(): boolean {
+        return this.lazyIncrementalActive;
+    }
+
+    /** Whether the in-progress incremental render has rendered the whole sheet (its last measure). */
+    public get IncrementalRenderingComplete(): boolean {
+        return this.lazyIncrementalActive && !!this.sheet && this.lazyNextSourceIndex > this.sheet.SourceMeasures.length - 1;
+    }
+
+    /** Current incremental-render progress as a snapshot (same shape {@link renderNext} returns), queryable
+     *  at any time -- e.g. for a progress bar, or to re-render the same extent after a resize. Reports zero
+     *  rendered measures when no session is active. */
+    public get IncrementalRenderProgress(): IRenderNextResult {
+        const totalMeasures: number = this.graphic ? this.visualMeasureCount(0, this.sheet.SourceMeasures.length) : 0;
+        const active: boolean = !!this.graphic && this.lazyIncrementalActive;
+        const done: boolean = this.IncrementalRenderingComplete;
+        const renderedMeasures: number = active
+            ? this.visualMeasureCount(0, Math.min(this.lazyNextSourceIndex, this.sheet.SourceMeasures.length)) : 0;
+        return {
+            done, renderedMeasures, totalMeasures,
+            lastRenderedMeasure: active && this.lazyNextSourceIndex > 0 ? this.graphicalMeasuresAtOrBefore(this.lazyNextSourceIndex - 1) : [],
+            nextUnrenderedMeasure: active && !done ? this.graphicalMeasuresAtOrBefore(this.lazyNextSourceIndex) : []
+        };
+    }
+
+    /** All GraphicalMeasures (one per staff/instrument) at the measure position for source-measure index
+     *  `sourceIndex`, walking BACK over collapsed multi-rest members (which have no graphical measure of their
+     *  own) to the nearest real measure. Empty if there is none at/before it. Used to resolve the last- /
+     *  next-measure handles for renderNext(). */
+    private graphicalMeasuresAtOrBefore(sourceIndex: number): GraphicalMeasure[] {
+        if (!this.graphic) {
+            return [];
+        }
+        const measureList: GraphicalMeasure[][] = this.graphic.MeasureList;
+        let li: number = Math.min(sourceIndex, measureList.length - 1);
+        while (li >= 0 && !(measureList[li] && measureList[li].some(measure => !!measure))) {
+            li--;
+        }
+        return li >= 0 ? measureList[li].filter(measure => !!measure) : [];
+    }
+
+    /**
+     * Abandon any in-progress incremental render and restore the draw-measure range it mutated, so a
+     * following normal render() draws the whole sheet again. Called
+     * automatically by render(), load() and clear(); call it directly only to cancel a session yourself.
+     */
+    public resetIncrementalRendering(): void {
+        if (!this.lazyIncrementalActive) {
+            return;
+        }
+        this.disableIncrementalRenderingOnScroll(); // drop the scroll listener with the session
+        this.lazyIncrementalActive = false;
+        this.lazyNextSourceIndex = 0;
+        this.lazyDrawnSystemCount = 0;
+        this.lazyDrawnSystemY = [];
+        this.lazyDrawnHMeasureCount = 0;
+        this.lazyHReuseLayout = false;
+        this.rules.MinMeasureToDrawIndex = this.lazySavedMinMeasureToDrawIndex;
+        this.rules.MaxMeasureToDrawIndex = this.lazySavedMaxMeasureToDrawIndex;
+    }
+
+    /**
+     * Drive {@link renderNext} automatically from scrolling: render the next batch whenever the user scrolls
+     * within ~1.5 viewports of the not-yet-rendered edge (the page bottom for the endless vertical format,
+     * the right edge for RenderSingleHorizontalStaffline). Renders the first batch immediately if none has
+     * been rendered yet, then keeps appending as the user scrolls, and detaches itself once the whole sheet
+     * is rendered. Re-enabling replaces any previous listener; reset/render/load also detach it.
+     *
+     * @param options batch size (as {@link renderNext}) plus an optional `scrollElement` -- the element whose
+     *  scrolling drives loading. Defaults to the OSMD container for a single horizontal staffline (it scrolls
+     *  horizontally) and to `window` otherwise (the page scrolls vertically).
+     */
+    public enableIncrementalRenderingOnScroll(options?: IRenderNextOptions & { scrollElement?: HTMLElement | Window }): void {
+        if (typeof window === "undefined") {
+            return; // no DOM (e.g. headless): nothing to attach to
+        }
+        this.disableIncrementalRenderingOnScroll(); // drop any previous listener
+        const horizontal: boolean = this.rules.RenderSingleHorizontalStaffline;
+        const target: HTMLElement | Window = options?.scrollElement ?? (horizontal ? this.container : window);
+        const batchOptions: IRenderNextOptions = { measures: options?.measures };
+        if (!this.IncrementalRenderingActive) {
+            this.renderNext(batchOptions); // paint the first batch so there is something to scroll
+        }
+        if (this.IncrementalRenderingComplete) {
+            return; // the whole sheet fit in the first batch; nothing to load on scroll
+        }
+        const nearEnd: () => boolean = () => {
+            const margin: number = 1.5; // start loading ~1.5 viewports before the edge
+            const el: HTMLElement = (target === window ? document.scrollingElement || document.documentElement : target) as HTMLElement;
+            if (horizontal) {
+                return el.scrollLeft + el.clientWidth >= el.scrollWidth - el.clientWidth * margin;
+            }
+            if (target === window) {
+                return window.scrollY + window.innerHeight >= document.body.scrollHeight - window.innerHeight * margin;
+            }
+            return el.scrollTop + el.clientHeight >= el.scrollHeight - el.clientHeight * margin;
+        };
+        let loading: boolean = false;
+        const onScroll: () => void = () => {
+            if (loading || !this.IncrementalRenderingActive || this.IncrementalRenderingComplete) {
+                return;
+            }
+            if (!nearEnd()) {
+                return;
+            }
+            loading = true;
+            const result: IRenderNextResult = this.renderNext(batchOptions);
+            loading = false;
+            if (result.done) {
+                this.disableIncrementalRenderingOnScroll();
+            } else if (typeof window.requestAnimationFrame === "function") {
+                window.requestAnimationFrame(onScroll); // keep filling while still near the edge
+            }
+        };
+        this.lazyScrollTarget = target;
+        this.lazyScrollHandler = onScroll;
+        target.addEventListener("scroll", onScroll, { passive: true });
+        if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(onScroll); // fill the viewport if the first batch was short
+        }
+    }
+
+    /** Stop driving {@link renderNext} from scrolling (see {@link enableIncrementalRenderingOnScroll}). */
+    public disableIncrementalRenderingOnScroll(): void {
+        if (this.lazyScrollHandler && this.lazyScrollTarget) {
+            this.lazyScrollTarget.removeEventListener("scroll", this.lazyScrollHandler);
+        }
+        this.lazyScrollHandler = undefined;
+        this.lazyScrollTarget = undefined;
+    }
+
+    /** Start a fresh incremental session: save the draw-measure range the lazy layout mutates (restored on
+     *  reset). Lazy needs the greedy, forward-stable builder so earlier systems keep their position as the
+     *  prefix grows -- public OSMD is greedy-only, so that is already in effect (nothing to force). */
+    private beginIncrementalRendering(): void {
+        this.lazySavedMinMeasureToDrawIndex = this.rules.MinMeasureToDrawIndex;
+        this.lazySavedMaxMeasureToDrawIndex = this.rules.MaxMeasureToDrawIndex;
+        this.lazyIncrementalActive = true;
+        this.lazyNextSourceIndex = 0;
+    }
+
+    /** Number of VISUAL measures in the source-measure range [from, toExcl): a multi-rest renders as one
+     *  GraphicalMeasure when RenderMultipleRestMeasures collapses it, so it counts as one. */
+    private visualMeasureCount(from: number, toExcl: number): number {
+        const sourceMeasures: SourceMeasure[] = this.sheet.SourceMeasures;
+        const collapse: boolean = this.rules.RenderMultipleRestMeasures;
+        let visual: number = 0;
+        let i: number = from;
+        while (i < toExcl && i < sourceMeasures.length) {
+            i += collapse && sourceMeasures[i].multipleRestMeasures > 0 ? sourceMeasures[i].multipleRestMeasures : 1;
+            visual++;
+        }
+        return visual;
+    }
+
+    /** Source-measure index (inclusive) at which a batch of `visualCount` visual measures starting at source
+     *  index `from` ends -- i.e. the toMeasureIndex to render this batch (multi-rests collapsed; see above). */
+    private visualBatchEndIndex(from: number, visualCount: number): number {
+        const sourceMeasures: SourceMeasure[] = this.sheet.SourceMeasures;
+        const collapse: boolean = this.rules.RenderMultipleRestMeasures;
+        let end: number = from;
+        let visual: number = 0;
+        while (visual < visualCount && end < sourceMeasures.length) {
+            end += collapse && sourceMeasures[end].multipleRestMeasures > 0 ? sourceMeasures[end].multipleRestMeasures : 1;
+            visual++;
+        }
+        return Math.min(end - 1, sourceMeasures.length - 1);
+    }
+
+    /**
+     * Lazy rendering (EngravingRules.LazyConsistentGraphic). Lays out the WHOLE prefix
+     * [0..toMeasureIndex] into ONE globally-consistent graphic and draws only the systems that became
+     * stable since the previous batch, appending them into the shared backend below what's already drawn.
+     *
+     * There is no per-batch vertical offset or seam-distance
+     * computation: the real Y-layout already stacks and crisp-snaps every system at its final absolute
+     * position, and the title space / first-system instrument names fall out of laying the prefix from
+     * measure 0 each time. The greedy builder is forward-stable -- every system except the LAST of a
+     * prefix is *usually* forward-stable (an interior system keeps its position as the prefix grows), so
+     * we skip drawing the already-drawn systems above and DEFER the last system of a non-final batch (it
+     * is unstretched and shifts once it becomes an interior, stretched system next batch). But this is NOT
+     * universal -- some scores re-position earlier systems by several px as later systems are added -- so
+     * each batch first VERIFIES the drawn systems against their drawn Y (lazyDrawnSystemY) and, if any
+     * moved, redraws the whole drawn range at the corrected positions (reconciliation). In the common
+     * (stable) case nothing is redrawn. See export/inspect_prefix_stability.mjs / inspect_optionb_drawpos.mjs.
+     *
+     * @returns the source-measure index at which the next batch should continue (past the last drawn system).
+     */
+    private renderAppendGrowing(fromMeasureIndex: number, toMeasureIndex: number, clearFirst: boolean,
+                                targetNewSystems?: number): number {
+        if (clearFirst) {
+            this.lazyDrawnSystemCount = 0;
+            this.lazyDrawnSystemY = [];
+            this.graphic.GetCalculator?.clearSkyBottomLineCache(); // fresh lazy session: drop reused sky/bottom lines
+        }
+        const lastSheetMeasureIndex: number = this.sheet.SourceMeasures.length - 1;
+
+        // Lay out the whole prefix [0..to] (Min stays 0). Earlier systems are re-laid-out identically;
+        // only the newly-completed systems are drawn below.
+        this.rules.MinMeasureToDrawIndex = 0;
+        this.rules.MaxMeasureToDrawIndex = Math.min(toMeasureIndex, lastSheetMeasureIndex);
+
+        const width: number = this.container.offsetWidth;
+        this.sheet.pageWidth = width / this.zoom / 10.0;
+        this.rules.PageHeight = 100001; // lazy assumes the endless (vertical scroll) page format
+
+        this.graphic.reCalculate();
+
+        // Ensure the prefix yields enough NEW systems to draw beyond the deferred last one (>= drawn +
+        // minNewSystems + 1 systems total); otherwise this batch only grew the current last system. Extend the
+        // prefix by a batch span and retry until enough systems appear or the sheet ends. minNewSystems is 1 in
+        // measures mode (the batch's other complete systems are drawn too) and `targetNewSystems` in systems mode.
+        let page: GraphicalMusicPage = this.graphic.MusicPages[0];
+        const minNewSystems: number = targetNewSystems ?? 1;
+        const extendStep: number = Math.max(4, toMeasureIndex - fromMeasureIndex + 1);
+        let extendedTo: number = this.rules.MaxMeasureToDrawIndex;
+        while (page && extendedTo < lastSheetMeasureIndex &&
+               page.MusicSystems.length < this.lazyDrawnSystemCount + minNewSystems + 1) {
+            extendedTo = Math.min(extendedTo + extendStep, lastSheetMeasureIndex);
+            this.rules.MaxMeasureToDrawIndex = extendedTo;
+            this.graphic.reCalculate();
+            page = this.graphic.MusicPages[0];
+        }
+        if (!page || page.MusicSystems.length === 0) {
+            return lastSheetMeasureIndex + 1; // produced nothing (e.g. all-invisible): nothing more to do
+        }
+
+        const systemCount: number = page.MusicSystems.length;
+        const finalBatch: boolean = extendedTo >= lastSheetMeasureIndex;
+        const sysAbsY: (i: number) => number = i => page.MusicSystems[i].StaffLines[0].PositionAndShape.AbsolutePosition.y;
+        // Reconciliation: forward-stability is not universal -- this batch's full-prefix layout may have
+        // moved an already-drawn system. If the topmost drawn system whose Y changed exists, everything
+        // already drawn is stale; clear the backend and redraw the whole drawn range at the corrected
+        // positions. In the common (stable) case nothing moved and we only append the new systems.
+        let someDrawnSystemMoved: boolean = false;
+        for (let i: number = 0; i < this.lazyDrawnSystemCount && i < systemCount; i++) {
+            if (Math.abs(sysAbsY(i) - (this.lazyDrawnSystemY[i] ?? sysAbsY(i))) > 1e-4) {
+                someDrawnSystemMoved = true;
+                break;
+            }
+        }
+        // Recreating the backend erases everything, so a recreate batch redraws from system 0.
+        const recreateBackend: boolean = clearFirst || someDrawnSystemMoved;
+        const drawFromIdx: number = recreateBackend ? 0 : this.lazyDrawnSystemCount;
+        // Hold the last (unstretched, not-yet-stable) system unless this is the final batch, where the last
+        // system is the sheet's true last system and never changes again. In systems mode, also cap the draw at
+        // `targetNewSystems` new systems (the layout may hold a few more from the last extend step), so each
+        // batch advances by exactly that many whole systems; any extra are re-laid-out and drawn next batch.
+        let drawToIdxExcl: number;
+        if (finalBatch) {
+            drawToIdxExcl = systemCount;
+        } else if (targetNewSystems !== undefined) {
+            drawToIdxExcl = Math.min(systemCount - 1, this.lazyDrawnSystemCount + targetNewSystems);
+        } else {
+            drawToIdxExcl = systemCount - 1;
+        }
+        if (drawToIdxExcl <= drawFromIdx) {
+            this.lazyDrawnSystemCount = Math.max(this.lazyDrawnSystemCount, drawToIdxExcl);
+            return lastSheetMeasureIndex + 1; // no new complete system (only happens at the very end)
+        }
+        const lastDrawnSystem: MusicSystem = page.MusicSystems[drawToIdxExcl - 1];
+
+        // createOrRefreshRenderBackend rebuilds the drawer (resetting the lazy draw window), so it must
+        // run BEFORE setting that window below. A purely-appending batch keeps the existing backend.
+        if (recreateBackend) {
+            this.createOrRefreshRenderBackend();
+        }
+        const backend: VexFlowBackend = this.drawer.Backends[0];
+        const isCanvas: boolean = backend.getOSMDBackendType() === BackendType.Canvas;
+        // Grow the backend to fit through the last system we draw. On the final batch, size exactly as
+        // createOrRefreshRenderBackend() does for a full page so the finished image height byte-matches a
+        // normal render; on continuation batches, size to the last drawn system (the deferred system's
+        // slot is filled next batch).
+        let heightUnits: number;
+        if (finalBatch) {
+            heightUnits = page.PositionAndShape.Size.height + this.rules.PageBottomMargin + page.PositionAndShape.BorderTop;
+        } else {
+            heightUnits = lastDrawnSystem.PositionAndShape.AbsolutePosition.y
+                + lastDrawnSystem.PositionAndShape.BorderBottom + this.rules.PageBottomMargin;
+        }
+        if (isCanvas) {
+            heightUnits += 0.1; // Canvas bug: cuts off the bottom pixel with PageBottomMargin = 0
+        }
+        if (this.rules.RenderTitle) {
+            heightUnits += this.rules.TitleTopDistance; // title sits above the first system
+        }
+        backend.graphicalMusicPage = page;
+        backend.resize(backend.width, heightUnits * 10 * this.zoom);
+        // Re-establish the default music color: createOrRefreshRenderBackend sets it on the first batch,
+        // but a reused canvas backend keeps stateful context and could inherit a stale fill/stroke color.
+        backend.getContext().setFillStyle(this.rules.DefaultColorMusic);
+        backend.getContext().setStrokeStyle(this.rules.DefaultColorMusic);
+        this.drawer.setZoom(this.zoom);
+
+        if (this.drawingParameters.drawCursors) {
+            this.graphic.Cursors.length = 0; // clear any stale graphical cursors before drawing, as render() does
+        }
+        // Mark everything up to the drawn range as on-screen (for playback/cursor lookups), since the
+        // graphic was rebuilt this batch.
+        for (let i: number = 0; i < drawToIdxExcl; i++) {
+            for (const staffLine of page.MusicSystems[i].StaffLines) {
+                for (const measure of staffLine.Measures) {
+                    if (measure?.parentSourceMeasure) { // some graphical measures (e.g. extra-instruction) have none
+                        measure.parentSourceMeasure.WasRendered = true;
+                    }
+                }
+            }
+        }
+        // Draw only the new systems (and the title block only on the first batch); see drawPage().
+        this.drawer.LazyDrawSystemsFromIndex = drawFromIdx;
+        this.drawer.LazyDrawSystemsToIndexExcl = drawToIdxExcl;
+        this.drawer.drawSheet(this.graphic);
+        this.drawer.LazyDrawSystemsFromIndex = -1;
+        this.drawer.LazyDrawSystemsToIndexExcl = Number.POSITIVE_INFINITY;
+
+        // Reposition the HTML cursors for this batch's growing / reconciled layout, mirroring render()'s
+        // post-draw cursor handling. When the backend was rebuilt this batch, re-create the cursors on it
+        // (enableOrDisableCursors restores their position via RestoreCursorAfterRerender); otherwise just
+        // update() them in place. update() no-ops if the cursor's target measure isn't laid out yet (the
+        // user hasn't scrolled there) -- a later batch repositions it once that measure is rendered.
+        if (this.drawingParameters.drawCursors) {
+            if (recreateBackend) {
+                this.enableOrDisableCursors(this.drawingParameters.drawCursors);
+            }
+            this.cursors.forEach(cursor => cursor.update());
+        }
+
+        // Record where each drawn system landed, so the next batch can detect (and reconcile) any that
+        // the growing layout moves.
+        for (let i: number = 0; i < drawToIdxExcl; i++) {
+            this.lazyDrawnSystemY[i] = sysAbsY(i);
+        }
+        this.lazyDrawnSystemY.length = drawToIdxExcl;
+        this.lazyDrawnSystemCount = drawToIdxExcl;
+        this.rules.RenderCount++;
+
+        if (finalBatch) {
+            return lastSheetMeasureIndex + 1;
+        }
+        // Continue at the deferred (held) system's first source measure.
+        const heldMeasures: GraphicalMeasure[] = page.MusicSystems[drawToIdxExcl].StaffLines[0].Measures;
+        return this.sheet.SourceMeasures.indexOf(heldMeasures[0].parentSourceMeasure);
+    }
+
+    /**
+     * Lazy rendering for RenderSingleHorizontalStaffline (one continuous staffline, horizontal scroll).
+     * Lays out the whole prefix [0..toMeasureIndex] as ONE system (greedy builder at SheetMaximumWidth so it
+     * never breaks) and draws only the measures (and spanning elements) whose right edge first entered the
+     * drawn frontier this batch -- the single SVG grows to the RIGHT (and taller if later measures are tall).
+     * Measure X and Y are forward-stable here, so unlike the vertical path there is no reconciliation and no
+     * deferred last unit: every batch simply appends. SVG backend only (Canvas keeps its existing width cap).
+     * @returns the source-measure index at which the next batch should continue.
+     */
+    private renderAppendGrowingHorizontal(fromMeasureIndex: number, toMeasureIndex: number, clearFirst: boolean): number {
+        if (clearFirst) {
+            this.lazyDrawnHMeasureCount = 0;
+            this.graphic.GetCalculator?.clearSkyBottomLineCache();
+            // Multi-staff: lay the whole score out once and reuse that final layout (see lazyHReuseLayout);
+            // single-staff: grow the laid-out prefix each batch.
+            this.lazyHReuseLayout = this.sheet.getCompleteNumberOfStaves() > 1;
+        }
+        const lastSheetMeasureIndex: number = this.sheet.SourceMeasures.length - 1;
+        // One horizontal staffline: SheetMaximumWidth keeps it a single system; the cursor coordinate region
+        // still uses the real container width (mirrors render()).
+        this.rules.MinMeasureToDrawIndex = 0;
+        this.sheet.pageWidth = this.rules.SheetMaximumWidth / this.zoom / 10.0;
+        this.rules.PageHeight = 100001;
+        if (this.lazyHReuseLayout) {
+            // Lay the whole score out once on the first batch; later batches reuse it (only the drawn x-window
+            // grows). This keeps every element at its final, full-score position, so multi-staff batches are
+            // byte-identical to a normal render.
+            if (clearFirst) {
+                this.rules.MaxMeasureToDrawIndex = lastSheetMeasureIndex;
+                this.graphic.reCalculate();
+            }
+        } else {
+            this.rules.MaxMeasureToDrawIndex = Math.min(toMeasureIndex, lastSheetMeasureIndex);
+            this.graphic.reCalculate();
+        }
+        const page: GraphicalMusicPage = this.graphic.MusicPages[0];
+        if (!page || page.MusicSystems.length === 0 || page.MusicSystems[0].StaffLines.length === 0) {
+            return lastSheetMeasureIndex + 1; // produced nothing (e.g. all invisible)
+        }
+        const system: MusicSystem = page.MusicSystems[0];
+        const measures0: GraphicalMeasure[] = system.StaffLines[0].Measures;
+        const drawFromIdx: number = Math.min(this.lazyDrawnHMeasureCount, measures0.length);
+        let finalBatch: boolean;
+        let drawToIdxExcl: number;
+        if (this.lazyHReuseLayout) {
+            // Reused full layout -- every measure is already final, so draw up to the requested source frontier
+            // with no deferral (no growing-prefix end-barline to hold). Find the graphical measures whose source
+            // measure is at/before the frontier (mapping handles multi-rests that collapse several into one).
+            const frontierSource: number = Math.min(toMeasureIndex, lastSheetMeasureIndex);
+            finalBatch = frontierSource >= lastSheetMeasureIndex;
+            let f: number = drawFromIdx;
+            while (f < measures0.length && measures0[f].parentSourceMeasure.measureListIndex <= frontierSource) {
+                f++;
+            }
+            drawToIdxExcl = f;
+        } else {
+            // Growing prefix -- HOLD the prefix's last measure: as the prefix end it carries an end-barline and
+            // is unstretched, and becomes a normal interior measure (drawn) next batch (the horizontal analog of
+            // the vertical path deferring its last system).
+            finalBatch = this.rules.MaxMeasureToDrawIndex >= lastSheetMeasureIndex;
+            drawToIdxExcl = finalBatch ? measures0.length : measures0.length - 1;
+        }
+        if (drawToIdxExcl <= drawFromIdx) {
+            // No new complete measure this batch; continue at the next undrawn measure (or finish).
+            return finalBatch ? lastSheetMeasureIndex + 1
+                : this.sheet.SourceMeasures.indexOf(measures0[drawFromIdx].parentSourceMeasure);
+        }
+        const measureRightX: (m: GraphicalMeasure) => number =
+            m => m.PositionAndShape.AbsolutePosition.x + m.PositionAndShape.BorderRight;
+        // x-window: only objects whose right edge is in (fromX, toX] -- the measures that newly completed
+        // this batch plus any spanning element (slur, ...) whose right end just became available.
+        const fromX: number = drawFromIdx > 0 ? measureRightX(measures0[drawFromIdx - 1]) : Number.NEGATIVE_INFINITY;
+        const toX: number = measureRightX(measures0[drawToIdxExcl - 1]);
+
+        if (clearFirst) {
+            this.createOrRefreshRenderBackend(); // one persistent backend, sized to the first batch's page
+        }
+        const backend: VexFlowBackend = this.drawer.Backends[0];
+        // Grow the single backend to fit what's drawn so far: width to the drawn frontier (so the SVG/scroll
+        // width tracks drawn content even when the whole score is laid out in reuse mode), height to the full
+        // page (later measures may have taller content). The staff origin is forward-stable, so already-drawn
+        // content stays put.
+        const widthUnits: number = this.lazyHReuseLayout
+            ? toX + this.rules.PageRightMargin
+            : this.rules.PageLeftMargin + page.PositionAndShape.Size.width + this.rules.PageRightMargin;
+        let heightUnits: number = page.PositionAndShape.Size.height + this.rules.PageBottomMargin + page.PositionAndShape.BorderTop;
+        if (this.rules.RenderTitle) {
+            heightUnits += this.rules.TitleTopDistance;
+        }
+        backend.graphicalMusicPage = page;
+        backend.resize(widthUnits * 10 * this.zoom, heightUnits * 10 * this.zoom);
+        backend.getContext().setFillStyle(this.rules.DefaultColorMusic);
+        backend.getContext().setStrokeStyle(this.rules.DefaultColorMusic);
+        this.drawer.setZoom(this.zoom);
+
+        if (this.drawingParameters.drawCursors) {
+            this.graphic.Cursors.length = 0;
+        }
+        // Mark the measures drawn so far on-screen (playback / cursor lookups), since the graphic was rebuilt.
+        for (let i: number = 0; i < drawToIdxExcl; i++) {
+            for (const staffLine of system.StaffLines) {
+                const m: GraphicalMeasure = staffLine.Measures[i];
+                if (m?.parentSourceMeasure) {
+                    m.parentSourceMeasure.WasRendered = true;
+                }
+            }
+        }
+        // Each batch draws the measures (and once-only left-edge brackets/labels) up to its frontier. The
+        // page labels (title/credits) re-center as the page widens, so they are drawn only on the final batch,
+        // at their full-width positions; drawPage() then opens the x-window so none are dropped (see drawPage).
+        this.drawer.LazyDrawFromXUnits = fromX;
+        this.drawer.LazyDrawToXUnits = toX + 1e-4;
+        this.drawer.LazySkipPageLabels = !finalBatch;
+        this.drawer.drawSheet(this.graphic);
+        this.drawer.LazyDrawFromXUnits = Number.NEGATIVE_INFINITY;
+        this.drawer.LazyDrawToXUnits = Number.POSITIVE_INFINITY;
+        this.drawer.LazySkipPageLabels = false;
+
+        if (this.drawingParameters.drawCursors) {
+            if (clearFirst) {
+                this.enableOrDisableCursors(this.drawingParameters.drawCursors);
+            }
+            this.cursors.forEach(cursor => cursor.update());
+        }
+        this.lazyDrawnHMeasureCount = drawToIdxExcl;
+        this.rules.RenderCount++;
+        if (finalBatch) {
+            return lastSheetMeasureIndex + 1;
+        }
+        // Continue at the held (deferred) last measure.
+        return this.sheet.SourceMeasures.indexOf(measures0[drawToIdxExcl].parentSourceMeasure);
     }
 
     protected createOrRefreshRenderBackend(): void {
@@ -764,6 +1428,7 @@ export class OpenSheetMusicDisplay {
      * FIXME: Probably unnecessary
      */
     protected reset(): void {
+        this.resetIncrementalRendering(); // abandon any incremental session + restore the rules it mutated
         if (this.drawingParameters.drawCursors) {
             this.cursors.forEach(cursor => {
                 cursor.hide();
@@ -924,7 +1589,7 @@ export class OpenSheetMusicDisplay {
         }
     }
 
-    public createBackend(type: BackendType, page: GraphicalMusicPage): VexFlowBackend {
+    public createBackend(type: BackendType, page: GraphicalMusicPage, idOverride?: string): VexFlowBackend {
         let backend: VexFlowBackend;
         if (type === undefined || type === BackendType.SVG) {
             backend = new SvgVexFlowBackend(this.rules);
@@ -932,7 +1597,7 @@ export class OpenSheetMusicDisplay {
             backend = new CanvasVexFlowBackend(this.rules);
         }
         backend.graphicalMusicPage = page; // the page the backend renders on. needed to identify DOM element to extract image/SVG
-        backend.initialize(this.container, this.zoom);
+        backend.initialize(this.container, this.zoom, idOverride);
         //backend.getContext().setFillStyle(this.rules.DefaultColorMusic);
         //backend.getContext().setStrokeStyle(this.rules.DefaultColorMusic);
         // color needs to be set after resize() for CanvasBackend


### PR DESCRIPTION
Closes #1604, #1554

Render large scores progressively instead of blocking on one full render(), for faster first paint.

E.g. here, after osmd.load(), we only render the first 2 systems ("lines") of the somewhat long Bach Prelude in C major:
<img width="721" height="406" alt="image" src="https://github.com/user-attachments/assets/3c478e23-048b-4dfa-9b48-bc33c262d7ce" />
```js
osmd.load(bachXml).then( () => {
  osmd.renderNext({systems: 2});
} );
```
We could then call `osmd.renderNext({systems: 2});` again to render the next 2 systems.

In our demo, you can try this interactively by enabling lazy/incremental rendering in the UI and loading a large score like Gounod - Meditation or the Bach Prelude. When you scroll down, OSMD will automatically render more (powered by `osmd.enableIncrementalRenderingOnScroll()`).

Works for the endless vertical-scroll page format and for `RenderSingleHorizontalStaffline` (one staffline growing to the right).
Usually you specify the next x `measures` to draw, which will snap to full systems (so it may not be exactly x measures added).
The `systems` option allows you to render the next x systems ("lines"), so you don't need to count and estimate how many measures you need to draw to add vertical height (a new system).
And you should be able to estimate the added height by getting the height of the first music system.
(The `systems` option of course doesn't work for the `RenderSingleHorizontalStaffline` option, as that only has one system)

Public API (OpenSheetMusicDisplay):
- renderNext(options?: { measures?: number, systems?: number }): IRenderNextResult -- render and append the next batch. By default it advances ~8 visual measures (a multi-rest counts as one); pass `systems` to advance by whole music systems (lines) instead, ending each batch exactly on a system boundary (#1604). `systems` is vertical only -- a single horizontal staffline is one system, so it ignores `systems` and uses `measures`. The first call auto-starts a fresh session (clears, lays out from measure 0); later calls append. Returns progress { done, renderedMeasures, totalMeasures, lastRenderedMeasure, nextUnrenderedMeasure } where the measure handles are the GraphicalMeasure[] across all staves at that position.
- renderRemaining() -- finish rendering the score synchronously (e.g. before PDF/image export).
- resetIncrementalRendering() -- abandon a session; auto-called by render()/reset().
- IncrementalRenderingActive / IncrementalRenderingComplete / IncrementalRenderProgress.
- enableIncrementalRenderingOnScroll(options? & { scrollElement? }) / disableIncrementalRenderingOnScroll() -- passive scroll-to-load near the edge (page bottom for vertical, right edge for single-horizontal), rAF fill, and auto-detach on completion.

How it works:
- Vertical (renderAppendGrowing): re-lays the whole prefix each batch (the greedy builder is forward-stable), draws only the new systems, defers the prefix's last (unstretched) system, and reconciles if a growing layout moves an earlier system.
- Horizontal (renderAppendGrowingHorizontal): single growing system at SheetMaximumWidth; single-staff grows the laid-out prefix, multi-staff lays the whole score out once and reuses it (only the drawn x-window grows) so lower stafflines never drift.
- Skyline reuse cache (gated by EngravingRules.LazyConsistentGraphic) reuses stable interior systems' sky/bottom lines across batches, turning the per-batch O(prefix) skyline pass into O(new systems). Off for a normal render().
- Drawer x-window / system-index gates draw each element exactly once; inert at their +/-Infinity / -1 defaults, so a normal render() is unaffected.
- Canvas backend snapshots and redraws its bitmap on resize (a canvas resize clears it); the SVG backend grows in place.

All gates and caches are gated behind LazyConsistentGraphic (forced false by render()) or are no-ops at their defaults, so normal rendering is unchanged. Demo: an "Incremental rendering (load on scroll)" toggle plus a renderRemaining() guard before PDF export.

Verified renderNext() output multiset-identical to a normal render() on Bach / Gounod / Actor, both vertical and single-horizontal.