### PR TITLE
perf(SkyBottomLineCalculator): Remove per-render allocations in updateLines - 2-3% speedup in dense scores, 10-20% in skyline phase

### DIFF
--- a/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
+++ b/src/MusicalScore/Graphical/SkyBottomLineCalculator.ts
@@ -52,39 +52,62 @@ export class SkyBottomLineCalculator {
         }
 
         const arrayLength: number = Math.max(Math.ceil(this.StaffLineParent.PositionAndShape.Size.width * this.SamplingUnit), 1);
-        this.mSkyLine = [];
-        this.mBottomLine = [];
 
+        // Concatenate the per-measure sky/bottom line arrays (device-pixel resolution) into one array
+        // per line for the whole staffline. Preallocate and index-fill instead of push(...skyLine):
+        // the spread turns each measure's array into individual call arguments (allocating and, for
+        // wide measures, risking a call-stack overflow), and this runs for every staffline every render.
+        let concatLength: number = 0;
+        for (const { skyLine } of calculationResults) {
+            concatLength += skyLine.length;
+        }
+        const skyLineConcat: number[] = new Array(concatLength);
+        const bottomLineConcat: number[] = new Array(concatLength);
+        let writeIndex: number = 0;
         for (const { skyLine, bottomLine } of calculationResults) {
-            this.mSkyLine.push(...skyLine);
-            this.mBottomLine.push(...bottomLine);
+            for (let i: number = 0; i < skyLine.length; i++) {
+                skyLineConcat[writeIndex] = skyLine[i];
+                bottomLineConcat[writeIndex] = bottomLine[i];
+                writeIndex++;
+            }
         }
 
         // Subsampling:
         // The pixel width is bigger than the measure size in units. So we split the array into
-        // chunks with the size of MeasurePixelWidth/measureUnitWidth and reduce the value to its
-        // average
-        const arrayChunkSize: number = this.mSkyLine.length / arrayLength;
-
+        // chunks with the size of MeasurePixelWidth/measureUnitWidth and reduce each chunk to its
+        // extreme (min for the skyline, max for the bottom line).
+        // The reduction is an in-place scan instead of slice(chunk) + Math.min(...chunk): the old form
+        // allocated a small array and spread it into a call for every one of the (tens of thousands of)
+        // chunks per render. The scanned column range is identical to the old slice(chunkIndex, endIndex + 1)
+        // range - Array.slice truncates its float bounds toward zero, which Math.trunc reproduces - so the
+        // subsampled values are unchanged (min/max are order- and duplicate-independent).
+        const arrayChunkSize: number = concatLength / arrayLength;
         const subSampledSkyLine: number[] = [];
         const subSampledBottomLine: number[] = [];
-        for (let chunkIndex: number = 0; chunkIndex < this.mSkyLine.length; chunkIndex += arrayChunkSize) {
+        for (let chunkIndex: number = 0; chunkIndex < concatLength; chunkIndex += arrayChunkSize) {
             if (subSampledSkyLine.length === arrayLength) {
                 break; // TODO find out why skyline.length becomes arrayLength + 1. see log.debug below
             }
 
-            const endIndex: number = Math.min(this.mSkyLine.length, chunkIndex + arrayChunkSize);
-            let chunk: number[] = this.mSkyLine.slice(chunkIndex, endIndex + 1); // slice does not include end index
-            // TODO chunkIndex + arrayChunkSize is sometimes bigger than this.mSkyLine.length -> out of bounds
-            // TODO chunkIndex + arrayChunkSize is often a non-rounded float as well. is that ok to use with slice?
-            /*const diff: number = this.mSkyLine.length - (chunkIndex + arrayChunkSize);
-            if (diff < 0) { // out of bounds
-                console.log("length - slice end index: " + diff);
-            }*/
+            const endIndex: number = Math.min(concatLength, chunkIndex + arrayChunkSize);
+            const startColumn: number = Math.trunc(chunkIndex); // slice(chunkIndex, ...) truncates the start toward zero
+            let endColumn: number = Math.trunc(endIndex + 1); // slice's end is exclusive; "+ 1" mirrors the old endIndex + 1
+            if (endColumn > concatLength) {
+                endColumn = concatLength;
+            }
 
-            subSampledSkyLine.push(Math.min(...chunk));
-            chunk = this.mBottomLine.slice(chunkIndex, endIndex + 1); // slice does not include end index
-            subSampledBottomLine.push(Math.max(...chunk));
+            let skyLineMin: number = Number.POSITIVE_INFINITY;
+            let bottomLineMax: number = Number.NEGATIVE_INFINITY;
+            for (let column: number = startColumn; column < endColumn; column++) {
+                if (skyLineConcat[column] < skyLineMin) {
+                    skyLineMin = skyLineConcat[column];
+                }
+                if (bottomLineConcat[column] > bottomLineMax) {
+                    bottomLineMax = bottomLineConcat[column];
+                }
+            }
+            subSampledSkyLine.push(skyLineMin);
+            subSampledBottomLine.push(bottomLineMax);
         }
 
         this.mSkyLine = subSampledSkyLine;
@@ -93,12 +116,29 @@ export class SkyBottomLineCalculator {
             log.debug(`SkyLine calculation was not correct (${this.mSkyLine.length} instead of ${arrayLength})`);
         }
 
-        // Remap the values from 0 to +/- height in units
-        const lowestSkyLine: number = Math.max(...this.mSkyLine);
-        this.mSkyLine = this.mSkyLine.map(v => (v - lowestSkyLine) / unitInPixels + this.StaffLineParent.TopLineOffset);
+        // Remap the values from 0 to +/- height in units. The extremes are found with a scan instead of
+        // Math.max(...array) (which spreads the whole array into a call), and the remap is done in place.
+        let lowestSkyLine: number = Number.NEGATIVE_INFINITY;
+        for (let i: number = 0; i < subSampledSkyLine.length; i++) {
+            if (subSampledSkyLine[i] > lowestSkyLine) {
+                lowestSkyLine = subSampledSkyLine[i];
+            }
+        }
+        const topLineOffset: number = this.StaffLineParent.TopLineOffset;
+        for (let i: number = 0; i < subSampledSkyLine.length; i++) {
+            subSampledSkyLine[i] = (subSampledSkyLine[i] - lowestSkyLine) / unitInPixels + topLineOffset;
+        }
 
-        const highestBottomLine: number = Math.min(...this.mBottomLine);
-        this.mBottomLine = this.mBottomLine.map(v => (v - highestBottomLine) / unitInPixels + this.StaffLineParent.BottomLineOffset);
+        let highestBottomLine: number = Number.POSITIVE_INFINITY;
+        for (let i: number = 0; i < subSampledBottomLine.length; i++) {
+            if (subSampledBottomLine[i] < highestBottomLine) {
+                highestBottomLine = subSampledBottomLine[i];
+            }
+        }
+        const bottomLineOffset: number = this.StaffLineParent.BottomLineOffset;
+        for (let i: number = 0; i < subSampledBottomLine.length; i++) {
+            subSampledBottomLine[i] = (subSampledBottomLine[i] - highestBottomLine) / unitInPixels + bottomLineOffset;
+        }
     }
 
     /**


### PR DESCRIPTION
updateLines() runs once per staff line of every render and is the most allocation-heavy step of the skyline calculation (the largest layout sub-phase). Its work is pure array arithmetic, so the allocations were the cost: push(...skyLine) per measure, a slice(...) + Math.min(...chunk) per sub-sample chunk (tens of thousands per render), Math.max(...array) over the whole line, and two .map() passes.

Same algorithm, no per-element allocations: concatenate by index-fill, sub-sample each chunk with an in-place min/max scan, and remap in place. Array.slice truncates its float bounds toward zero, which Math.trunc reproduces, so the scanned column range - and every sub-sampled value - is unchanged (min/max are order- and duplicate-independent).

Byte-identical SVG on all 316 renderable test/data samples (both the geometric and raster skyline paths). updateLines itself is 6-10x faster; the skyline-calculation phase is 11-21% faster; ~2-3% of total render on the densest scores. Also removes the spreads that could throw RangeError on a very wide staff line.

## Summary

`SkyBottomLineCalculator.updateLines()` runs once per staff line of every render (it turns each
measure's per-pixel sky/bottom line into the sub-sampled, unit-space line for the staff line). It is
the single most allocation-heavy step of the skyline calculation — the biggest layout sub-phase — and
its work is pure array arithmetic, so the allocations are the cost:

- `this.mSkyLine.push(...skyLine)` per measure — spreads each measure's array into call arguments.
- `this.mSkyLine.slice(chunkIndex, endIndex + 1)` then `Math.min(...chunk)` **per sub-sample chunk** —
  one small-array allocation *and* one spread call for every ~3.3 device pixels of the whole score
  (tens of thousands of chunks per render).
- `Math.max(...this.mSkyLine)` / `Math.min(...this.mBottomLine)` — spread the whole array into a call.
- two `.map(...)` — allocate two more arrays for the unit-space remap.

## Fix

Same algorithm, no per-element allocations:

- **Concatenate** by pre-computing the total length and index-filling two arrays, instead of
  `push(...spread)`.
- **Sub-sample** each chunk with an in-place min/max scan instead of `slice(...)` + `Math.min(...chunk)`.
  `Array.slice` truncates its float bounds toward zero, which `Math.trunc` reproduces, so the scanned
  column range — and therefore every sub-sampled value — is **exactly** the same (`min`/`max` are order-
  and duplicate-independent).
- **Remap** in place, finding the extremes with a scan instead of `Math.max(...array)`.

As a side benefit this removes the spreads that can throw `RangeError: Maximum call stack size exceeded`
for a very wide staff line (`Math.min(...)` / `push(...)` on an array of >~10⁵ elements), which a large
zoom or a long single-system score could reach.

## Numbers

Node + jsdom, production build, Endless page. Baseline = current `develop` (with #1711/#1712/#1713
merged); "after" = this commit rebased on top of it. Interleaved (before/after back-to-back per sample).

**`updateLines()` self-time** (median of 15 warm renders) — the function itself:

| Score | Notes | before | after | speedup |
|---|---:|---:|---:|---:|
| ActorPreludeSample | 2188 | 28.6 ms | 3.7 ms | **7.8×** |
| Gounod – Meditation | 1949 | 14.5 ms | 1.7 ms | **8.8×** |
| Haydn – ConcertanteCello | 1473 | 3.2 ms | 0.5 ms | 6.0× |
| Joplin – The Entertainer | 1715 | 2.2 ms | 0.4 ms | 6.0× |

**Skyline-calculation phase and whole render** (`calculateSkyBottomLines` and `render()`, min of 21
interleaved renders, one run):

| Score | Notes | skyline before | skyline after | **skyline** | **total render** |
|---|---:|---:|---:|---:|---:|
| Gounod – Meditation | 1949 | 58.0 ms | 46.9 ms | **19.2%** | **+2.7%** |
| ActorPreludeSample | 2188 | 135.7 ms | 113.8 ms | **16.1%** | **+2.9%** |
| Clementi – Sonatina 36/3 Pt.1 | 1047 | 13.7 ms | 11.5 ms | 16.1% | +0.0% ◊ |
| Schubert – An die Musik | 626 | 5.4 ms | 4.6 ms | 14.6% | +0.6% ◊ |
| Joplin – The Entertainer | 1715 | 15.1 ms | 13.1 ms | 13.3% | −0.7% ◊ |
| Haydn – ConcertanteCello | 1473 | 23.4 ms | 21.1 ms | 9.8% | +0.1% ◊ |

◊ within measurement noise (±~1–2%). The skyline phase is **10–20% faster on every score** and is a
clean, reproducible signal; the total-render effect is not, because the skyline is only ~18.5% of
`render()` and `updateLines` within it is only ~1–1.5% of render for a typical score, rising to
~3.3–3.7% only for the two densest scores.

**Median total-render improvement** (21 real scores, min-time, interleaved):

- **All 21 scores: ≈0%** (−0.5% median; the effect is below the noise floor for a typical score, whose
  `updateLines` is ~1% of render).
- **Scores where `updateLines` is a significant cost (≥2% of render): ~2%** — in practice the two densest
  scores, Actor and Gounod, which reproduce at **+2.7–2.9%** across runs. This is where the skyline
  dominates render and the phase win surfaces end-to-end.

So the honest headline is the **skyline phase (10–20%) and the `updateLines` function (6–9×)**; end-to-end
this is a ~2–3% win on the densest scores and a neutral (within-noise), lower-allocation/GC change
elsewhere.

## Verification

- **Byte-identical output:** all 316 renderable `test/data` samples produce identical SVG before vs.
  after (per-page FNV-1a hash). The change is shared by the geometric (default) and raster skyline
  paths; both feed `updateLines` equal-length per-measure arrays, so both are unaffected.
- **`npm test`:** 365 passing, 2 skipped (unchanged); `eslint` clean.
- **Visual regression tests:** no diffs.

Independent of #1703/#1704/#1711/#1712 (a different phase — this is the skyline sub-sampling, not
glyph drawing/formatting) and stacks with them.
