### PR TITLE
fix: include octave-change in PlaybackTranspose

### DIFF
--- a/src/MusicalScore/ScoreIO/InstrumentReader.ts
+++ b/src/MusicalScore/ScoreIO/InstrumentReader.ts
@@ -820,9 +820,15 @@ export class InstrumentReader {
     }
     const transposeNode: IXmlElement = attrNode.element("transpose");
     if (transposeNode) {
+      // MusicXML: sounding pitch = written pitch + chromatic + 12 * octave-change.
+      // E.g. Bb clarinet: chromatic -2. Bb tenor sax: chromatic -2, octave-change -1.
       const chromaticNode: IXmlElement = transposeNode.element("chromatic");
-      if (chromaticNode) {
-        this.instrument.PlaybackTranspose = parseInt(chromaticNode.value, 10);
+      const octaveChangeNode: IXmlElement = transposeNode.element("octave-change");
+      const chromatic: number = chromaticNode ? parseInt(chromaticNode.value, 10) : NaN;
+      const octaveChange: number = octaveChangeNode ? parseInt(octaveChangeNode.value, 10) : NaN;
+      if (!isNaN(chromatic) || !isNaN(octaveChange)) {
+        this.instrument.PlaybackTranspose =
+          (isNaN(chromatic) ? 0 : chromatic) + 12 * (isNaN(octaveChange) ? 0 : octaveChange);
       }
     }
     const clefList: IXmlElement[] = attrNode.elements("clef");

--- a/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
+++ b/test/MusicalScore/ScoreIO/MusicSheetReader_Test.ts
@@ -316,4 +316,33 @@ describe("Music Sheet Reader", () => {
             done();
         });
     });
+
+    describe("transpose octave-change", () => {
+        const filename: string = "test/data/test_transpose_octave_change.musicxml";
+        let transposeSheet: MusicSheet;
+
+        before((): void => {
+            const doc: Document = getSheet(filename);
+            expect(doc, filename + " should be preprocessed by karma").to.not.be.undefined;
+            const fileScore: IXmlElement = new IXmlElement(doc.getElementsByTagName("score-partwise")[0]);
+            transposeSheet = new MusicSheetReader().createMusicSheet(fileScore, filename);
+        });
+
+        // MusicXML: sounding pitch = written pitch + chromatic + 12 * octave-change.
+        // Only <chromatic> used to be read, so octave-transposing instruments were an octave off.
+        it("reads chromatic without octave-change unchanged (regression guard)", (done: Mocha.Done) => {
+            expect(transposeSheet.Instruments[0].PlaybackTranspose).to.equal(-2);
+            done();
+        });
+
+        it("adds 12 per octave-change (Bb tenor sax: chromatic -2, octave-change -1)", (done: Mocha.Done) => {
+            expect(transposeSheet.Instruments[1].PlaybackTranspose).to.equal(-14);
+            done();
+        });
+
+        it("reads octave-change without chromatic", (done: Mocha.Done) => {
+            expect(transposeSheet.Instruments[2].PlaybackTranspose).to.equal(12);
+            done();
+        });
+    });
 });

--- a/test/data/test_transpose_octave_change.musicxml
+++ b/test/data/test_transpose_octave_change.musicxml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Transpose octave-change test</work-title>
+  </work>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Bb Clarinet</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Bb Clarinet</instrument-name>
+      </score-instrument>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Bb Tenor Saxophone</part-name>
+      <score-instrument id="P2-I1">
+        <instrument-name>Bb Tenor Saxophone</instrument-name>
+      </score-instrument>
+    </score-part>
+    <score-part id="P3">
+      <part-name>Piccolo</part-name>
+      <score-instrument id="P3-I1">
+        <instrument-name>Piccolo</instrument-name>
+      </score-instrument>
+    </score-part>
+  </part-list>
+  <!-- P1: chromatic only (-2). Expected PlaybackTranspose: -2 -->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <!-- P2: chromatic (-2) plus octave-change (-1). Expected PlaybackTranspose: -14 -->
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          <octave-change>-1</octave-change>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <!-- P3: octave-change only (+1), no chromatic. Expected PlaybackTranspose: 12 -->
+  <part id="P3">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <octave-change>1</octave-change>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>5</octave></pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## Problem

MusicXML defines the sounding pitch of a transposing instrument as:

```
sounding pitch = written pitch + <chromatic> + 12 * <octave-change>
```

`InstrumentReader` only reads `<chromatic>` into `Instrument.PlaybackTranspose`, so the `<octave-change>` part of a `<transpose>` element is silently dropped. Instruments that transpose by a full octave in addition to their chromatic interval end up an octave off for playback consumers.

Concrete cases:

| Instrument | `<chromatic>` | `<octave-change>` | Expected | Current |
|---|---|---|---|---|
| Bb clarinet | -2 | — | -2 | -2 ✅ |
| Bb tenor sax | -2 | -1 | **-14** | -2 ❌ (sounds an octave too high) |
| Piccolo | — | +1 | **+12** | 0 ❌ |

Bass clarinet is affected the same way as tenor sax. Parts that carry only `<octave-change>` with no `<chromatic>` currently yield `0`, because the value is read inside an `if (chromaticNode)` branch.

This affects consumers that use `PlaybackTranspose` to derive sounding pitch (MIDI export, playback engines); the rendered notation itself is unchanged.

## Fix

Read both elements and combine them:

```ts
this.instrument.PlaybackTranspose =
  (isNaN(chromatic) ? 0 : chromatic) + 12 * (isNaN(octaveChange) ? 0 : octaveChange);
```

Parts with only `<chromatic>` keep exactly their previous value, so existing scores are unaffected. The assignment now also runs when only `<octave-change>` is present.

## Tests

Adds `test/data/test_transpose_octave_change.musicxml` with three parts covering all cases, and three assertions in `MusicSheetReader_Test.ts`:

- chromatic only → `-2` (regression guard: previous behaviour preserved)
- chromatic + octave-change → `-14`
- octave-change only → `+12`

The fixture is picked up automatically by the existing `test/data/*.musicxml` karma pattern.

## Note on an unrelated test failure

When running the suite locally (macOS, Chrome 151, ChromeHeadless) one unrelated test fails:

```
widest slur's flattened arc (3.0) should be far below unflattened (4.6):
expected 3.0405566236394037 to be below 3.0012267258723133
```

This is **not caused by this PR**. It reproduces on a clean checkout of the base commit, and also on `08379287` — the commit that introduced that test — with a bit-identical value. It looks environment-dependent (the flattening does work: 4.6 → 3.04, a 34% reduction against an asserted 35%), so it presumably passes on CI. Mentioning it only so it is not mistaken for fallout from this change; happy to open a separate issue if it is useful.
