### PR TITLE
perf(Glyph): memoize glyph width lookups during formatting - median 5% speedup

### DIFF
--- a/src/VexFlowPatch/src/glyph.js
+++ b/src/VexFlowPatch/src/glyph.js
@@ -129,6 +129,27 @@ export class Glyph extends Element {
     );
   }
 
+  // VexFlowPatch: the note-width tables query glyph widths constantly during formatting
+  // (the same few dozen (code, point) pairs, tens of thousands of times per render), each
+  // time constructing a throwaway Glyph just to read getMetrics().width. That width is a
+  // pure function of (code, point) — it is the cached bbox width — so memoize it on the font,
+  // next to cached_outline / cached_bboxes.
+  static cachedWidth(code, point) {
+    const font = Font;
+    let cache = font.cached_widths;
+    if (!cache) {
+      cache = Object.create(null);
+      font.cached_widths = cache;
+    }
+    const key = code + '/' + point;
+    let width = cache[key];
+    if (width === undefined) {
+      width = new Glyph(code, point).getMetrics().width;
+      cache[key] = width;
+    }
+    return width;
+  }
+
   /**
    * @constructor
    */

--- a/src/VexFlowPatch/src/tables.js
+++ b/src/VexFlowPatch/src/tables.js
@@ -659,7 +659,7 @@ Flow.getGlyphProps.duration_codes = {
   '1/2': {
     common: {
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'v53', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'v53', scale);
       },
       stem: false,
       stem_offset: 0,
@@ -699,7 +699,7 @@ Flow.getGlyphProps.duration_codes = {
   '1': {
     common: {
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'v1d', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'v1d', scale);
       },
       stem: false,
       stem_offset: 0,
@@ -739,7 +739,7 @@ Flow.getGlyphProps.duration_codes = {
   '2': {
     common: {
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'v81', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'v81', scale);
       },
       stem: true,
       stem_offset: 0,
@@ -780,7 +780,7 @@ Flow.getGlyphProps.duration_codes = {
   '4': {
     common: {
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'vb', scale);
       },
       stem: true,
       stem_offset: 0,
@@ -823,7 +823,7 @@ Flow.getGlyphProps.duration_codes = {
   '8': {
     common: {
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'vb', scale);
       },
       stem: true,
       stem_offset: 0,
@@ -870,7 +870,7 @@ Flow.getGlyphProps.duration_codes = {
     common: {
       beam_count: 2,
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'vb', scale);
       },
       stem: true,
       stem_offset: 0,
@@ -916,7 +916,7 @@ Flow.getGlyphProps.duration_codes = {
     common: {
       beam_count: 3,
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'vb', scale);
       },
       stem: true,
       stem_offset: 0,
@@ -962,7 +962,7 @@ Flow.getGlyphProps.duration_codes = {
     common: {
       beam_count: 4,
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'vb', scale);
       },
       stem: true,
       stem_offset: 0,
@@ -1008,7 +1008,7 @@ Flow.getGlyphProps.duration_codes = {
     common: {
       beam_count: 5,
       getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
-        return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
+        return Glyph.cachedWidth(this.code_head || 'vb', scale);
       },
       stem: true,
       stem_offset: 0,


### PR DESCRIPTION
Flow.getGlyphProps' duration codes compute note widths as new Glyph(code, scale).getMetrics().width, allocating a throwaway Glyph on every call. The formatter queries these constantly: one render of Gounod (1949 notes) constructs ~89,000 Glyphs across only 15 distinct (code, point) pairs -- the 'vb'/39 notehead ~79,000 times alone.

getMetrics().width is the cached bbox width (#1704), a pure function of (code, point), so memoize it on the font next to cached_outline / cached_bboxes. The nine width call sites now go through Glyph.cachedWidth().

Byte-identical output (317/317 test/data samples produce identical SVG; 365 unit tests pass). render() is ~5% faster on medium/large scores, up to ~10% (Joplin, Cornelius, Actor). Independent of #1704 and stacks with it.

## Summary

The note-width tables (`Flow.getGlyphProps` duration codes) compute a glyph's width like this:

```js
getWidth(scale = Flow.DEFAULT_NOTATION_FONT_SCALE) {
  return new Glyph(this.code_head || 'vb', scale).getMetrics().width;
}
```

— a throwaway `Glyph` allocation on every call, with no memoization. The formatter queries these widths constantly. Instrumenting the `Glyph` constructor shows the scale of the redundancy for a single render:

| Score | Notes | `new Glyph()` calls | distinct `(code, point)` | most-built glyph |
|---|---:|---:|---:|---|
| Gounod – Meditation | 1949 | ~88,900 | 15 | `vb`/39 ~79,000× |
| ActorPreludeSample | 2188 | ~157,600 | 19 | `vb`/39 ~121,600× |

The same handful of glyphs are rebuilt tens of thousands of times. `getMetrics().width` is `this.bbox.getW()` — the cached bbox width from #1704 — a pure function of `(code, point)`, so it is safe to memoize.

## Fix

A static `Glyph.cachedWidth(code, point)` that caches the width on the font object, next to `cached_outline` / `cached_bboxes`:

```js
static cachedWidth(code, point) {
  const font = Font;
  let cache = font.cached_widths;
  if (!cache) { cache = Object.create(null); font.cached_widths = cache; }
  const key = code + '/' + point;
  let width = cache[key];
  if (width === undefined) {
    width = new Glyph(code, point).getMetrics().width;
    cache[key] = width;
  }
  return width;
}
```

The nine `new Glyph(...).getMetrics().width` sites in `tables.js` now call `Glyph.cachedWidth(...)`. The ~89k constructions per render collapse to the 15 distinct pairs (built once, then cache hits).

## Numbers

Median of 7 interleaved renders (before/after back-to-back per sample), Node + jsdom, production build, Endless page:

| Score | Notes | Before | After | Improvement |
|---|---:|---:|---:|---:|
| Joplin – The Entertainer | 1715 | 208 ms | 186 ms | 10.6% |
| Cornelius – Christbaum Op. 8/1 | 854 | 158 ms | 141 ms | 10.6% |
| Telemann Sonate Nr.1.1 – Dolce | 635 | 111 ms | 101 ms | 8.6% |
| Bach – Air | 543 | 92 ms | 85 ms | 7.8% |
| ActorPreludeSample | 2188 | 809 ms | 746 ms | 7.7% |
| Telemann Sonate Nr.1.2 – Allegro | 911 | 148 ms | 139 ms | 6.3% |

Whole corpus ~4.4% faster; median 4.7% (≥300 notes), 4.9% (≥1000 notes). Because #1704 already cached the expensive bbox computation, the remaining per-construction cost is allocation/constructor overhead — which this removes, along with the GC pressure it created.

## Verification

- **Byte-identical output:** all 317 `test/data` samples produce identical SVG before vs. after (per-page FNV-1a hash).
- **Visual regression tests:** clean.
- **`npm test`:** 365 passing, 2 skipped (unchanged); `eslint` clean.

Independent of #1704 (which caches the bbox); this caches the width lookup that reads it. The two stack.

## Note on the cache location

`cached_widths` lives on the font object, so it is shared across OSMD instances — the same pattern #1704 uses for `cached_bboxes`. This is safe (a glyph's width is a pure function of `(code, point, font)`, and the cache is keyed per font object) and is a small net win when several OSMD instances share a page: the cache is populated once in aggregate rather than once per instance. If per-instance isolation is preferred later, both caches (`cached_bboxes` and `cached_widths`) can be moved onto `EngravingRules` together. But I think the cross-instance speedup is a fair tradeoff for now for missing isolation.
