### PR TITLE
perf(NoteHead): re-enable glyph outline caching for noteheads - 2% median speedup

### DIFF
--- a/src/VexFlowPatch/src/notehead.js
+++ b/src/VexFlowPatch/src/notehead.js
@@ -241,7 +241,12 @@ export class NoteHead extends Note {
       const staveSpace = this.stave.getSpacingBetweenLines();
       drawSlashNoteHead(ctx, this.duration, head_x, y, stem_direction, staveSpace);
     } else {
-      Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code, this.id);
+      // Don't pass a 6th argument here: it is Glyph.renderGlyph's `nocache` flag, and a truthy
+      // value disables the glyph outline cache and deletes the shared cached_outline, so the
+      // outline string is re-split on every notehead draw (and the note width path, which caches
+      // with the same key, keeps re-splitting too). The notehead's SVG id comes from openGroup,
+      // not from this call, so omitting it does not change the rendered output.
+      Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);
     }
 
     if (this.style) {


### PR DESCRIPTION
NoteHead.draw passed this.id as the 6th argument of Glyph.renderGlyph, which is its `nocache` flag. A truthy value disables the glyph outline cache and deletes the shared cached_outline, so the outline string is re-split on every notehead draw; and because the note-width path caches the same glyph code with caching on, the two thrash each other every render.

The notehead's SVG element id comes from openGroup, not from this call, so dropping the argument leaves output byte-identical (verified: 317/317 test/data samples produce identical SVG) while removing the redundant work. render() is ~2% faster on average, and up to ~10% on notehead-dense scores (Telemann, Schubert, Haydn).

The stray argument was introduced alongside setColor() in #1620.

`NoteHead.draw()` renders the notehead glyph with:

```js
Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code, this.id);
```

but `Glyph.renderGlyph`'s 6th parameter is `nocache`. Passing a truthy value (`this.id`) runs `loadMetrics` with caching **off**, which on every draw re-splits the glyph's outline string *and* deletes the shared `glyph.cached_outline`. Because the note-width path (`new Glyph(code, scale).getMetrics()`) caches that same glyph code with caching on, the two paths thrash the cache against each other every render — and they do it for the notehead, the most common glyph on the page.

The `this.id` argument was introduced alongside `setColor()` (#1620). The notehead's SVG element id comes from `openGroup` (used by `getNoteheadSVGs()` etc.), not from this call, so removing the argument does not change the rendered output, it only stops disabling the cache.
I'm pretty sure the intention was to give the notehead id to Vexflow to use as an SVG id or something, but that was clearly the wrong place to do it.

## Fix

```diff
-      Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code, this.id);
+      Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);
```

A comment is added at the call site explaining that no 6th argument belongs there (it is the `nocache` flag), to prevent it being re-added.

## Numbers

Median of 7 interleaved renders (before/after measured back-to-back per sample, so machine drift cancels), Node + jsdom, production build, Endless page. `render()` on the larger `test/data` scores:

| Score | Notes | Before | After | Improvement |
|---|---:|---:|---:|---:|
| Telemann Sonate Nr.1.1 – Dolce | 635 | 115 ms | 104 ms | 9.8% |
| Schubert – An die Musik | 626 | 85 ms | 78 ms | 7.7% |
| Haydn – ConcertanteCello | 1473 | 386 ms | 363 ms | 5.9% |
| Joplin – Elite Syncopations | 1388 | 188 ms | 180 ms | 4.6% |
| Cornelius – Christbaum Op. 8/1 | 854 | 167 ms | 159 ms | 4.3% |
| Joplin – The Entertainer | 1715 | 203 ms | 197 ms | 2.7% |

Whole corpus ~1.4% faster; median 1.9% on scores ≥300 notes. The effect scales with notehead density, so notehead-heavy scores (Telemann, Schubert) gain the most.

## Verification

- **Byte-identical output:** all 317 `test/data` samples produce identical SVG before vs. after (per-page FNV-1a hash of the serialized SVG).
- **Visual regression tests:** clean.
- **`npm test`:** 365 passing, 2 skipped (unchanged); `eslint` clean.

Independent of #1703 and #1704 (different file), and stacks with them.
