### PR TITLE
Fix repetition instructions overlapping chord symbols (harmony)

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -167,7 +167,8 @@ export class EngravingRules {
     public CustomChords: CustomChord[];
     /** Not always a symbol, can also be text (RepetitionInstruction). Keeping the name for backwards compatibility. */
     public RepetitionSymbolsYOffset: number;
-    /** Adds a percent of the stave's width (e.g. 0.4 = 40%) to the x position of end instructions like Fine or D.C. al fine */
+    /** Adds a percent of the stave's width (e.g. 0.4 = 40%) to the x position of end instructions like Fine or D.C. al fine.
+     *  Only applied in the last measure of a staffline, so that the instruction is not shifted into the next measure. */
     public RepetitionEndInstructionXShiftAsPercentOfStaveWidth: number;
     public RehearsalMarkXOffset: number;
     public RehearsalMarkXOffsetDefault: number;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -1236,6 +1236,25 @@ export abstract class MusicSheetCalculator {
                                     minimumOffset = skybottomcalculator.getSkyLineMinInRange(start, end); // same as above, less code executed
                                 }
                             }
+                            // even with y-aligned chord symbols (ChordSymbolYAlignment), don't overlap chord symbols
+                            //   already placed in this range, e.g. the previous chord symbol in a too narrow measure (#1688).
+                            //   (the aligned offsets don't include chord symbols placed after their calculation,
+                            //   so a colliding chord symbol needs to be put above (below for placement below) the aligned position)
+                            let chordMaximumOffset: number = maximumOffset;
+                            let chordMinimumOffset: number = minimumOffset;
+                            if (this.rules.ChordSymbolYAlignment) {
+                                // check the collision only for the label without its margins (BorderLeft instead of BorderMarginLeft),
+                                //   so that chord symbols whose (visible) labels don't collide stay on the aligned position
+                                const collisionStart: number = gps.BorderLeft + parentBbox.AbsolutePosition.x + gps.RelativePosition.x;
+                                const collisionEnd: number = gps.BorderRight + parentBbox.AbsolutePosition.x + gps.RelativePosition.x;
+                                if (placement === PlacementEnum.Below) {
+                                    chordMaximumOffset = Math.max(chordMaximumOffset,
+                                                                  skybottomcalculator.getBottomLineMaxInRange(collisionStart, collisionEnd));
+                                } else {
+                                    chordMinimumOffset = Math.min(chordMinimumOffset,
+                                                                  skybottomcalculator.getSkyLineMinInRange(collisionStart, collisionEnd));
+                                }
+                            }
                             let yShift: number = 0;
                             if (i === 0) {
                                 yShift += this.rules.ChordSymbolYOffset;
@@ -1248,17 +1267,17 @@ export abstract class MusicSheetCalculator {
                             }
                             const gLabel: GraphicalLabel = graphicalChordContainer.GraphicalLabel;
                             if (placement === PlacementEnum.Below) {
-                                gLabel.PositionAndShape.RelativePosition.y = maximumOffset + yShift;
+                                gLabel.PositionAndShape.RelativePosition.y = chordMaximumOffset + yShift;
                                 gLabel.setLabelPositionAndShapeBorders();
                                 gLabel.PositionAndShape.calculateBoundingBox();
                                 skybottomcalculator.updateBottomLineInRange(start, end,
-                                    maximumOffset + gLabel.PositionAndShape.BorderMarginBottom +
+                                    chordMaximumOffset + gLabel.PositionAndShape.BorderMarginBottom +
                                     this.rules.ChordSymbolBottomMargin); // TODO somehow off without margin for I numeral
                             } else {
-                                gLabel.PositionAndShape.RelativePosition.y = minimumOffset + yShift;
+                                gLabel.PositionAndShape.RelativePosition.y = chordMinimumOffset + yShift;
                                 gLabel.setLabelPositionAndShapeBorders();
                                 gLabel.PositionAndShape.calculateBoundingBox();
-                                skybottomcalculator.updateSkyLineInRange(start, end, minimumOffset + gLabel.PositionAndShape.BorderMarginTop);
+                                skybottomcalculator.updateSkyLineInRange(start, end, chordMinimumOffset + gLabel.PositionAndShape.BorderMarginTop);
                             }
                             previousChordContainer = graphicalChordContainer;
                         }

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -507,7 +507,13 @@ export class VexFlowMeasure extends GraphicalMeasure {
         }
         if (instruction) {
             const repetition: VF.Repetition = new VF.Repetition(instruction, xShift, -this.rules.RepetitionSymbolsYOffset);
-            (repetition as any).xShiftAsPercentOfStaveWidth = this.rules.RepetitionEndInstructionXShiftAsPercentOfStaveWidth;
+            const stafflineMeasures: GraphicalMeasure[] = this.ParentStaffLine?.Measures;
+            if (!stafflineMeasures || stafflineMeasures[stafflineMeasures.length - 1] === this) {
+                // only shift end instructions like Fine to the right in the last measure of the staffline,
+                //   where the shifted text ends in free space. In earlier measures it would be shifted
+                //   into the next measure, where it can collide e.g. with that measure's end instruction (#1689).
+                (repetition as any).xShiftAsPercentOfStaveWidth = this.rules.RepetitionEndInstructionXShiftAsPercentOfStaveWidth;
+            }
             this.stave.addModifier(repetition, position);
             this.vfRepetitionWords.push(repetition);
             return repetition;

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -121,6 +121,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
         (this.stave as any).MeasureNumber = this.MeasureNumber; // for debug info. vexflow automatically uses stave.measure for rendering measure numbers
         // also see VexFlowMusicSheetDrawer.drawSheet() for some other vexflow default value settings (like default font scale)
         this.hasMetronomeMark = false;
+        this.vfRepetitionWords = []; // the modifiers were discarded with the old stave above, so don't keep stale entries
 
         if (this.ParentStaff) {
             this.setLineNumber(this.ParentStaff.StafflineCount);
@@ -456,7 +457,13 @@ export class VexFlowMeasure extends GraphicalMeasure {
           });
     }
 
-    public addWordRepetition(repetitionInstruction: RepetitionInstruction): void {
+    /**
+     * Adds a repetition instruction (e.g. Segno, D.S. al Fine) as a VexFlow StaveRepetition to the measure's stave
+     * (or as a Volta for endings).
+     * @param repetitionInstruction the instruction to add
+     * @returns the created VF.Repetition, or undefined if a volta (ending) was added instead
+     */
+    public addWordRepetition(repetitionInstruction: RepetitionInstruction): VF.Repetition {
         let instruction: number | undefined;
         let position: number = VF.StaveModifier.Position.END;
         const xShift: number = this.beginInstructionsWidth;
@@ -502,10 +509,12 @@ export class VexFlowMeasure extends GraphicalMeasure {
             const repetition: VF.Repetition = new VF.Repetition(instruction, xShift, -this.rules.RepetitionSymbolsYOffset);
             (repetition as any).xShiftAsPercentOfStaveWidth = this.rules.RepetitionEndInstructionXShiftAsPercentOfStaveWidth;
             this.stave.addModifier(repetition, position);
-            return;
+            this.vfRepetitionWords.push(repetition);
+            return repetition;
         }
 
         this.addVolta(repetitionInstruction);
+        return undefined;
     }
 
     protected addVolta(repetitionInstruction: RepetitionInstruction): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -3,6 +3,9 @@ import { VexFlowGraphicalSymbolFactory } from "./VexFlowGraphicalSymbolFactory";
 import { GraphicalMeasure } from "../GraphicalMeasure";
 import { StaffLine } from "../StaffLine";
 import { SkyBottomLineBatchCalculator } from "../SkyBottomLineBatchCalculator";
+import { SkyBottomLineCalculator } from "../SkyBottomLineCalculator";
+import { Fonts } from "../../../Common/Enums/Fonts";
+import { FontStyles } from "../../../Common/Enums/FontStyles";
 import { VoiceEntry } from "../../VoiceData/VoiceEntry";
 import { GraphicalNote } from "../GraphicalNote";
 import { GraphicalStaffEntry } from "../GraphicalStaffEntry";
@@ -2003,8 +2006,128 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     // now create corresponding graphical symbol or Text in VexFlow:
     // use top measure and staffline for positioning.
     if (uppermostMeasure) {
-      uppermostMeasure.addWordRepetition(repetitionInstruction);
+      const repetition: VF.Repetition = uppermostMeasure.addWordRepetition(repetitionInstruction);
+      this.placeWordRepetitionInSkyline(uppermostMeasure, repetition);
     }
+  }
+
+  /**
+   * Shifts a repetition instruction (VF.Repetition, e.g. Coda sign or "D.S. al Fine" text) above the skyline
+   * and reserves its space in the skyline, so that it doesn't overlap with other objects in its range,
+   * e.g. chord symbols, which are calculated before the repetition instructions (see #1689).
+   * The horizontal and default vertical position replicate the drawing code
+   * in VexFlowPatch/src/staverepetition.js (drawSymbolText() etc).
+   * @param measure the (uppermost) measure the repetition instruction was added to
+   * @param repetition the VexFlow repetition (stave modifier) to place, created by addWordRepetition()
+   */
+  protected placeWordRepetitionInSkyline(measure: VexFlowMeasure, repetition: VF.Repetition): void {
+    const staffLine: StaffLine = measure.ParentStaffLine;
+    if (!repetition || !staffLine) {
+      return;
+    }
+    const type: number = (repetition as any).symbol_type;
+    const repetitionTypes: {[key: string]: number} = VF.Repetition.type as any;
+    let text: string; // the texts drawn by staverepetition.js drawSymbolText()
+    let hasCodaGlyphAfterText: boolean = false; // types that draw a coda glyph after the text
+    switch (type) {
+      case repetitionTypes.CODA_LEFT:
+        text = "Coda";
+        hasCodaGlyphAfterText = true;
+        break;
+      case repetitionTypes.TO_CODA:
+        text = "To";
+        hasCodaGlyphAfterText = true;
+        break;
+      case repetitionTypes.DC_AL_CODA:
+        text = "D.C. al";
+        hasCodaGlyphAfterText = true;
+        break;
+      case repetitionTypes.DS_AL_CODA:
+        text = "D.S. al";
+        hasCodaGlyphAfterText = true;
+        break;
+      case repetitionTypes.DC:
+        text = "D.C.";
+        break;
+      case repetitionTypes.DC_AL_FINE:
+        text = "D.C. al Fine";
+        break;
+      case repetitionTypes.DS:
+        text = "D.S.";
+        break;
+      case repetitionTypes.DS_AL_FINE:
+        text = "D.S. al Fine";
+        break;
+      case repetitionTypes.FINE:
+        text = "Fine";
+        break;
+      default:
+        text = ""; // segno/coda glyphs without text
+        break;
+    }
+    const fontHeightUnits: number = 1.6; // staverepetition.js draws the text with a 12pt (16px) font
+    let textWidthUnits: number = 0;
+    if (text.length > 0) {
+      // measure with the same font family string ("times") that staverepetition.js draws with,
+      //   so that the measured width matches the drawn width even if the font falls back to another one
+      textWidthUnits = MusicSheetCalculator.TextMeasurer.computeTextWidthToHeightRatio(
+        text, Fonts.TimesNewRoman, FontStyles.BoldItalic, "times") * fontHeightUnits;
+    }
+    const glyphWidthUnits: number = 2.4; // coda/segno glyph width (plus the 12px gap after the text for symbol_x)
+    const measureStartX: number = measure.PositionAndShape.RelativePosition.x;
+    const measureWidth: number = measure.PositionAndShape.Size.width;
+    let startX: number;
+    let endX: number;
+    if (type === repetitionTypes.SEGNO_LEFT) {
+      // drawSignoFixed() draws the glyph after the measure's begin instructions (clef, key, time signature):
+      //   its x anchor additionally gets the stave's modifier x shift, which is the begin instructions width
+      //   at draw time - and that can still change (e.g. shrink by alignment) after this calculation.
+      //   So reserve a tolerant range around the begin instructions width.
+      startX = measureStartX + measure.beginInstructionsWidth * 0.7;
+      endX = measureStartX + measure.beginInstructionsWidth * 1.2 +
+        measure.beginInstructionsWidth / unitInPixels + glyphWidthUnits;
+    } else if (type === repetitionTypes.CODA_LEFT) {
+      // drawn at the start of the measure (plus beginInstructionsWidth, which drawSymbolText uses as pixels)
+      startX = measureStartX + measure.beginInstructionsWidth / unitInPixels;
+      endX = startX + textWidthUnits + glyphWidthUnits;
+    } else {
+      // texts at the end of the measure, drawn right-aligned to the measure end
+      //   (drawSymbolText: x_shift = -(text width + 12 + vertical_bar_width + 12), text_x = x + x_shift + vertical_bar_width,
+      //   and the anchor x is the stave end minus the end barline width/padding, so roughly half a unit before the measure end)
+      startX = measureStartX + measureWidth - 0.5 - textWidthUnits - 2.4;
+      if (type === repetitionTypes.DC || type === repetitionTypes.DC_AL_FINE || type === repetitionTypes.DS ||
+          type === repetitionTypes.DS_AL_FINE || type === repetitionTypes.FINE) {
+        // these are additionally shifted to the right, see xShiftAsPercentOfStaveWidth in staverepetition.js
+        startX += measureWidth * this.rules.RepetitionEndInstructionXShiftAsPercentOfStaveWidth;
+      }
+      endX = startX + textWidthUnits;
+      if (hasCodaGlyphAfterText) {
+        endX += glyphWidthUnits;
+      }
+    }
+    // don't add a safety margin to the range: it would unnecessarily stack repetition marks
+    //   that have a small gap between them. (the skyline sampling reads slightly beyond the range anyways)
+    // clamp to the staffline (e.g. an end instruction of the last measure can be shifted beyond the staffline end)
+    startX = Math.max(0, startX);
+    endX = Math.min(staffLine.PositionAndShape.Size.width, endX);
+    if (!(endX > startX)) {
+      return;
+    }
+    // default drawing band of staverepetition.js, relative to the top staff line:
+    //   the text baseline is at getYForTopText(5) + 25 + 5 = 3 units above the top staff line (plus y_shift),
+    //   glyphs are anchored similarly, so the drawn objects roughly span [-4.5, -2.5] units
+    const yShiftUnits: number = ((repetition as any).y_shift ?? 0) / unitInPixels; // -RepetitionSymbolsYOffset, see addWordRepetition
+    const defaultTop: number = -4.5 + yShiftUnits;
+    const defaultBottom: number = -2.5 + yShiftUnits;
+    const skyBottomLineCalculator: SkyBottomLineCalculator = staffLine.SkyBottomLineCalculator;
+    const skyLineMin: number = skyBottomLineCalculator.getSkyLineMinInRange(startX, endX);
+    let collisionShiftUnits: number = 0;
+    if (skyLineMin < defaultBottom && skyLineMin !== -Infinity && skyLineMin !== Infinity) {
+      // something (e.g. a chord symbol) protrudes into the default position -> shift the repetition above it
+      collisionShiftUnits = skyLineMin - defaultBottom;
+      repetition.setShiftY((repetition as any).y_shift + collisionShiftUnits * unitInPixels);
+    }
+    skyBottomLineCalculator.updateSkyLineInRange(startX, endX, defaultTop + collisionShiftUnits);
   }
 
   protected calculateSkyBottomLines(): void {

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -2011,10 +2011,15 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     }
   }
 
+  /** The repetition instruction boxes already placed per staff line, for their mutual collision checks.
+   *  (a WeakMap, so that the entries of a previous render's staff lines don't linger) */
+  private placedWordRepetitionBoxes: WeakMap<StaffLine, {startX: number, endX: number, top: number}[]> = new WeakMap();
+
   /**
-   * Shifts a repetition instruction (VF.Repetition, e.g. Coda sign or "D.S. al Fine" text) above the skyline
-   * and reserves its space in the skyline, so that it doesn't overlap with other objects in its range,
-   * e.g. chord symbols, which are calculated before the repetition instructions (see #1689).
+   * Shifts a repetition instruction (VF.Repetition, e.g. Coda sign or "D.S. al Fine" text) above
+   * other objects in its range, e.g. chord symbols, which are calculated before the repetition
+   * instructions, or previously placed repetition instructions (see #1689).
+   * Shifted instructions reserve their space in the skyline, so that the staffline borders account for them.
    * The horizontal and default vertical position replicate the drawing code
    * in VexFlowPatch/src/staverepetition.js (drawSymbolText() etc).
    * @param measure the (uppermost) measure the repetition instruction was added to
@@ -2097,8 +2102,9 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
       startX = measureStartX + measureWidth - 0.5 - textWidthUnits - 2.4;
       if (type === repetitionTypes.DC || type === repetitionTypes.DC_AL_FINE || type === repetitionTypes.DS ||
           type === repetitionTypes.DS_AL_FINE || type === repetitionTypes.FINE) {
-        // these are additionally shifted to the right, see xShiftAsPercentOfStaveWidth in staverepetition.js
-        startX += measureWidth * this.rules.RepetitionEndInstructionXShiftAsPercentOfStaveWidth;
+        // these are additionally shifted to the right (only in the staffline's last measure, see addWordRepetition()),
+        //   see xShiftAsPercentOfStaveWidth in staverepetition.js
+        startX += measureWidth * ((repetition as any).xShiftAsPercentOfStaveWidth ?? 0);
       }
       endX = startX + textWidthUnits;
       if (hasCodaGlyphAfterText) {
@@ -2120,14 +2126,37 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     const defaultTop: number = -4.5 + yShiftUnits;
     const defaultBottom: number = -2.5 + yShiftUnits;
     const skyBottomLineCalculator: SkyBottomLineCalculator = staffLine.SkyBottomLineCalculator;
-    const skyLineMin: number = skyBottomLineCalculator.getSkyLineMinInRange(startX, endX);
+    let collisionMin: number = skyBottomLineCalculator.getSkyLineMinInRange(startX, endX);
+    if (collisionMin === -Infinity || collisionMin === Infinity) {
+      collisionMin = 0;
+    }
+    // repetition instructions in their default position don't reserve skyline space (see below),
+    //   so also check against the already placed repetition instructions of this staff line:
+    let placedBoxes: {startX: number, endX: number, top: number}[] = this.placedWordRepetitionBoxes.get(staffLine);
+    if (!placedBoxes) {
+      placedBoxes = [];
+      this.placedWordRepetitionBoxes.set(staffLine, placedBoxes);
+    }
+    for (const box of placedBoxes) {
+      if (box.endX > startX && box.startX < endX) {
+        collisionMin = Math.min(collisionMin, box.top);
+      }
+    }
     let collisionShiftUnits: number = 0;
-    if (skyLineMin < defaultBottom && skyLineMin !== -Infinity && skyLineMin !== Infinity) {
-      // something (e.g. a chord symbol) protrudes into the default position -> shift the repetition above it
-      collisionShiftUnits = skyLineMin - defaultBottom;
+    if (collisionMin < defaultBottom) {
+      // something (e.g. a chord symbol or another repetition instruction) protrudes
+      //   into the default position -> shift the repetition above it
+      collisionShiftUnits = collisionMin - defaultBottom;
       repetition.setShiftY((repetition as any).y_shift + collisionShiftUnits * unitInPixels);
     }
-    skyBottomLineCalculator.updateSkyLineInRange(startX, endX, defaultTop + collisionShiftUnits);
+    placedBoxes.push({ startX: startX, endX: endX, top: defaultTop + collisionShiftUnits });
+    if (collisionShiftUnits < 0) {
+      // only instructions that were shifted upwards reserve their space in the skyline, so that the
+      //   staffline borders (and thus the system spacing) account for them. Unshifted instructions stay
+      //   in their default band close above the staff, which shouldn't increase the system spacing
+      //   (as it also didn't before repetition instructions were placed via the skyline).
+      skyBottomLineCalculator.updateSkyLineInRange(startX, endX, defaultTop + collisionShiftUnits);
+    }
   }
 
   protected calculateSkyBottomLines(): void {

--- a/test/MusicalScore/ScoreCalculation/ChordSymbolsRepetitionsCollision_Test.ts
+++ b/test/MusicalScore/ScoreCalculation/ChordSymbolsRepetitionsCollision_Test.ts
@@ -1,0 +1,192 @@
+import { expect } from "chai";
+import { IXmlElement } from "../../../src/Common/FileIO/Xml";
+import { MusicSheetReader } from "../../../src/MusicalScore/ScoreIO/MusicSheetReader";
+import { MusicSheet } from "../../../src/MusicalScore/MusicSheet";
+import { MusicSheetCalculator } from "../../../src/MusicalScore/Graphical/MusicSheetCalculator";
+import { VexFlowMusicSheetCalculator } from "../../../src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator";
+import { VexFlowTextMeasurer } from "../../../src/MusicalScore/Graphical/VexFlow/VexFlowTextMeasurer";
+import { VexFlowMeasure } from "../../../src/MusicalScore/Graphical/VexFlow/VexFlowMeasure";
+import { GraphicalMusicSheet } from "../../../src/MusicalScore/Graphical/GraphicalMusicSheet";
+import { EngravingRules } from "../../../src/MusicalScore/Graphical/EngravingRules";
+import { GraphicalLabel } from "../../../src/MusicalScore/Graphical/GraphicalLabel";
+import { StaffLine } from "../../../src/MusicalScore/Graphical/StaffLine";
+import { MusicSystem } from "../../../src/MusicalScore/Graphical/MusicSystem";
+import { BoundingBox } from "../../../src/MusicalScore/Graphical/BoundingBox";
+import { TestUtils } from "../../Util/TestUtils";
+import Vex from "vexflow";
+import VF = Vex.Flow;
+
+interface LabelRect {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    text: string;
+}
+
+/**
+ * Builds the graphical music sheet (layout) for a test sample file, without rendering it.
+ * @param filename the sample file name in test/data
+ * @returns the calculated GraphicalMusicSheet
+ */
+function buildGraphicalMusicSheet(filename: string): GraphicalMusicSheet {
+    const reader: MusicSheetReader = new MusicSheetReader();
+    const calculator: MusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+    MusicSheetCalculator.TextMeasurer = new VexFlowTextMeasurer(new EngravingRules());
+    const xml: Document = TestUtils.getScore(filename);
+    expect(xml, "sample file is loaded").to.not.equal(undefined);
+    const score: IXmlElement = new IXmlElement(TestUtils.getPartWiseElement(xml));
+    const sheet: MusicSheet = reader.createMusicSheet(score, "path-of-" + filename);
+    const graphicalSheet: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calculator);
+    graphicalSheet.reCalculate();
+    return graphicalSheet;
+}
+
+/**
+ * Computes the page-absolute position of a bounding box by walking up the bounding box tree.
+ * @param bbox the bounding box
+ * @returns the absolute x and y position
+ */
+function absolutePosition(bbox: BoundingBox): { x: number, y: number } {
+    let x: number = 0;
+    let y: number = 0;
+    for (let current: BoundingBox = bbox; current; current = current.Parent) {
+        x += current.RelativePosition.x;
+        y += current.RelativePosition.y;
+    }
+    return { x, y };
+}
+
+/**
+ * Collects the absolute label rectangles (without margins) of all chord symbols in a staff line.
+ * @param staffLine the staff line to collect chord symbol labels from
+ * @returns the label rectangles
+ */
+function collectChordLabelRects(staffLine: StaffLine): LabelRect[] {
+    const rects: LabelRect[] = [];
+    for (const measure of staffLine.Measures) {
+        for (const staffEntry of measure.staffEntries) {
+            for (const chordContainer of staffEntry.graphicalChordContainers) {
+                const label: GraphicalLabel = chordContainer.GraphicalLabel;
+                const pos: { x: number, y: number } = absolutePosition(label.PositionAndShape);
+                rects.push({
+                    left: pos.x + label.PositionAndShape.BorderLeft,
+                    right: pos.x + label.PositionAndShape.BorderRight,
+                    top: pos.y + label.PositionAndShape.BorderTop,
+                    bottom: pos.y + label.PositionAndShape.BorderBottom,
+                    text: label.Label.text
+                });
+            }
+        }
+    }
+    return rects;
+}
+
+/**
+ * Expects that none of the given label rectangles overlap each other.
+ * @param rects the label rectangles to check pairwise
+ */
+function expectNoOverlaps(rects: LabelRect[]): void {
+    const epsilon: number = 0.01; // ignore merely touching edges
+    for (let i: number = 0; i < rects.length; i++) {
+        for (let j: number = i + 1; j < rects.length; j++) {
+            const a: LabelRect = rects[i];
+            const b: LabelRect = rects[j];
+            const xOverlap: number = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+            const yOverlap: number = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+            const overlaps: boolean = xOverlap > epsilon && yOverlap > epsilon;
+            expect(overlaps, `chord symbol labels "${a.text}" and "${b.text}" overlap`).to.equal(false);
+        }
+    }
+}
+
+describe("Chord symbol and repetition instruction collision avoidance", () => {
+    describe("chord symbols in a too narrow measure (issue #1688)", () => {
+        const filename: string = "test_chord_symbols_overlap_narrow_measure_1688.musicxml";
+        let graphicalSheet: GraphicalMusicSheet;
+        let staffLines: StaffLine[];
+
+        before((): void => {
+            graphicalSheet = buildGraphicalMusicSheet(filename);
+            staffLines = [];
+            for (const page of graphicalSheet.MusicPages) {
+                for (const system of page.MusicSystems as MusicSystem[]) {
+                    staffLines.push(...system.StaffLines);
+                }
+            }
+        });
+
+        it("renders all chord symbols", () => {
+            const allRects: LabelRect[] = staffLines.map(collectChordLabelRects).reduce(
+                (all: LabelRect[], rects: LabelRect[]): LabelRect[] => all.concat(rects), []);
+            expect(allRects.length, "two chord symbols per measure").to.equal(16);
+        });
+
+        it("does not overlap chord symbols, even in narrow measures", () => {
+            for (const staffLine of staffLines) {
+                expectNoOverlaps(collectChordLabelRects(staffLine));
+            }
+        });
+
+        it("stacks colliding chord symbols above each other", () => {
+            let stackedPairFound: boolean = false;
+            for (const staffLine of staffLines) {
+                const rects: LabelRect[] = collectChordLabelRects(staffLine);
+                for (let i: number = 1; i < rects.length; i++) {
+                    if (Math.abs(rects[i].top - rects[i - 1].top) > 0.5) {
+                        stackedPairFound = true;
+                    }
+                }
+            }
+            expect(stackedPairFound, "at least one chord symbol is stacked above a colliding one").to.equal(true);
+        });
+    });
+
+    describe("chord symbols and repetition instructions (issue #1689)", () => {
+        const filename: string = "test_chord_symbols_repetition_instructions_overlap_1689.musicxml";
+        let graphicalSheet: GraphicalMusicSheet;
+        let measures: VexFlowMeasure[];
+        let staffLine: StaffLine;
+
+        before((): void => {
+            graphicalSheet = buildGraphicalMusicSheet(filename);
+            measures = graphicalSheet.MeasureList.map(
+                (measuresOfAllStaves: VexFlowMeasure[]): VexFlowMeasure => measuresOfAllStaves[0]);
+            staffLine = measures[0].ParentStaffLine;
+        });
+
+        it("creates the repetition instruction stave modifiers", () => {
+            const repetitionTypes: number[][] = measures.map((measure: VexFlowMeasure): number[] =>
+                measure.vfRepetitionWords.map((repetition: VF.Repetition): number => (repetition as any).symbol_type));
+            // measure 1: Segno / measure 2: To Coda / measure 3: D.S. al Coda / measure 4: Coda
+            expect(repetitionTypes).to.deep.equal([
+                [VF.Repetition.type.SEGNO_LEFT],
+                [(VF.Repetition as any).type.TO_CODA],
+                [VF.Repetition.type.DS_AL_CODA],
+                [VF.Repetition.type.CODA_LEFT]
+            ]);
+        });
+
+        it("shifts colliding repetition instructions upwards, above the chord symbols", () => {
+            for (const measure of measures) {
+                for (const repetition of measure.vfRepetitionWords) {
+                    const yShift: number = (repetition as any).y_shift;
+                    expect(yShift, "repetition instructions are never shifted downwards").to.be.at.most(0);
+                }
+            }
+            // the segno sign in measure 1 is shifted above the chord symbol at the measure start:
+            expect((measures[0].vfRepetitionWords[0] as any).y_shift).to.be.lessThan(0);
+            // the To Coda text at the end of measure 2 is shifted above the chord symbol on the third beat:
+            expect((measures[1].vfRepetitionWords[0] as any).y_shift).to.be.lessThan(0);
+        });
+
+        it("reserves skyline space for the repetition instructions", () => {
+            // the default drawing position of the repetition texts/glyphs reaches 4.5 units above the staff
+            expect(Math.min(...staffLine.SkyLine)).to.be.at.most(-4.4);
+        });
+
+        it("does not overlap the chord symbols in the same measure (measure 3)", () => {
+            expectNoOverlaps(collectChordLabelRects(staffLine));
+        });
+    });
+});

--- a/test/data/test_chord_symbols_overlap_narrow_measure_1688.musicxml
+++ b/test/data/test_chord_symbols_overlap_narrow_measure_1688.musicxml
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+        "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+    <work><work-title>test_chord_symbols_overlap_narrow_measure_1688</work-title></work>
+    <part-list>
+        <score-part id="P1">
+            <part-name> </part-name>
+        </score-part>
+    </part-list>
+    <part id="P1">
+        <measure number="1">
+            <attributes>
+                <divisions>256</divisions>
+                <key>
+                    <fifths>0</fifths>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+            </attributes>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000" default-x="87">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="2">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="3">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="4">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="5">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="6">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="7">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+        <measure number="8">
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note color="#000000">
+                <pitch>
+                    <step>D</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony color="#000000" default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>minor-sixth</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+        </measure>
+    </part>
+</score-partwise>

--- a/test/data/test_chord_symbols_repetition_instructions_overlap_1689.musicxml
+++ b/test/data/test_chord_symbols_repetition_instructions_overlap_1689.musicxml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+        "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+    <work><work-title>test_chord_symbols_repetition_instructions_overlap_1689</work-title></work>
+    <part-list>
+        <score-part id="P1">
+            <part-name> </part-name>
+        </score-part>
+    </part-list>
+    <part id="P1">
+        <measure number="1">
+            <attributes>
+                <divisions>256</divisions>
+                <key>
+                    <fifths>2</fifths>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+            </attributes>
+            <direction placement="above">
+                <direction-type>
+                    <segno/>
+                </direction-type>
+                <sound segno="segno1"/>
+            </direction>
+            <harmony default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+            <note>
+                <rest/>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+        </measure>
+        <measure number="2">
+            <harmony default-y="25">
+                <root>
+                    <root-step>B</root-step>
+                </root>
+                <kind>minor-seventh</kind>
+            </harmony>
+            <note>
+                <rest/>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <direction placement="above">
+                <direction-type>
+                    <words>To Coda</words>
+                </direction-type>
+                <sound tocoda="coda1"/>
+            </direction>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony default-y="25">
+                <root>
+                    <root-step>E</root-step>
+                </root>
+                <kind>dominant</kind>
+            </harmony>
+        </measure>
+        <measure number="3">
+            <harmony default-y="25">
+                <root>
+                    <root-step>G</root-step>
+                </root>
+                <kind>major</kind>
+                <bass>
+                    <bass-step>D</bass-step>
+                </bass>
+            </harmony>
+            <note>
+                <rest/>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+            <direction placement="above">
+                <direction-type>
+                    <words>D.S. al Coda</words>
+                </direction-type>
+                <sound dalsegno="segno1"/>
+            </direction>
+            <backup>
+                <duration>512</duration>
+            </backup>
+            <harmony default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+            </harmony>
+        </measure>
+        <measure number="4">
+            <harmony default-y="25">
+                <root>
+                    <root-step>D</root-step>
+                </root>
+                <kind>major</kind>
+                <bass>
+                    <bass-step>E</bass-step>
+                </bass>
+            </harmony>
+            <direction placement="above">
+                <direction-type>
+                    <coda/>
+                </direction-type>
+                <sound coda="coda1"/>
+            </direction>
+            <note>
+                <rest/>
+                <duration>1024</duration>
+                <type>whole</type>
+            </note>
+        </measure>
+    </part>
+</score-partwise>


### PR DESCRIPTION
Fixes #1688. Fixes #1689.

Before:
<img width="291" height="136" alt="Image" src="https://github.com/user-attachments/assets/22949045-1f96-4a62-a4d1-db829fd5f31c" />

After:
<img width="614" height="132" alt="Image" src="https://github.com/user-attachments/assets/172e6fca-6159-4b12-a32a-8c4b00dfd81a" />

Chord symbols ("harmony texts") could overlap each other in narrow measures, and
repetition instructions (Coda/Segno signs, texts like "D.S. al Coda") could overlap
chord symbols and each other, because they were drawn at a fixed position above the
staff without any collision handling.

### #1688: Chord symbols could overlap each other in narrow measures

With `ChordSymbolYAlignment` (default), all chord symbols were placed at the shared
aligned y position even when their labels collide in a too narrow measure.

Now each chord symbol additionally checks the skyline in its own range (which every
placed chord symbol updates): a chord symbol that would overlap an already placed one
is stacked above it (below, for placement below).
The collision check uses the label borders without margins, so chord symbols with a small visible gap keep their aligned
position — samples without actual collisions render pixel-identically
(e.g. `test_chord_whole_rest_overlap` from #791).

### #1689: Repetition instructions had no bounding box / collision handling

Repetition instructions are drawn as VexFlow `StaveRepetition` stave modifiers.
Their drawn box (replicating the positioning of the VexFlowPatch's
`staverepetition.js`, with text widths measured using the same "times" font) is now
checked for collisions:

- Chord symbols are calculated before the repetition instructions, so a repetition
  instruction that would overlap one is shifted above it (`setShiftY`).
- Repetition instructions also check against each other (via a list of the already
  placed instruction boxes), so e.g. a long "D.S. al Coda" reaching back over a
  barline in narrow measures stacks above the previous measure's "To Coda" instead
  of overlapping it.
- Only instructions that were actually shifted upwards reserve their raised space in
  the skyline, so the staffline borders account for them — unshifted instructions
  don't change the system spacing at all (no vertical layout regressions).
- `RepetitionEndInstructionXShiftAsPercentOfStaveWidth` (40% right-shift of end
  instructions like Fine) is now only applied in the last measure of a staffline,
  where the shifted text ends in free space. In earlier measures it shifted the text
  into the following measure, where it could collide with that measure's own end
  instruction.
- `VexFlowMeasure.addWordRepetition()` now returns the created `VF.Repetition` and
  registers it in the previously unused `vfRepetitionWords` list.

### Tests / regression safety

- New test samples: `test_chord_symbols_overlap_narrow_measure_1688.musicxml` (the
  issue's measure, repeated so it gets narrow at any width) and
  `test_chord_symbols_repetition_instructions_overlap_1689.musicxml` (a musically
  coherent D.S. al Coda piece — Segno, To Coda, D.S. al Coda, Coda — each mark
  colliding with a chord symbol), plus layout tests for both issues
  (`ChordSymbolsRepetitionsCollision_Test.ts`).
- All 249 karma tests pass.
- A/B render of all 291 test samples against develop: 288 byte-identical. The only
  differences are the two new samples and `test_words_voice_tacet_on_ds_1687`, where
  "Fine" is no longer shifted into the next measure, so "Fine" and "D.S. al Fine" no
  longer render on top of each other (vertical spacing is unchanged).