### PR TITLE
perf(Formatter): Dedupe the duration key computation in evaluate()

### DIFF
--- a/src/VexFlowPatch/src/formatter.js
+++ b/src/VexFlowPatch/src/formatter.js
@@ -556,9 +556,14 @@ export class Formatter {
 
     this.voices.forEach(voice => {
       voice.getTickables().forEach((note, i, notes) => {
+        // VexFlowPatch: the duration key (getTicks().clone().simplify().toString()) is a pure
+        // function of the note but was recomputed in the deviation loop below - a Fraction clone +
+        // simplify + string per note, twice. Compute it once and stash it on the (persistent,
+        // per-Tickable) formatter metrics so the second loop can reuse it instead of recomputing.
         const duration = note.getTicks().clone().simplify().toString();
         const metrics = note.getMetrics();
         const formatterMetrics = note.getFormatterMetrics();
+        formatterMetrics.duration = duration;
         const leftNoteEdge = note.getX() + metrics.noteWidth +
           metrics.modRightPx + metrics.extraRightPx;
         let space = 0;
@@ -587,11 +592,10 @@ export class Formatter {
     let totalDeviation = 0;
     this.voices.forEach(voice => {
       voice.getTickables().forEach((note) => {
-        const duration = note.getTicks().clone().simplify().toString();
         const metrics = note.getFormatterMetrics();
+        const duration = metrics.duration; // VexFlowPatch: reuse the key computed in the mean-spacing loop above
         metrics.iterations += 1;
         metrics.space.deviation = metrics.space.used - durationStats[duration].mean;
-        metrics.duration = duration;
         metrics.space.mean = durationStats[duration].mean;
 
         totalDeviation += Math.pow(durationStats[duration].mean, 2);


### PR DESCRIPTION
Small optimization saving a precomputed value for later, performance gain likely below significance threshold.

Formatter.evaluate() (VexFlowPatch) computed each note's duration key, note.getTicks().clone().simplify().toString() - a Fraction clone + simplify + string allocation - twice per note: once in the mean-spacing loop and again in the deviation loop. The key is a pure function of the note, so compute it once in the first loop and stash it on the note's persistent formatter metrics (getFormatterMetrics() returns the object created once in the Tickable ctor), then reuse it in the second loop. The value written to metrics.duration is unchanged, so output is byte-identical.