### PR TITLE
perf(Glyph): cache outline bounding boxes

### DIFF
--- a/src/VexFlowPatch/src/glyph.js
+++ b/src/VexFlowPatch/src/glyph.js
@@ -176,12 +176,37 @@ export class Glyph extends Element {
       this.code,
       this.options.cache
     );
-    this.bbox = Glyph.getOutlineBoundingBox(
-      this.metrics.outline,
-      this.scale,
-      0,
-      0
-    );
+    // The origin is fixed at 0,0, so the box depends only on the outline and the
+    // scale: every glyph with the same code and point size walks the same curves
+    // again. Cache the four numbers on the font, next to cached_outline, and hand
+    // out a fresh BoundingBox because callers keep a reference to it.
+    if (this.options.cache) {
+      const key = this.code + '/' + this.scale;
+      let cache = this.options.font.cached_bboxes;
+      if (!cache) {
+        cache = Object.create(null);
+        this.options.font.cached_bboxes = cache;
+      }
+      let box = cache[key];
+      if (!box) {
+        const computed = Glyph.getOutlineBoundingBox(
+          this.metrics.outline,
+          this.scale,
+          0,
+          0
+        );
+        box = [computed.getX(), computed.getY(), computed.getW(), computed.getH()];
+        cache[key] = box;
+      }
+      this.bbox = new BoundingBox(box[0], box[1], box[2], box[3]);
+    } else {
+      this.bbox = Glyph.getOutlineBoundingBox(
+        this.metrics.outline,
+        this.scale,
+        0,
+        0
+      );
+    }
   }
 
   getMetrics() {


### PR DESCRIPTION
`Glyph.reset()` builds `this.bbox` with `Glyph.getOutlineBoundingBox(outline, scale, 0, 0)`, which walks the glyph's bezier outline point by point. It runs once per `Glyph` instance, so a score with a few thousand noteheads walks the same few dozen outlines a few thousand times.

The origin is fixed at 0,0 in that call, so the box depends only on the outline and the scale — and `loadMetrics` already shares the outline array per glyph code via `cached_outline`. Caching the box next to it makes `render()` 19–21% faster with byte-identical SVG.

Independent of #1703; different file, and the two stack.

## Numbers

Median of 3, headless Chrome, alternating builds (running one build's three passes back to back drifts enough to hide the effect). Synthetic scores, 4 quarter notes per measure per part:

| Score | Before | After |
|---|---:|---:|
| 6 parts × 100 measures | 983 ms | 774 ms |
| 6 parts × 200 measures | 1657 ms | 1345 ms |
| 24 parts × 200 measures | 8786 ms | 6939 ms |

`load()` benefits as well, since `StaveNote` construction creates glyphs too, though by less.

The effect is larger on slow hardware: on a low-end Android phone this cut `render()` by a further 20% for a 102-measure / 6-part score, on top of #1703.

Where the time went, from a V8 CPU profile of 6 parts × 200 measures (self time, one `render()`):

| | before | after |
|---|---:|---:|
| `Glyph.getOutlineBoundingBox` (inclusive) | 416 ms | below the sampling floor |
| `BoundingBoxComputation.addBezierCurve` | 108 ms | below the sampling floor |
| `processOutline` and its inner functions | 270 ms | 24 ms |

## Verification

Both revisions built with `npm run build:webpack` and rendered in headless Chrome; the SVG is serialised and hashed (FNV-1a), so a match means identical output. **95 scores, all identical** — the same set as #1703: 94 from `test/data`, picked for constructs this could break (tablature, drums, grace notes, multiple voices, chords, invisible notes, in-measure clef changes, multi-rests, octave shifts, tuplets, fingerings, arpeggios, plus `ActorPreludeSample`, Haydn, Gounod, Joplin, Bach, Clementi), plus one purpose-built guitar + tablature score.

`npm test` is unchanged: 361 passing, 2 skipped, and the same `SlurFlattenToObstacle, width-driven` failure that `develop` already produces when run in Chrome instead of the configured Firefox — identical numbers to 15 decimal places.

## Two notes

1. **The cache is keyed on `code + '/' + scale` and lives on the font object**, next to `cached_outline`, and respects `options.cache` the same way `loadMetrics` does. That keeps it per-font, which matters when more than one font is loaded.

2. **Callers get a fresh `BoundingBox`, not the cached one.** `Glyph.bbox` is only read inside VexFlow today (`getMetrics`, `setOriginX`/`setOriginY`, `vibratobracket`), but `BoundingBox` has `setX`/`move`/`mergeWith`, so handing out the shared instance would be a trap waiting for the first caller that mutates it. Only four numbers are cached, so the copy is cheap.
