### PR TITLE
perf: scope correctNotePositions to its own measure (render 27-57% faster)

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMeasure.ts
@@ -768,27 +768,39 @@ export class VexFlowMeasure extends GraphicalMeasure {
             }
             return; // don't do the below y position adaptations meant for non-tab notes
         }
-        for (const voice of this.getVoicesWithinMeasure()) {
-            for (const ve of voice.VoiceEntries) {
-                for (const note of ve.Notes) {
-                    if (note.isRest()) {
+        // Iterate this measure's own staff entries. Going through
+        // Voice.VoiceEntries instead would walk every entry that voice has in
+        // the whole score, from a method that runs once per measure, so each
+        // measure would re-position every note in the piece (quadratic in
+        // measure count, and every pass after the first writes the same value).
+        for (const gse of this.staffEntries) {
+            for (const gve of gse.graphicalVoiceEntries) {
+                const notes: GraphicalNote[] = gve.notes;
+                if (notes.length === 0) {
+                    continue;
+                }
+                const lastNote: VexFlowGraphicalNote = notes[notes.length - 1] as VexFlowGraphicalNote;
+                if (!lastNote.vfnote) { // notehead() below reads its vfnote[0] with no argument
+                    continue;
+                }
+                for (const graphicalNote of notes) {
+                    const gNote: VexFlowGraphicalNote = graphicalNote as VexFlowGraphicalNote;
+                    if (gNote.sourceNote.isRest()) {
                         continue;
                         // rest positions are already fine.
                         // Doing the below for rests messes up the y-position calculation / bbox for non-rest note for some reason.
                         //   they were not in the voice's voice entries until #1612, so it didn't matter.
                     }
-                    const gNote: VexFlowGraphicalNote = this.rules.GNote(note) as VexFlowGraphicalNote;
-                    if (!gNote?.vfnote) { // can happen were invisible, then multi rest measure. TODO fix multi rest measure not removed
-                        return;
+                    if (!gNote.vfnote) { // can happen were invisible, then multi rest measure. TODO fix multi rest measure not removed
+                        continue;
                     }
                     const vfnote: VF.StemmableNote = gNote.vfnote[0];
-                    // if (note.isRest()) // TODO somehow there are never rest notes in ve.Notes
-                    // TODO also, grace notes are not included here, need to be fixed as well. (and a few triple beamed notes in Bach Air)
+                    // TODO grace notes are not included here, need to be fixed as well. (and a few triple beamed notes in Bach Air)
                     let relPosY: number = 0;
-                    if (gNote.parentVoiceEntry.parentVoiceEntry.StemDirection === StemDirectionType.Up && gNote.vfnote[0].getDuration() !== "w") {
+                    if (gNote.parentVoiceEntry.parentVoiceEntry.StemDirection === StemDirectionType.Up && vfnote.getDuration() !== "w") {
                         relPosY += 3.5; // about 3.5 lines too high. this seems to be related to the default stem height, not actual stem height.
                         // alternate calculation using actual stem height: somehow wildly varying.
-                        // if (ve.Notes.length > 1) {
+                        // if (notes.length > 1) {
                         //     const stemHeight: number = vfnote.getStem().getHeight();
                         //     // relPosY += shortFactor * stemHeight / unitInPixels - 3.5;
                         //     relPosY += stemHeight / unitInPixels - 3.5; // for some reason this varies in its correctness between similar notes
@@ -799,7 +811,7 @@ export class VexFlowMeasure extends GraphicalMeasure {
                         relPosY += 0.5; // center-align bbox
                     }
                     const line: number = -gNote.notehead(vfnote).line; // vexflow y direction is opposite of osmd's
-                    relPosY += line + (gNote.parentVoiceEntry.notes.last() as VexFlowGraphicalNote).notehead().line; // don't move for first note: - (-vexline)
+                    relPosY += line + lastNote.notehead().line; // don't move for first note: - (-vexline)
                     gNote.PositionAndShape.RelativePosition.y = relPosY;
                 }
             }


### PR DESCRIPTION
`VexFlowMeasure.correctNotePositions()` runs once per graphical measure, but its loop walks `Voice.VoiceEntries` — every entry that voice has in the **entire score**. So each measure re-writes the vertical position of every note in the piece, and everything after the first pass writes the same value again.

This changes the loop to walk the measure's own `staffEntries`. `render()` gets 27–57% faster on larger scores, and the SVG output is byte-identical.

## Numbers

Median of 3 runs each, headless Chrome, synthetic scores (4 quarter notes per measure per part):

| Score | Before | After |
|---|---:|---:|
| 6 parts × 50 measures | 685 ms | 501 ms |
| 6 parts × 100 measures | 1222 ms | 854 ms |
| 6 parts × 200 measures | 3793 ms | 1626 ms |
| 24 parts × 200 measures | 11342 ms | 4986 ms |

Scaling exponent over a 4× longer score (`log(t₂₀₀/t₅₀)/log 4`): **1.24 → 0.85**.

The effect is bigger on slow hardware — on a low-end Android phone the same change cut `render()` by 40% for a 102-measure / 6-part score.

## Why it was quadratic

```ts
for (const voice of this.getVoicesWithinMeasure()) {
    for (const ve of voice.VoiceEntries) {   // <-- whole score, not this measure
```

`getVoicesWithinMeasure()` correctly narrows to the voices in this measure, but `Voice.VoiceEntries` expands right back out to the full score.

Profiling 6 parts × 200 measures (4,800 notes), one `render()`. Every one of these calls came from this method and nowhere else:

| | calls | per note |
|---|---:|---:|
| `EngravingRules.GNote` | 1,920,000 | 400 |
| `VexFlowGraphicalNote.notehead` | 3,840,000 | 800 |

400 visits per note is exactly the score length in measures. The method accounted for 41% of render self time with a scaling exponent of 2.08, while every other method measured sat near 1.0. (Skyline calculation is down to 1.5% since #1681 — that change is what left this as the dominant term.)

Walking `staffEntries` also drops the `rules.GNote()` lookups entirely, since `graphicalVoiceEntries` already holds the `GraphicalNote` objects.

## Verification

Both revisions built with `npm run build:webpack` and rendered in headless Chrome; the SVG is serialised and hashed (FNV-1a), so a match means identical output. **95 scores, all identical, zero differences:**

- 94 from `test/data`, picked for constructs this could break: tablature, drums, grace notes, multiple voices, chords, invisible notes, in-measure clef changes, multi-rests, octave shifts, tuplets, fingerings, arpeggios, plus `ActorPreludeSample`, Haydn, Gounod, Joplin, Bach, Clementi
- 1 purpose-built guitar + tablature score, see note 3 below

Also identical with `renderSingleHorizontalStaffline: true` on the four synthetic scores above — the 24 × 200 one matched across 30,704,121 characters of SVG.

`npm test` is unchanged: 361 passing, 2 skipped, and one slur test (`SlurFlattenToObstacle, width-driven`) failing — it fails identically on unmodified `develop`, with the same numbers to 15 decimal places, when run in Chrome instead of the configured Firefox.

## Three things worth your judgement

1. **`continue` instead of `return` on a missing `vfnote`.** The existing `return` abandons the whole loop — which, in the whole-score loop, meant the rest of the score. Skipping just that note looks like the intent, and it lines up with the existing `TODO fix multi rest measure not removed` comment. A variant keeping `return` also produces identical output on all 95 scores, if you prefer the smaller semantic change.

2. **The new `lastNote.vfnote` check is required.** `notehead()` with no argument dereferences `this.vfnote[0]`, and a staff entry holding only grace notes never gets a `StaveNote`. The old code got away with it because it bailed out of the entire loop at the first such note; skipping per entry exposes it, and `draw()` has no `try`/`catch`.

3. **For a part with both a standard and a tablature staff, a different `GraphicalNote` object gets adjusted.** `NoteToGraphicalNoteMap` holds the tab-side one (created last, overwrites the id), so `rules.GNote()` returned that while walking `staffEntries` reaches the standard-staff one. VexFlow owns the drawn coordinates, so the SVG is unaffected — I checked with a score using `<staves>2</staves>` plus a 6-line tab staff, since every tablature fixture in `test/data` is tab-only and never exercises this path. But if anything downstream reads `GraphicalNote.PositionAndShape` for these notes, it now sees the offset on the standard-staff object. That seems more correct to me, but you would know if something depends on the current arrangement.

The tab-measure branch has the same `Voice.VoiceEntries` problem and can take the same treatment. I left it alone rather than change tab layout without fixtures to check against.
