### PR TITLE
fix(layout): align voices when a note's type and dots disagree with its duration

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -1424,15 +1424,26 @@ export class VexFlowMeasure extends GraphicalMeasure {
                 // different voices use different normal-type values in their tuplets, the calculated
                 // ticks can differ even for notes at the same timestamp. We use graphicalNoteLength
                 // (which represents the actual musical duration) to calculate correct tick values.
+                // The same correction is applied when the XML <type> (+<dot>s) disagrees with the
+                // actual <duration> (e.g. an invisible rest with type half + dot, but a duration of
+                // only 2.5 quarters): otherwise the vexflow tick counting of the voice goes out of
+                // sync and all following notes of the voice are misaligned with the other voices.
                 if (voiceEntry.notes.length > 0 && voiceEntry.notes[0].sourceNote) {
                     const sourceNote: Note = voiceEntry.notes[0].sourceNote;
-                    if (sourceNote.NoteTuplet) {
-                        const graphicalLength: Fraction = voiceEntry.notes[0].graphicalNoteLength;
+                    const graphicalLength: Fraction = voiceEntry.notes[0].graphicalNoteLength;
+                    const vfTicks: VF.Fraction = vexFlowVoiceEntry.vfStaveNote.getTicks();
+                    // whole measure rests keep their vexflow "w" ticks: nothing follows them
+                    //   in the voice, and correcting them would change spacing unnecessarily.
+                    const isWholeMeasureRest: boolean = sourceNote.IsWholeMeasureRest ||
+                        graphicalLength.RealValue === this.parentSourceMeasure.ActiveTimeSignature.RealValue;
+                    const ticksMismatch: boolean =
+                        Math.abs(vfTicks.value() - graphicalLength.RealValue * VF.RESOLUTION) > 0.001;
+                    if (sourceNote.NoteTuplet ||
+                        (ticksMismatch && !isWholeMeasureRest && !voiceEntry.parentVoiceEntry?.IsGrace)) {
                         // Calculate ticks using VexFlow Fraction to preserve precision.
                         // graphicalLength.RealValue is the note length as a fraction of a whole note.
                         // VF.RESOLUTION (e.g., 16384) is the number of ticks for a whole note.
                         // We use Fraction arithmetic to avoid floating-point precision issues.
-                        const vfTicks: VF.Fraction = vexFlowVoiceEntry.vfStaveNote.getTicks();
                         vfTicks.numerator = graphicalLength.Numerator * VF.RESOLUTION;
                         vfTicks.denominator = graphicalLength.Denominator;
                         // Simplify the fraction to reduce large numbers

--- a/test/data/test_voice_alignment_type_duration_mismatch.musicxml
+++ b/test/data/test_voice_alignment_type_duration_mismatch.musicxml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Voice alignment: type+dots vs duration mismatch</work-title>
+  </work>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Test</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <!-- Measure 1 (bug case): voice 1 has an INVISIBLE rest whose type+dot
+         (half + dot = 3 quarters) disagrees with its duration (5 eighths =
+         2.5 quarters). Without the fix, the vexflow tick counting of voice 1
+         drifts by half a beat and the following eighth (F4) is drawn in its
+         own column instead of aligned with the simultaneous G4 of voice 2. -->
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>6</beats><beat-type>8</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note print-object="no">
+        <rest/>
+        <duration>5</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+      </note>
+      <backup><duration>6</duration></backup>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>3</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <dot/>
+        <stem>up</stem>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+      </note>
+    </measure>
+    <!-- Measure 2 (control): same music, but the invisible rest is encoded
+         as two rests whose types match their durations. Renders correctly
+         with or without the fix — both measures must look identical. -->
+    <measure number="2">
+      <note print-object="no">
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+      <note print-object="no">
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+      </note>
+      <note>
+        <pitch><step>F</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+      </note>
+      <backup><duration>6</duration></backup>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>3</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <dot/>
+        <stem>up</stem>
+      </note>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Fixes #1698.

## The problem

When a note or rest is encoded with a `<type>` (plus `<dot>`s) that does not match its actual `<duration>`, the VexFlow `StaveNote` is built from the type and dots, so the tick counting of that voice drifts out of sync with the other voices. Every subsequent note of the voice is then drawn horizontally misaligned: two simultaneous notes end up in separate tick contexts / columns, looking like *sequential* notes to the reader (and confusing musicians, since the playback cursor correctly treats them as one onset).

A common real-world source of this encoding is an **invisible rest filling an irregular gap** — e.g. a rest with `print-object="no"`, `type=half` + `<dot/>` (3 quarters) but a `duration` of only 2.5 quarters. Notation editors export this pattern when the padding rest has no clean single-type representation. Other renderers (e.g. MuseScore) align these scores correctly because they position by actual duration.

Related (same symptom, different mechanism, already fixed): #910.

## The fix

`VexFlowMeasure.ts` already rewrites VexFlow ticks exactly (via `VF.Fraction` and `graphicalNoteLength`) **for tuplets**. This PR generalizes that correction to any note whose VexFlow ticks disagree with its actual graphical length:

- whole-measure rests keep their vexflow whole-rest ticks (nothing follows them in the voice; correcting them would only churn spacing),
- grace notes are excluded,
- the tuplet branch behaves exactly as before.

14 insertions, 3 deletions, single file.

## Test sample

Adds `test/data/test_voice_alignment_type_duration_mismatch.musicxml`: measure 1 reproduces the bug (invisible dotted-half rest with duration 2.5 quarters, voice 2 with a simultaneous eighth at the last onset); measure 2 is a control with the same music but correctly-encoded rests. **Both measures must render identically** — without the fix, measure 1 draws the two simultaneous eighths (F4/G4) in separate columns.

Happy to adjust guards/naming or extend the sample if you prefer a different scope.