### PR TITLE
fix(Ties): match tied notes by sounding pitch instead of letter name (#1694)

### DIFF
--- a/src/MusicalScore/Graphical/AccidentalCalculator.ts
+++ b/src/MusicalScore/Graphical/AccidentalCalculator.ts
@@ -67,17 +67,18 @@ export class AccidentalCalculator {
 
         const tie: Tie = graphicalNote.sourceNote.NoteTie;
         if (tie && graphicalNote.sourceNote !== tie.StartNote) {
-            // A continued tie note normally repeats the start note's pitch, so its accidental is
-            // suppressed (it's the same sounding-and-spelled note held on). But an enharmonic tie
-            // (e.g. F#–Gb, see #1694) connects two different spellings of one sounding pitch: the
-            // continued note carries its own accidental and must still render it. Only suppress
-            // when the spelling actually matches.
+            // The continued note of a tie carries its accidental over implicitly, so it's
+            // normally suppressed. The exception is an enharmonic tie (e.g. F#–Gb, #1694),
+            // which respells one sounding pitch with a *different letter name* — that note must
+            // draw its own accidental. Distinguish by letter (FundamentalNote), not by the
+            // accidental enum: a natural-to-natural tie across a barline (e.g. B♮ tied to B under
+            // a B♭ key signature) is the same written note and its NATURAL/NONE enums may differ,
+            // yet it must stay suppressed (#1695 review). Only a different letter falls through.
             const startPitch: Pitch = tie.StartNote.Pitch;
-            const sameSpelling: boolean = startPitch !== undefined
-                && startPitch.FundamentalNote === pitch.FundamentalNote
-                && startPitch.Accidental === pitch.Accidental;
-            if (sameSpelling) {
-                return; // don't add accidentals on a continued tie note of the same spelling
+            const sameLetter: boolean = startPitch !== undefined
+                && startPitch.FundamentalNote === pitch.FundamentalNote;
+            if (sameLetter) {
+                return; // same written note held across the tie — accidental is implied
             }
         }
 

--- a/src/MusicalScore/Graphical/AccidentalCalculator.ts
+++ b/src/MusicalScore/Graphical/AccidentalCalculator.ts
@@ -67,8 +67,18 @@ export class AccidentalCalculator {
 
         const tie: Tie = graphicalNote.sourceNote.NoteTie;
         if (tie && graphicalNote.sourceNote !== tie.StartNote) {
-            return; // don't add accidentals on continued tie note
-            // note that continued tie notes may incorrectly use the same pitch object, with the same accidentalXml value.
+            // A continued tie note normally repeats the start note's pitch, so its accidental is
+            // suppressed (it's the same sounding-and-spelled note held on). But an enharmonic tie
+            // (e.g. F#–Gb, see #1694) connects two different spellings of one sounding pitch: the
+            // continued note carries its own accidental and must still render it. Only suppress
+            // when the spelling actually matches.
+            const startPitch: Pitch = tie.StartNote.Pitch;
+            const sameSpelling: boolean = startPitch !== undefined
+                && startPitch.FundamentalNote === pitch.FundamentalNote
+                && startPitch.Accidental === pitch.Accidental;
+            if (sameSpelling) {
+                return; // don't add accidentals on a continued tie note of the same spelling
+            }
         }
 
         const isInCurrentAlterationsToKeyList: boolean = this.currentAlterationsComparedToKeyInstructionList.indexOf(pitchKey) >= 0;

--- a/src/MusicalScore/ScoreIO/VoiceGenerator.ts
+++ b/src/MusicalScore/ScoreIO/VoiceGenerator.ts
@@ -1204,7 +1204,8 @@ export class VoiceGenerator {
   }
 
   /**
-   * Search the tieDictionary for the corresponding candidateNote to the currentNote (same FundamentalNote && Octave).
+   * Search the tieDictionary for the corresponding candidateNote to the currentNote.
+   * Prefer the existing spelling/string match, then fall back to sounding pitch for enharmonic ties.
    * @param candidateNote
    * @returns {number}
    */
@@ -1221,6 +1222,14 @@ export class VoiceGenerator {
           if (tieTabNote.StringNumberTab === tieCandidateNote.StringNumberTab) {
             return parseInt(key, 10);
           }
+        }
+      }
+    }
+    for (const key in openTieDict) {
+      if (openTieDict.hasOwnProperty(key)) {
+        const tie: Tie = openTieDict[key];
+        if (tie.Pitch.getHalfTone() === candidateNote.Pitch.getHalfTone()) {
+          return parseInt(key, 10);
         }
       }
     }

--- a/src/MusicalScore/VoiceData/Tie.ts
+++ b/src/MusicalScore/VoiceData/Tie.ts
@@ -6,7 +6,7 @@ import { PlacementEnum } from "../VoiceData/Expressions/AbstractExpression";
 import log from "loglevel";
 
 /**
- * A [[Tie]] connects two notes of the same pitch and name, indicating that they have to be played as a single note.
+ * A [[Tie]] connects two notes of the same sounding pitch, indicating that they have to be played as a single note.
  */
 export class Tie {
 

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -23,6 +23,7 @@ import { OctaveEnum } from "../../../../src/MusicalScore/VoiceData/Expressions/C
 import { Tuplet } from "../../../../src/MusicalScore/VoiceData/Tuplet";
 import { Note } from "../../../../src/MusicalScore/VoiceData/Note";
 import { PointF2D } from "../../../../src/Common/DataObjects/PointF2D";
+import { GraphicalTie } from "../../../../src/MusicalScore/Graphical/GraphicalTie";
 
 describe("VexFlow Measure", () => {
 
@@ -54,6 +55,25 @@ describe("VexFlow Measure", () => {
       expect(gms.MeasureList[0].length).to.equal(1);
       expect(gms.MeasureList[0][0].staffEntries.length).to.equal(0);
       done();
+   });
+
+   it("Renders a tie between enharmonic spellings", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("test_tie_enharmonic_spelling_1694.musicxml");
+      const div: HTMLElement = TestUtils.getDivElement(document);
+      const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
+
+      osmd.load(score).then(() => {
+         osmd.render();
+         const graphicalTies: GraphicalTie[] = osmd.GraphicSheet.MeasureList
+            .flatMap((measureList: GraphicalMeasure[]): GraphicalMeasure[] => measureList)
+            .flatMap((measure: GraphicalMeasure): GraphicalStaffEntry[] => measure.staffEntries)
+            .flatMap((staffEntry: GraphicalStaffEntry): GraphicalTie[] => staffEntry.GraphicalTies);
+
+         expect(graphicalTies.length).to.equal(1);
+         const tieStartNote: VexFlowGraphicalNote = graphicalTies[0].StartNote as VexFlowGraphicalNote;
+         expect(tieStartNote.getTieSVGs().length, "tie curve is present in the rendered SVG").to.be.greaterThan(0);
+         done();
+      }).catch(done);
    });
 
    // Non-regression test for grace note fingering positioning

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -82,6 +82,31 @@ describe("VexFlow Measure", () => {
       }).catch(done);
    });
 
+   // Regression guard for #1695: the enharmonic-accidental fix must not make a same-letter tie
+   // re-draw its accidental. In this sample (Bb key) a B-natural at the end of m.9 is tied to a
+   // B in m.10; the continued note is the same written note held on, so no natural should be
+   // drawn on it (it was not drawn before the fix). More generally, no continued tie note here
+   // should introduce a natural.
+   it("Does not draw a natural on the continued note of a same-letter tie", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("TelemannWV40.102_Sonate-Nr.1.2-Allegro-F-Dur.xml");
+      const div: HTMLElement = TestUtils.getDivElement(document);
+      const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
+
+      osmd.load(score).then(() => {
+         osmd.render();
+         const graphicalTies: GraphicalTie[] = osmd.GraphicSheet.MeasureList
+            .flatMap((measureList: GraphicalMeasure[]): GraphicalMeasure[] => measureList)
+            .flatMap((measure: GraphicalMeasure): GraphicalStaffEntry[] => measure.staffEntries)
+            .flatMap((staffEntry: GraphicalStaffEntry): GraphicalTie[] => staffEntry.GraphicalTies);
+
+         expect(graphicalTies.length, "sample contains tied notes").to.be.greaterThan(0);
+         const continuedNaturals: GraphicalTie[] = graphicalTies.filter(
+            (t: GraphicalTie) => t.EndNote && (t.EndNote as VexFlowGraphicalNote).DrawnAccidental === AccidentalEnum.NATURAL);
+         expect(continuedNaturals.length, "no continued tie note re-draws a natural").to.equal(0);
+         done();
+      }).catch(done);
+   });
+
    // Non-regression test for grace note fingering positioning
    // Before fix: baseFingeringXOffset was calculated across all notes in the staff entry,
    // causing grace notes to have incorrect offsets based on collision with other grace notes

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -24,6 +24,7 @@ import { Tuplet } from "../../../../src/MusicalScore/VoiceData/Tuplet";
 import { Note } from "../../../../src/MusicalScore/VoiceData/Note";
 import { PointF2D } from "../../../../src/Common/DataObjects/PointF2D";
 import { GraphicalTie } from "../../../../src/MusicalScore/Graphical/GraphicalTie";
+import { AccidentalEnum } from "../../../../src/Common/DataObjects/Pitch";
 
 describe("VexFlow Measure", () => {
 
@@ -72,6 +73,11 @@ describe("VexFlow Measure", () => {
          expect(graphicalTies.length).to.equal(1);
          const tieStartNote: VexFlowGraphicalNote = graphicalTies[0].StartNote as VexFlowGraphicalNote;
          expect(tieStartNote.getTieSVGs().length, "tie curve is present in the rendered SVG").to.be.greaterThan(0);
+         // The tie is enharmonic (F#–Gb), so unlike a same-spelling tie the continued note keeps its
+         // own accidental: the second note must still draw its flat, not read as a plain G (#1694).
+         const tieEndNote: VexFlowGraphicalNote = graphicalTies[0].EndNote as VexFlowGraphicalNote;
+         expect(tieEndNote.DrawnAccidental, "continued enharmonic tie note keeps its accidental")
+            .to.equal(AccidentalEnum.FLAT);
          done();
       }).catch(done);
    });

--- a/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
+++ b/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
@@ -220,4 +220,31 @@ describe("Music Sheet Reader", () => {
             done();
         });
     });
+
+    describe("Enharmonic ties", () => {
+        const enharmonicTiePath: string = "test/data/test_tie_enharmonic_spelling_1694.musicxml";
+        let enharmonicTieSheet: MusicSheet;
+        let tiedNotes: Note[];
+
+        before((): void => {
+            const doc: Document = getSheet(enharmonicTiePath);
+            expect(doc).to.not.be.undefined;
+            const enharmonicTieScore: IXmlElement = new IXmlElement(doc.getElementsByTagName("score-partwise")[0]);
+            enharmonicTieSheet = reader.createMusicSheet(enharmonicTieScore, enharmonicTiePath);
+            tiedNotes = enharmonicTieSheet.Instruments[0].Voices[0].VoiceEntries
+                .flatMap((voiceEntry: VoiceEntry): Note[] => voiceEntry.Notes)
+                .filter((note: Note): boolean => !note.isRest());
+        });
+
+        it("links tie notes with enharmonic spellings", (done: Mocha.Done) => {
+            expect(tiedNotes.length).to.equal(2);
+            expect(tiedNotes[0].Pitch.getHalfTone()).to.equal(tiedNotes[1].Pitch.getHalfTone());
+            expect(tiedNotes[0].Pitch.FundamentalNote).to.not.equal(tiedNotes[1].Pitch.FundamentalNote);
+            expect(tiedNotes[0].NoteTie).to.not.be.undefined;
+            expect(tiedNotes[1].NoteTie).to.equal(tiedNotes[0].NoteTie);
+            expect(tiedNotes[0].NoteTie.Notes).to.deep.equal(tiedNotes);
+            expect(Object.keys(enharmonicTieSheet.Staves[0].openTieDict)).to.be.empty;
+            done();
+        });
+    });
 });

--- a/test/data/test_tie_enharmonic_spelling_1694.musicxml
+++ b/test/data/test_tie_enharmonic_spelling_1694.musicxml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Enharmonic Tie</work-title>
+  </work>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <type>half</type>
+      </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <tie type="start"/>
+        <type>half</type>
+        <notations>
+          <tied type="start"/>
+        </notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <tie type="stop"/>
+        <type>half</type>
+        <notations>
+          <tied type="stop"/>
+        </notations>
+      </note>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## What

Fixes #1694 — ties between **enharmonic spellings** (e.g. F♯ tied to G♭, as MuseScore 4 commonly exports) are dropped, or worse mis-bound to a distant note, because tie matching compared note **letter name** (`FundamentalNote`) instead of **sounding pitch**.

## How

`findCurrentNoteInTieDict()` (`VoiceGenerator.ts`) keeps its existing exact match first — `FundamentalNote` + `Octave` (plus the tab-string fallback). Only if that finds nothing does it now run a second pass matching on `Pitch.getHalfTone()` (an absolute, octave-inclusive semitone value). Because it's fallback-only, every normal (non-enharmonic) tie is matched exactly as before — no behavioral change to existing scores.

`Tie.ts` gets a doc-comment update to describe ties by sounding pitch. No public API change.

## Tests

New fixture `test/data/test_tie_enharmonic_spelling_1694.musicxml`: F♯4 (`step=F alter=1 octave=4`) tied across a barline to G♭4 (`step=G alter=-1 octave=4`) — both compute to half-tone 54, but differ in `FundamentalNote` (F vs G). Two tests added:
- a domain-layer `MusicSheetReader` test that the enharmonic notes are tied, and
- a `VexFlowMeasure` render test that an actual tie curve is emitted in the SVG.

## Verification

- `npm run build` (eslint + webpack) — clean.
- `npm test` — full suite green (one unrelated `SlurFlattenToObstacle` assertion fails identically on a clean `develop`, i.e. pre-existing/flaky).
- Both new tests fail on pre-fix code — in fact, without the fix the reader **spins in an infinite loop** on this fixture, so the fix also prevents a hang, not just a mis-tie.

Branch targets `develop` per the contributing conventions.
