### PR TITLE
perf(Glyph): cache scaled glyph outline segments for drawing - median 2.5% speedup, 9% for largest score

### DIFF
--- a/src/VexFlowPatch/src/glyph.js
+++ b/src/VexFlowPatch/src/glyph.js
@@ -38,6 +38,36 @@ function processOutline(outline, originX, originY, scaleX, scaleY, outlineFns) {
   }
 }
 
+// VexFlowPatch: cache of a glyph outline's scaled, origin-relative path segments, keyed by the
+// outline array (already cached per glyph code) and scale. Glyph.renderOutline replays these with
+// just an add per point, instead of re-walking and re-coercing the outline string array (the
+// outline is stored as strings) on every draw. WeakMap so entries vanish if the outline is GC'd.
+const glyphSegmentCache = new WeakMap();
+
+function getScaledGlyphSegments(outline, scale) {
+  let byScale = glyphSegmentCache.get(outline);
+  if (!byScale) {
+    byScale = new Map();
+    glyphSegmentCache.set(outline, byScale);
+  }
+  let segments = byScale.get(scale);
+  if (!segments) {
+    segments = [];
+    // Record with origin 0,0 so the captured coordinates are purely scale*point (matching what
+    // renderOutline's per-point `x_pos + ...` / `y_pos + ...` would add the position to). Same
+    // scaleX/scaleY (scale, -scale) and consumption order as the original processOutline walk,
+    // so replaying produces byte-identical absolute coordinates.
+    processOutline(outline, 0, 0, scale, -scale, {
+      m: (x, y) => segments.push(['m', x, y]),
+      l: (x, y) => segments.push(['l', x, y]),
+      q: (x1, y1, x, y) => segments.push(['q', x1, y1, x, y]),
+      b: (x1, y1, x2, y2, x, y) => segments.push(['b', x1, y1, x2, y2, x, y]),
+    });
+    byScale.set(scale, segments);
+  }
+  return segments;
+}
+
 export class Glyph extends Element {
   /* Static methods used to implement loading / unloading of glyphs */
   static loadMetrics(font, code, cache) {
@@ -102,12 +132,19 @@ export class Glyph extends Element {
     }
     ctx.beginPath();
     ctx.moveTo(x_pos, y_pos);
-    processOutline(outline, x_pos, y_pos, scale, -scale, {
-      m: ctx.moveTo.bind(ctx),
-      l: ctx.lineTo.bind(ctx),
-      q: ctx.quadraticCurveTo.bind(ctx),
-      b: ctx.bezierCurveTo.bind(ctx),
-    });
+    // VexFlowPatch: replay cached scaled segments (position added per point) instead of re-walking
+    // and re-coercing the outline string array on every draw. Produces byte-identical coordinates.
+    const segments = getScaledGlyphSegments(outline, scale);
+    for (let i = 0; i < segments.length; i++) {
+      const s = segments[i];
+      switch (s[0]) {
+        case 'm': ctx.moveTo(x_pos + s[1], y_pos + s[2]); break;
+        case 'l': ctx.lineTo(x_pos + s[1], y_pos + s[2]); break;
+        case 'q': ctx.quadraticCurveTo(x_pos + s[1], y_pos + s[2], x_pos + s[3], y_pos + s[4]); break;
+        case 'b': ctx.bezierCurveTo(x_pos + s[1], y_pos + s[2], x_pos + s[3], y_pos + s[4], x_pos + s[5], y_pos + s[6]); break;
+        default: break;
+      }
+    }
     ctx.fill();
   }
 


### PR DESCRIPTION
Glyph.renderOutline walked the glyph outline on every draw, re-coercing and re-scaling each point (the outline is stored as a string array) and allocating four bound context methods per call. The scaled, origin-relative segments are constant per (outline, scale), so cache them once (keyed by the outline array and scale) and replay them, adding the draw position per point. This is the draw-time counterpart to #1704/#1712, which cache the bbox and width used during formatting.

Byte-identical output: the replayed coordinates are the same floats the walk produced, so all 317 test/data samples render identical SVG. render() is ~2.3% faster on medium/large scores, up to ~9% on glyph-dense scores (ActorPreludeSample 9.0%, Gounod 7.3%).

## Summary

`Glyph.renderOutline` draws a glyph by walking its outline and emitting path commands to the render context:

```js
processOutline(outline, x_pos, y_pos, scale, -scale, {
  m: ctx.moveTo.bind(ctx),
  l: ctx.lineTo.bind(ctx),
  q: ctx.quadraticCurveTo.bind(ctx),
  b: ctx.bezierCurveTo.bind(ctx),
});
```

This runs on **every** glyph draw. The outline is stored as a string array (`glyph.o.split(' ')`), so each point is re-coerced from string to number and re-multiplied by the scale, and four bound context methods are allocated per call. But the scaled, origin-relative coordinates are constant per `(outline, scale)` - only the draw position `(x_pos, y_pos)` changes.

This is the draw-time counterpart to #1704 and #1712, which cache the bbox and the width used during *formatting*; the same few dozen glyph shapes are re-walked thousands of times per render here too.

## Fix

Cache the scaled, origin-relative segments per `(outline, scale)` (keyed on the outline array, which is itself cached per glyph code, via a `WeakMap`), then replay them, adding the draw position per point:

```js
const segments = getScaledGlyphSegments(outline, scale); // built once per (outline, scale)
for (let i = 0; i < segments.length; i++) {
  const s = segments[i];
  switch (s[0]) {
    case 'm': ctx.moveTo(x_pos + s[1], y_pos + s[2]); break;
    case 'l': ctx.lineTo(x_pos + s[1], y_pos + s[2]); break;
    case 'q': ctx.quadraticCurveTo(x_pos + s[1], y_pos + s[2], x_pos + s[3], y_pos + s[4]); break;
    case 'b': ctx.bezierCurveTo(x_pos + s[1], y_pos + s[2], x_pos + s[3], y_pos + s[4], x_pos + s[5], y_pos + s[6]); break;
  }
}
```

The segments are recorded by running the existing `processOutline` once with origin `0,0` and the same `scale, -scale`, so the replayed absolute coordinates (`x_pos + relX`, `y_pos + relY`) are the same floats the walk produced - byte-identical. The `ctx.drawCachedGlyphOutline` skyline fast path is untouched.

## Numbers

Median of 7 interleaved renders (before/after back-to-back per sample), Node + jsdom, production build, Endless page:

| Score | Notes | Before | After | Improvement |
|---|---:|---:|---:|---:|
| ActorPreludeSample | 2188 | 858 ms | 780 ms | 9.0% |
| Gounod – Meditation | 1949 | 464 ms | 430 ms | 7.3% |
| Joplin – Elite Syncopations | 1388 | 180 ms | 173 ms | 4.1% |
| Schubert – An die Musik | 626 | 77 ms | 74 ms | 3.4% |
| Clementi – Sonatina 36/3 Pt.1 | 1047 | 154 ms | 149 ms | 3.1% |
| Joplin – The Entertainer | 1715 | 196 ms | 191 ms | 2.6% |

Whole corpus ~2.4%; median 2.3% (≥300 notes), 2.6% (≥1000 notes). The gain tracks glyph density - the densest scores (Actor, Gounod) draw the most glyphs and gain the most.

## Verification

- **Byte-identical output:** all 317 `test/data` samples produce identical SVG before vs. after (per-page FNV-1a hash).
- **Visual regression:** to be confirmed.
- **`npm test`:** 365 passing, 2 skipped (unchanged); `eslint` clean.

Independent of #1704/#1712 (which cache format-time values); this caches draw-time work, and stacks with them.

## Note: a larger, non-byte-identical alternative (not done here)

A bigger win is possible by emitting each glyph shape once into `<defs>` and referencing it with `<use x= y=>` per draw, cutting both path-string building and DOM size. It was **not** pursued because it changes the SVG structure (only *pixel*-identical, so it needs a visual-regression re-bless) and would likely break `setColor()` - `getNoteheadSVGs()` looks for notehead `<path>` elements, which would become `<use>` elements. Worth revisiting only if the draw phase becomes the binding constraint; the cache above is the safe, byte-identical win.

