### PR TITLE
fix: don't crash on unterminated octave-shift (Fraction.lte on undefined endTimeStamp)

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1290,7 +1290,9 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         startStaffEntry = startMeasure.staffEntries[0];
       }
       let endStaffEntry: GraphicalStaffEntry = endMeasure.findGraphicalStaffEntryFromTimestamp(endTimeStamp);
-      if (!endStaffEntry) {
+      if (!endStaffEntry && endTimeStamp) {
+        // endTimeStamp can be undefined for an unterminated octave-shift (start without stop,
+        //   e.g. from OMR-generated MusicXML), see #1439 / #1376 for similar cases.
         // No exact match (e.g. pending stop with computed inclusive end).
         // Find the latest staff entry at or before the end timestamp.
         for (let i: number = endMeasure.staffEntries.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Problem

`osmd.render()` throws `TypeError: Cannot read properties of undefined (reading 'realValue')` and aborts rendering the whole sheet when the MusicXML contains an **octave-shift start without a matching stop**. Such files are produced in the wild by OMR tools (e.g. Audiveris exports `<octave-shift type="down">` and never closes it).

```
TypeError: Cannot read properties of undefined (reading 'realValue')
    at Fraction.lte
    at VexFlowMusicSheetCalculator.calculateSingleOctaveShift
    at MusicSheetCalculator.calculateOctaveShifts
    at MusicSheetCalculator.calculateMusicSystems
```

Minimal trigger inside any part (never followed by a `stop`):

```xml
<direction placement="above">
  <direction-type>
    <octave-shift type="down" number="1" size="8"/>
  </direction-type>
</direction>
```

## Cause

For an unterminated shift, `octaveShift.ParentEndMultiExpression` is undefined, so `endTimeStamp` is undefined. The code already clamps `endMeasure` to the last rendered measure for this case, but the "latest staff entry at or before the end timestamp" fallback loop then calls `entry.relInMeasureTimestamp?.lte(endTimeStamp)` — and `Fraction.lte` dereferences its argument unconditionally (unlike `Fraction.Equals`, which is null-safe).

## Fix

Guard the fallback search loop on `endTimeStamp`. When it is undefined the loop is skipped and the existing `endMeasure.staffEntries[last]` fallback right below handles the unterminated case, so the shift is drawn up to the last rendered measure instead of crashing.

See also earlier octave-shift robustness work in #1439 and #1376.

## Verification

- Reproduced with a 13-page Audiveris-exported score (2 unterminated `type="down"` shifts): crash on 2.0.0 → renders fine with this patch (headless jsdom + browser).
- Removing the two unterminated octave-shift elements from the same file also renders fine on unpatched 2.0.0, confirming the trigger.
- `npm run lint` passes; webpack build succeeds.

