### PR TITLE
feat: add rehearsal mark metronome offset

### DIFF
--- a/src/MusicalScore/Graphical/EngravingRules.ts
+++ b/src/MusicalScore/Graphical/EngravingRules.ts
@@ -175,6 +175,8 @@ export class EngravingRules {
     public RehearsalMarkXOffsetSystemStartMeasure: number;
     public RehearsalMarkYOffset: number;
     public RehearsalMarkYOffsetDefault: number;
+    /** y offset for rehearsal marks in measures that also contain a metronome mark. */
+    public RehearsalMarkYOffsetWithMetronome: number;
     /** y offset added to avoid collisions of rehearsal marks (e.g. "A" or "Verse") with multiple measure rest numbers. */
     public RehearsalMarkYOffsetAddedForRehearsalMarks: number;
     public RehearsalMarkFontSize: number;
@@ -800,6 +802,7 @@ export class EngravingRules {
         this.RehearsalMarkXOffset = 0; // user defined
         this.RehearsalMarkXOffsetSystemStartMeasure = -20; // good test: Haydn Concertante
         this.RehearsalMarkYOffsetDefault = -15;
+        this.RehearsalMarkYOffsetWithMetronome = 0;
         this.RehearsalMarkYOffsetAddedForRehearsalMarks = -12;
         this.RehearsalMarkYOffset = 0; // user defined
         this.RehearsalMarkFontSize = 10; // vexflow default: 12, too big with chord symbols

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator.ts
@@ -1117,6 +1117,9 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
         continue;
       }
       let yOffset: number = -this.rules.RehearsalMarkYOffsetDefault - this.rules.RehearsalMarkYOffset;
+      if ((gMeasure as VexFlowMeasure).hasMetronomeMark) {
+        yOffset += this.rules.RehearsalMarkYOffsetWithMetronome;
+      }
       if (gMeasure.parentSourceMeasure.isReducedToMultiRest) {
         // we could add other conditions here where we want more offset to avoid collisions
         yOffset += this.rules.RehearsalMarkYOffsetAddedForRehearsalMarks;
@@ -2674,4 +2677,3 @@ export class VexFlowMusicSheetCalculator extends MusicSheetCalculator {
     }
   }
 }
-


### PR DESCRIPTION
> EDIT: Sorry, I didn't mean to create an upstream PR directly. I apologize for the noise. 

Rehearsal marks and metronome marks can share a measure but need application-specific vertical spacing. The existing rehearsal Y offset applies globally, which also moves marks that do not collide with a metronome mark.

This PR adds `RehearsalMarkYOffsetWithMetronome`, a neutral-by-default engraving rule applied only when the graphical measure contains a metronome mark. This lets consumers adjust the conflicting marks without changing rehearsal marks elsewhere in the score.