### PR TITLE
feat(Fingering): Link each fingering label to its note (GraphicalLabel.sourceNote)

### DIFF
--- a/src/MusicalScore/Graphical/GraphicalLabel.ts
+++ b/src/MusicalScore/Graphical/GraphicalLabel.ts
@@ -24,8 +24,9 @@ export class GraphicalLabel extends Clickable {
     /** The note this label was created for, if any. Set for fingerings (GraphicalStaffEntry.FingeringEntries),
      *  which are stacked in the pitch order of their notes rather than the order they were read in,
      *  so that the note a fingering belongs to can be told without re-deriving that order.
+     *  Named like GraphicalNote.sourceNote, which holds the same kind of reference.
      */
-    public SourceNote: Note;
+    public sourceNote: Note;
 
     /**
      * Creates a new GraphicalLabel from a Label

--- a/src/MusicalScore/Graphical/GraphicalLabel.ts
+++ b/src/MusicalScore/Graphical/GraphicalLabel.ts
@@ -1,5 +1,6 @@
 import { TextAlignmentEnum } from "../../Common/Enums/TextAlignment";
 import { Label } from "../Label";
+import { Note } from "../VoiceData/Note";
 import { BoundingBox } from "./BoundingBox";
 import { Clickable } from "./Clickable";
 import { EngravingRules } from "./EngravingRules";
@@ -20,6 +21,11 @@ export class GraphicalLabel extends Clickable {
     /** Read-only informational variable only set once by lyrics centering algorithm. */
     public CenteringXShift: number = 0;
     public ColorXML: string;
+    /** The note this label was created for, if any. Set for fingerings (GraphicalStaffEntry.FingeringEntries),
+     *  which are stacked in the pitch order of their notes rather than the order they were read in,
+     *  so that the note a fingering belongs to can be told without re-deriving that order.
+     */
+    public SourceNote: Note;
 
     /**
      * Creates a new GraphicalLabel from a Label

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3390,7 +3390,7 @@ export abstract class MusicSheetCalculator {
                             gLabel.PositionAndShape.RelativePosition.x = staffEntryPositionX;
                             gLabel.setLabelPositionAndShapeBorders();
                             gLabel.PositionAndShape.calculateBoundingBox();
-                            gLabel.SourceNote = fingering.sourceNote;
+                            gLabel.sourceNote = fingering.sourceNote;
                             gse.FingeringEntries.push(gLabel);
                             const start: number = gLabel.PositionAndShape.RelativePosition.x + gLabel.PositionAndShape.BorderLeft;
                             //start -= line.PositionAndShape.RelativePosition.x;

--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -3390,6 +3390,7 @@ export abstract class MusicSheetCalculator {
                             gLabel.PositionAndShape.RelativePosition.x = staffEntryPositionX;
                             gLabel.setLabelPositionAndShapeBorders();
                             gLabel.PositionAndShape.calculateBoundingBox();
+                            gLabel.SourceNote = fingering.sourceNote;
                             gse.FingeringEntries.push(gLabel);
                             const start: number = gLabel.PositionAndShape.RelativePosition.x + gLabel.PositionAndShape.BorderLeft;
                             //start -= line.PositionAndShape.RelativePosition.x;

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -350,9 +350,9 @@ describe("VexFlow Measure", () => {
 
    // A fingering label is stacked in the pitch order of its note, which is not the order the
    // fingerings were read in, so the label's index in FingeringEntries says nothing about which
-   // note it belongs to. GraphicalLabel.SourceNote carries that link, letting a consumer find the
+   // note it belongs to. GraphicalLabel.sourceNote carries that link, letting a consumer find the
    // note a rendered fingering was created for (e.g. to edit or re-position a single label).
-   it("Links each fingering label to the note it was created for (GraphicalLabel.SourceNote)", (done: Mocha.Done) => {
+   it("Links each fingering label to the note it was created for (GraphicalLabel.sourceNote)", (done: Mocha.Done) => {
       const score: Document = TestUtils.getScore("test_fingering_two_voices_pitch_order.musicxml");
       if (!score) {
          done(new Error("Score file not found"));
@@ -368,7 +368,7 @@ describe("VexFlow Measure", () => {
             const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, staffIndex);
             return gm.staffEntries[entryIndex].FingeringEntries
                .map((label: GraphicalLabel) =>
-                  `${label.SourceNote.Pitch.ToStringShort(Pitch.OctaveXmlDifference)}=${label.Label.text}`);
+                  `${label.sourceNote.Pitch.ToStringShort(Pitch.OctaveXmlDifference)}=${label.Label.text}`);
          }
 
          // treble staff: chord G4/C5 in voice 1 (fingerings 3 and 5), lowest note in voice 2 (fingering 1),

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -25,7 +25,7 @@ import { Note } from "../../../../src/MusicalScore/VoiceData/Note";
 import { TabNote } from "../../../../src/MusicalScore/VoiceData/TabNote";
 import { PointF2D } from "../../../../src/Common/DataObjects/PointF2D";
 import { GraphicalTie } from "../../../../src/MusicalScore/Graphical/GraphicalTie";
-import { AccidentalEnum } from "../../../../src/Common/DataObjects/Pitch";
+import { AccidentalEnum, Pitch } from "../../../../src/Common/DataObjects/Pitch";
 
 describe("VexFlow Measure", () => {
 
@@ -344,6 +344,40 @@ describe("VexFlow Measure", () => {
          // bass staff (Below placement): highest note's fingering closest to the staff, i.e. at the top of the stack
          expect(fingeringTextsTopToBottom(1, 0), "bass staff, beat 1").to.deep.equal(["1", "3", "5"]);
          expect(fingeringTextsTopToBottom(1, 1), "bass staff, beat 3").to.deep.equal(["2", "4", "5"]);
+         done();
+      }).catch(done);
+   });
+
+   // A fingering label is stacked in the pitch order of its note, which is not the order the
+   // fingerings were read in, so the label's index in FingeringEntries says nothing about which
+   // note it belongs to. GraphicalLabel.SourceNote carries that link, letting a consumer find the
+   // note a rendered fingering was created for (e.g. to edit or re-position a single label).
+   it("Links each fingering label to the note it was created for (GraphicalLabel.SourceNote)", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("test_fingering_two_voices_pitch_order.musicxml");
+      if (!score) {
+         done(new Error("Score file not found"));
+         return;
+      }
+      const div: HTMLElement = TestUtils.getDivElement(document);
+      const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
+
+      osmd.load(score).then(() => {
+         osmd.render();
+
+         function fingeringsByNote(staffIndex: number, entryIndex: number): string[] {
+            const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, staffIndex);
+            return gm.staffEntries[entryIndex].FingeringEntries
+               .map((label: GraphicalLabel) =>
+                  `${label.SourceNote.Pitch.ToStringShort(Pitch.OctaveXmlDifference)}=${label.Label.text}`);
+         }
+
+         // treble staff: chord G4/C5 in voice 1 (fingerings 3 and 5), lowest note in voice 2 (fingering 1),
+         //   stacked E4, G4, C5 from the staff outwards
+         expect(fingeringsByNote(0, 0), "treble staff, beat 1").to.deep.equal(["E4=1", "G4=3", "C5=5"]);
+         expect(fingeringsByNote(0, 1), "treble staff, beat 3").to.deep.equal(["D4=1", "F4=2", "A4=4"]);
+         // bass staff (Below placement): the same stack, highest note first
+         expect(fingeringsByNote(1, 0), "bass staff, beat 1").to.deep.equal(["G3=1", "E3=3", "C3=5"]);
+         expect(fingeringsByNote(1, 1), "bass staff, beat 3").to.deep.equal(["A3=2", "F3=4", "C3=5"]);
          done();
       }).catch(done);
    });


### PR DESCRIPTION
Since #1685, `calculateFingerings()` stacks the fingerings of a staff entry in the pitch order of their notes, which is deliberately *not* the order they were read in. So the index of a label in `GraphicalStaffEntry.FingeringEntries` says nothing about which note it belongs to, and the `GraphicalLabel` carries no reference back to the note either.

That leaves a consumer who wants to act on one rendered fingering — edit its text in place, re-position it, hit-test it — with no way to tell whose fingering it is except to re-implement the stacking order outside OSMD and keep that copy in sync with any later change to the heuristics here.

I know that cost first-hand: my app did exactly that, and when #1685 landed the copy silently went out of step with OSMD for two months. Editing a fingering in a two-voice chord rewrote a different note's label, because the app's ordering still assumed the old voice order.

## The change

Set `GraphicalLabel.sourceNote` where the label is created, from the `fingering.sourceNote` that is already in scope:

```ts
gLabel.sourceNote = fingering.sourceNote;
gse.FingeringEntries.push(gLabel);
```

Purely additive. The field is `undefined` for every other kind of label, and `FingeringEntries` keeps both its type (`GraphicalLabel[]`) and its order, so nothing downstream changes.

## Alternatives I considered, in case you would rather have one of them

- **A `GraphicalFingeringEntry` wrapper**, pairing the label with its note the way `GraphicalLyricEntry` and `GraphicalChordSymbolContainer` do. That is the more idiomatic shape for this codebase, and I would happily write it — but it changes the type of the public `FingeringEntries` array, so it felt like a call for a major rather than something to slip into 2.x.
- **`Clickable.dataObject`**, which `GraphicalLabel` already inherits and which nothing in `src/` currently assigns. It would cost no new field at all. I went with a typed field instead because `dataObject: Object` gives a consumer no type safety, and because a fingering label arguably "represents" its `TechnicalInstruction` rather than the note — I did not want to spend that generic slot on a narrower meaning. Glad to switch if you would prefer the existing field populated.
- **Setting it for other label kinds too.** Lyrics can already reach their note through `GraphicalLyricEntry`, and chord symbols have no single note, so only fingerings actually gain anything here.

The name follows `GraphicalNote.sourceNote` and `TechnicalInstruction.sourceNote` rather than the PascalCase fields on `GraphicalLabel` itself (`SVGNode`, `ColorXML`), since `Notehead.SourceNote` suggests PascalCase marks an accessor here rather than a plain field. Happy to flip it.

## Test

Extends `VexFlowMeasure_Test.ts` using the sample already added for #1685, asserting the pairing note-by-note for all four stacks — `["E4=1", "G4=3", "C5=5"]` and so on — so a later change to the stacking order cannot silently break the link.

Full suite green locally (366 passing, Firefox headless), lint clean.