### PR TITLE
Render all children in combined dynamics

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexFlowInstantaneousDynamicExpression.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowInstantaneousDynamicExpression.ts
@@ -1,5 +1,5 @@
 import { GraphicalInstantaneousDynamicExpression } from "../GraphicalInstantaneousDynamicExpression";
-import { InstantaneousDynamicExpression, DynamicEnum } from "../../VoiceData/Expressions/InstantaneousDynamicExpression";
+import { InstantaneousDynamicExpression } from "../../VoiceData/Expressions/InstantaneousDynamicExpression";
 import { GraphicalLabel } from "../GraphicalLabel";
 import { Label } from "../../Label";
 import { TextAlignmentEnum } from "../../../Common/Enums/TextAlignment";
@@ -28,6 +28,6 @@ export class VexFlowInstantaneousDynamicExpression extends GraphicalInstantaneou
     }
 
     get Expression(): string {
-        return DynamicEnum[this.mInstantaneousDynamicExpression.DynEnum];
+        return this.mInstantaneousDynamicExpression.DynamicExpression;
     }
 }

--- a/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
+++ b/src/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader.ts
@@ -639,24 +639,22 @@ export class ExpressionReader {
                 this.directionTimestamp = Fraction.createFromFraction(inSourceMeasureCurrentFraction);
             }
             const numberXml: number = this.readNumber(dynamicsNode); // probably never given, just to comply with createExpressionIfNeeded()
-            let expressionText: string = dynamicsNode.elements()[0]?.name; // elements can in rare cases still be empty even though hasElements=true, see #1269
-            if (expressionText === "other-dynamics") {
-                expressionText = dynamicsNode.elements()[0].value;
-            }
+            const dynamicsElements: IXmlElement[] = dynamicsNode.elements();
+            // A single <dynamics> element may contain multiple symbols, e.g. <sf/><mp/>.
+            const expressionText: string = dynamicsElements
+                .map((element: IXmlElement): string => element.name === "other-dynamics" ? element.value : element.name)
+                .join("");
             if (expressionText) {
+                // Keep the previous first-child enum behavior for playback while rendering the complete marking.
+                const firstDynamicText: string = dynamicsElements[0].name === "other-dynamics"
+                    ? dynamicsElements[0].value
+                    : dynamicsElements[0].name;
+                const dynamicEnum: DynamicEnum = DynamicEnum[firstDynamicText?.toLowerCase()];
                 // ToDo: make duplicate recognition an afterReadingModule, as we can't definitively check here if there is a repetition:
                 // Compare with the active dynamic expression and only add it if there is a change in dynamic
                 // Exception is when a repetition starts here, where the "repeated" dynamic might be desired.
                 // see PR #767 where this was removed
                 if (currentMeasure.Rules?.IgnoreRepeatedDynamics) {
-                    let dynamicEnum: DynamicEnum;
-                    try {
-                        dynamicEnum = DynamicEnum[expressionText];
-                    } catch (err) {
-                        const errorMsg: string = ITextTranslation.translateText("ReaderErrorMessages/DynamicError", "Error while reading dynamic.");
-                        this.musicSheet.SheetErrors.pushMeasureError(errorMsg);
-                        return;
-                    }
                     if (this.activeInstantaneousDynamic?.DynEnum === dynamicEnum) {
                         // repeated dynamic
                         return;
@@ -674,7 +672,8 @@ export class ExpressionReader {
                         this.soundDynamic,
                         this.placement,
                         this.staffNumber,
-                        currentMeasure);
+                        currentMeasure,
+                        dynamicEnum);
                 instantaneousDynamicExpression.InMeasureTimestamp = inSourceMeasureCurrentFraction.clone();
                 this.getMultiExpression.addExpression(instantaneousDynamicExpression, "");
                 // addExpression unnecessary now?:

--- a/src/MusicalScore/VoiceData/Expressions/InstantaneousDynamicExpression.ts
+++ b/src/MusicalScore/VoiceData/Expressions/InstantaneousDynamicExpression.ts
@@ -37,10 +37,11 @@ export class InstantaneousDynamicExpression extends AbstractExpression {
     }
 
     constructor(dynamicExpression: string, soundDynamics: number, placement: PlacementEnum, staffNumber: number,
-                measure: SourceMeasure) {
+                measure: SourceMeasure, dynamicEnum?: DynamicEnum) {
         super(placement);
         this.parentMeasure = measure;
-        this.dynamicEnum = DynamicEnum[dynamicExpression.toLowerCase()];
+        this.dynamicExpression = dynamicExpression;
+        this.dynamicEnum = dynamicEnum ?? DynamicEnum[dynamicExpression.toLowerCase()];
         this.soundDynamic = soundDynamics;
         this.staffNumber = staffNumber;
     }
@@ -48,6 +49,7 @@ export class InstantaneousDynamicExpression extends AbstractExpression {
     public static dynamicToRelativeVolumeDict: Dictionary<DynamicEnum, number> = new Dictionary<DynamicEnum, number>();
 
     private multiExpression: MultiExpression;
+    private dynamicExpression: string;
     private dynamicEnum: DynamicEnum;
     private soundDynamic: number;
     private staffNumber: number;
@@ -59,6 +61,9 @@ export class InstantaneousDynamicExpression extends AbstractExpression {
     }
     public set ParentMultiExpression(value: MultiExpression) {
         this.multiExpression = value;
+    }
+    public get DynamicExpression(): string {
+        return this.dynamicExpression;
     }
     public get DynEnum(): DynamicEnum {
         return this.dynamicEnum;

--- a/test/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader_Test.ts
+++ b/test/MusicalScore/ScoreIO/MusicSymbolModules/ExpressionReader_Test.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai";
+import { IXmlElement } from "../../../../src/Common/FileIO/Xml";
+import { MusicSheet } from "../../../../src/MusicalScore/MusicSheet";
+import { MusicSheetReader } from "../../../../src/MusicalScore/ScoreIO/MusicSheetReader";
+import { DynamicEnum, InstantaneousDynamicExpression } from
+    "../../../../src/MusicalScore/VoiceData/Expressions/InstantaneousDynamicExpression";
+import { MultiExpression } from "../../../../src/MusicalScore/VoiceData/Expressions/MultiExpression";
+
+describe("ExpressionReader", () => {
+    describe("combined dynamics (issue #1705)", () => {
+        const path: string = "test/data/test_combined_dynamics_1705.musicxml";
+        let dynamics: InstantaneousDynamicExpression[];
+
+        before((): void => {
+            const doc: Document = ((window as any).__xml__)[path];
+            expect(doc, "sample file is loaded").to.not.equal(undefined);
+            const score: IXmlElement = new IXmlElement(doc.getElementsByTagName("score-partwise")[0]);
+            const sheet: MusicSheet = new MusicSheetReader().createMusicSheet(score, path);
+            dynamics = sheet.SourceMeasures.flatMap((measure): InstantaneousDynamicExpression[] =>
+                measure.StaffLinkedExpressions.flatMap((staffExpressions: MultiExpression[]): InstantaneousDynamicExpression[] =>
+                    staffExpressions
+                        .map((expression: MultiExpression): InstantaneousDynamicExpression => expression.InstantaneousDynamic)
+                        .filter((expression: InstantaneousDynamicExpression): boolean => expression !== undefined)
+                )
+            );
+        });
+
+        it("retains every dynamic child in source order for rendering", () => {
+            expect(dynamics.map((dynamic: InstantaneousDynamicExpression): string => dynamic.DynamicExpression))
+                .to.deep.equal(["sfmp", "sfmp", "ffz"]);
+        });
+
+        it("retains the first child's dynamic enum for playback", () => {
+            expect(dynamics[0].DynEnum).to.equal(DynamicEnum.sf);
+            expect(dynamics[2].DynEnum).to.equal(DynamicEnum.ff);
+        });
+    });
+});

--- a/test/data/test_combined_dynamics_1705.musicxml
+++ b/test/data/test_combined_dynamics_1705.musicxml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <movement-title>Combined dynamics</movement-title>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics><sf/><mp/></dynamics>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <other-dynamics>s</other-dynamics><f/><other-dynamics>m</other-dynamics><p/>
+          </dynamics>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <direction placement="below">
+        <direction-type>
+          <dynamics><ff/><other-dynamics>z</other-dynamics></dynamics>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Fixes #1705.

## What changed

- Read every instantaneous-dynamic child from a MusicXML direction instead of stopping after the first.
- Preserve the child order for rendering compound dynamics such as `sf mp`.
- Keep the first dynamic as the playback enum so existing playback behavior remains stable.
- Add a focused MusicXML fixture and regression tests for rendering order and playback selection.

## Why

The expression reader previously retained only the first child element in a compound dynamics element. The remaining markings were discarded before graphical rendering.

## Validation

- `npm run lint`
- The two new issue #1705 regression tests pass.
- Headless browser suite: 366 passed and 2 skipped. One unrelated, browser-sensitive slur geometry assertion failed under Microsoft Edge.