### PR TITLE
perf(IXmlElement): fewer DOM round trips while reading MusicXML. load -11% to -23%

### DIFF
--- a/src/Common/FileIO/Xml.ts
+++ b/src/Common/FileIO/Xml.ts
@@ -20,13 +20,15 @@ export class IXmlElement {
     /**
      * Wraps 'elem' Element in a IXmlElement
      * @param elem
+     * @param knownName the element's lower-cased node name, when the caller
+     * already matched on it - saves a DOM read and a toLowerCase() per wrapper
      */
-    constructor(elem: Element) {
+    constructor(elem: Element, knownName?: string) {
         if (!elem) {
             throw new Error("IXmlElement: expected Element, got undefined");
         }
         this.elem = elem;
-        this.name = elem.nodeName.toLowerCase();
+        this.name = knownName !== undefined ? knownName : elem.nodeName.toLowerCase();
 
         if (elem.hasAttributes()) {
             this.hasAttributes = true;
@@ -34,8 +36,9 @@ export class IXmlElement {
         }
         this.hasElements = elem.hasChildNodes();
         // Look for a value
-        if (elem.childNodes.length === 1 && elem.childNodes[0].nodeType === Node.TEXT_NODE) {
-            this.value = elem.childNodes[0].nodeValue;
+        const first: Node = elem.firstChild;
+        if (first && !first.nextSibling && first.nodeType === Node.TEXT_NODE) {
+            this.value = first.nodeValue;
         } else {
             this.value = "";
         }
@@ -47,7 +50,7 @@ export class IXmlElement {
      * @returns {Attr}
      */
     public attribute(attributeName: string): IXmlAttribute {
-        return this.elem.attributes.getNamedItem(attributeName);
+        return this.elem.getAttributeNode(attributeName);
     }
 
     /**
@@ -72,11 +75,11 @@ export class IXmlElement {
      * @returns {IXmlElement}
      */
     public element(elementName: string): IXmlElement {
-        const nodes: NodeList = this.elem.childNodes;
-        for (let i: number = 0, length: number = nodes.length; i < length; i += 1) {
-            const node: Node = nodes[i];
-            if (node.nodeType === Node.ELEMENT_NODE && node.nodeName.toLowerCase() === elementName) {
-                return new IXmlElement(node as Element);
+        for (let node: Element = this.elem.firstElementChild; node; node = node.nextElementSibling) {
+            if (node.nodeName.toLowerCase() === elementName) {
+                // A match means elementName IS the lower-cased node name, so it
+                // can stand in for the name the wrapper would recompute.
+                return new IXmlElement(node, elementName);
             }
         }
     }
@@ -87,18 +90,16 @@ export class IXmlElement {
      * @returns {IXmlElement[]}
      */
     public elements(nodeName?: string): IXmlElement[] {
-        const nodes: NodeList = this.elem.childNodes;
         const ret: IXmlElement[] = [];
         const nameUnset: boolean = !nodeName;
         if (!nameUnset) {
             nodeName = nodeName.toLowerCase();
         }
-        for (let i: number = 0; i < nodes.length; i += 1) {
-            const node: Node = nodes[i];
-            if (node.nodeType === Node.ELEMENT_NODE &&
-                (nameUnset || node.nodeName.toLowerCase() === nodeName)
-            ) {
-                ret.push(new IXmlElement(node as Element));
+        for (let node: Element = this.elem.firstElementChild; node; node = node.nextElementSibling) {
+            if (nameUnset) {
+                ret.push(new IXmlElement(node));
+            } else if (node.nodeName.toLowerCase() === nodeName) {
+                ret.push(new IXmlElement(node, nodeName));
             }
         }
         return ret;
@@ -112,26 +113,23 @@ export class IXmlElement {
      * @returns {IXmlElement}
      */
     public combinedElement(elementName: string): IXmlElement {
-        const nodes: NodeList = this.elem.childNodes;
-        if (nodes.length > 0) {
-            let firstNode: Node;
-            for (let i: number = 0, length: number = nodes.length; i < length; i += 1) {
-                const otherNode: Node = nodes[i];
-                if (otherNode.nodeType === Node.ELEMENT_NODE && otherNode.nodeName.toLowerCase() === elementName) {
-                    if (firstNode) {
-                        const childNodes: NodeList = otherNode.childNodes;
-                        for (let j: number = 0, numChildNodes: number = childNodes.length; j < numChildNodes; j += 1) {
-                            const childNode: Node = childNodes[j];
-                            firstNode.appendChild(childNode.cloneNode(true));
-                        }
-                    } else {
-                        firstNode = otherNode;
-                    }
-                }
+        let firstNode: Element;
+        for (let otherNode: Element = this.elem.firstElementChild; otherNode; otherNode = otherNode.nextElementSibling) {
+            if (otherNode.nodeName.toLowerCase() !== elementName) {
+                continue;
             }
-            if (firstNode) {
-                return new IXmlElement(firstNode as Element);
+            if (!firstNode) {
+                firstNode = otherNode;
+                continue;
             }
+            const childNodes: NodeList = otherNode.childNodes;
+            for (let j: number = 0, numChildNodes: number = childNodes.length; j < numChildNodes; j += 1) {
+                const childNode: Node = childNodes[j];
+                firstNode.appendChild(childNode.cloneNode(true));
+            }
+        }
+        if (firstNode) {
+            return new IXmlElement(firstNode, elementName);
         }
     }
 }


### PR DESCRIPTION
`osmd.load()` spends roughly a quarter of its self time in `IXmlElement`, nearly all of it in DOM calls rather than in JS. Three changes, none of which alters what any method returns.

**Walk elements instead of all child nodes.** `element()`, `elements()` and `combinedElement()` index `childNodes` and check `nodeType`; they now use `firstElementChild` / `nextElementSibling`. Counted on `ActorPreludeSample.xml`: 72,678 `element()` calls and 24,043 `elements()` calls, visiting 456,821 child nodes between them — 4.7 per call, and double that when the file keeps its indentation.

**Pass the matched name to the wrapper.** The caller has already compared `nodeName.toLowerCase()` against the name it wants, and the wrapper then reads and folds `nodeName` again. A match means the queried name *is* the folded node name, so it can be handed over instead. The new constructor parameter is optional, and it is the only `.d.ts` change.

**`attribute()` uses `getAttributeNode()`** rather than going through `attributes.getNamedItem()`. Equivalent here, since `load()` parses as `application/xml`.

(The text-value check also reads `firstChild` / `nextSibling` instead of touching `childNodes` three times.)

## Numbers

Headless Chrome, alternating order, median of 13 rounds, `osmd.load()` only:

| score | load |
|---|---|
| `Land_der_Berge.musicxml` | 60 → 46 ms (**−23.0%**) |
| `JosephHaydn_ConcertanteCello.xml` | 231 → 192 ms (**−17.2%**) |
| `ScottJoplin_EliteSyncopations.xml` | 134 → 112 ms (**−16.8%**) |
| `ActorPreludeSample.xml` | 362 → 315 ms (**−13.0%**) |
| `CharlesGounod_Meditation.xml` | 264 → 233 ms (**−11.5%**) |
| `Schubert_An_die_Musik.xml` | 63 → 56 ms (**−11.0%**) |

One caveat on reproducing these: the input is minified (`>\s+<` → `><`), which is what our app hands OSMD. Run against `test/data` as-is, the walk change looks about twice this good, because the indentation puts a text node between every pair of tags.

`render()` is untouched and does not move. On a phone the win is the same size: in our app (Android WebView, Pixel 4a, profile build, APK swapped every round with the order flipped, n=4 per side) load goes 1420 → 1232 ms on a 6-part score and 1487 → 1238 ms on a 22-part one, with the raw per-run ranges not overlapping. Those runs carried one extra change that later measured as nothing; it is not in this PR.

## Verification

All 301 scores in `test/data`, rendered before and after, compared on the serialised SVG (FNV-1a over the markup, with the running `vf-auto####` ids normalised away) and on every laid-out staff entry's `RelativePosition` plus every note's border box:

- Geometry: identical on all 301.
- SVG: identical on all 301.
- `npm test`: 364 pass. The `SlurFlattenToObstacle` failure under Chrome Headless is there without this change too, with values identical to 15 decimals (`2.968493061845972` either way).

## Tried, didn't pay

Two things I measured and dropped, in case they come up:

**Deferring `hasAttributes` / `firstAttribute` / `hasElements` to first access.** The constructor reads those three plus the text value up front, and the three are read in about 25 places in total — but making them lazy came out at zero: faster on three of the six scores above, slower on the other three, and on the Pixel 4a 1260 vs 1276 ms and 1237 vs 1257 ms with overlapping ranges. `value` is the one field where it could have paid, and nearly every wrapper is asked for it. So all three stay plain fields and the public shape is unchanged.

**Testing `nodeName === elementName` before folding the case.** It changes behaviour — `element("Note")` matches nothing today and would start matching `<Note>` — and it measured at zero anyway, since the fold still runs for every sibling that does not match, which is most of them at 4.7 children per call.
