### PR TITLE
fix(stems): don't force a lone secondary voice stem-down (#1719)

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -4082,8 +4082,13 @@ export abstract class MusicSheetCalculator {
             }
         } else {
             if (voiceEntry.ParentVoice instanceof LinkedVoice) {
-                // Linked voice: set stem down:
-                voiceEntry.WantedStemDirection = StemDirectionType.Down;
+                // Linked voice: set stem down, but only while another voice is present at
+                // the same staff entry (same clash guard as the main-voice branch below).
+                // A linked voice alone at its staff entry has no voice to avoid, so leave
+                // WantedStemDirection undefined and let pitch-based auto-stemming apply.
+                if (voiceEntry.ParentSourceStaffEntry.VoiceEntries.length > 1) {
+                    voiceEntry.WantedStemDirection = StemDirectionType.Down;
+                }
             } else {
                 // if this voiceEntry belongs to the mainVoice:
                 // check first that there are also more voices present:

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_SecondaryVoiceStemDirection_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_SecondaryVoiceStemDirection_Test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import {GraphicalMusicSheet} from "../../../../src/MusicalScore/Graphical/GraphicalMusicSheet";
+import {IXmlElement} from "../../../../src/Common/FileIO/Xml";
+import {MusicSheet} from "../../../../src/MusicalScore/MusicSheet";
+import {MusicSheetReader} from "../../../../src/MusicalScore/ScoreIO/MusicSheetReader";
+import {VexFlowMusicSheetCalculator} from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowMusicSheetCalculator";
+import {TestUtils} from "../../../Util/TestUtils";
+import {GraphicalStaffEntry} from "../../../../src/MusicalScore/Graphical/GraphicalStaffEntry";
+import {GraphicalVoiceEntry} from "../../../../src/MusicalScore/Graphical/GraphicalVoiceEntry";
+import {StemDirectionType} from "../../../../src/MusicalScore/VoiceData/VoiceEntry";
+import {expect} from "chai";
+
+describe("VexFlow Measure - Secondary Voice Stem Direction (issue #1719)", () => {
+
+   const path: string = "test_secondary_voice_stem_direction.musicxml";
+
+   // Measures 1 and 2 carry the identical F4 half note (no <stem>). Measure 1 uses
+   // voice 1 (main voice); measure 2 uses voice 7, which OSMD parses as a LinkedVoice.
+   // Each measure has one voice entry per staff entry, so neither note collides with
+   // another voice and both should auto-stem (pitch-based), leaving WantedStemDirection
+   // Undefined. The bug forced the lone linked voice in measure 2 stem-down.
+   function graphicalMusicSheet(): GraphicalMusicSheet {
+      const score: Document = TestUtils.getScore(path);
+      expect(score).to.not.be.undefined;
+      const partwise: Element = TestUtils.getPartWiseElement(score);
+      expect(partwise).to.not.be.undefined;
+      const reader: MusicSheetReader = new MusicSheetReader();
+      const calc: VexFlowMusicSheetCalculator = new VexFlowMusicSheetCalculator(reader.rules);
+      const sheet: MusicSheet = reader.createMusicSheet(new IXmlElement(partwise), path);
+      const gms: GraphicalMusicSheet = new GraphicalMusicSheet(sheet, calc);
+      calc.calculate();
+      return gms;
+   }
+
+   // The single voice entry of measure `measureIndex` (staff 0), which holds the lone note.
+   function loneVoiceEntry(gms: GraphicalMusicSheet, measureIndex: number): GraphicalVoiceEntry {
+      const staffEntries: GraphicalStaffEntry[] = gms.MeasureList[measureIndex][0].staffEntries;
+      expect(staffEntries.length, `measure ${measureIndex + 1} should have one staff entry`).to.equal(1);
+      const gves: GraphicalVoiceEntry[] = staffEntries[0].graphicalVoiceEntries;
+      expect(gves.length, `measure ${measureIndex + 1} staff entry should have one voice entry`).to.equal(1);
+      return gves[0];
+   }
+
+   it("Should not force a lone secondary (linked) voice stem-down", (done: Mocha.Done) => {
+      const gms: GraphicalMusicSheet = graphicalMusicSheet();
+      const secondaryVoiceEntry: GraphicalVoiceEntry = loneVoiceEntry(gms, 1); // measure 2, voice 7
+      expect(secondaryVoiceEntry.parentVoiceEntry.WantedStemDirection).to.equal(
+         StemDirectionType.Undefined,
+         "a linked voice alone at its staff entry must keep an undefined (auto) stem, not forced Down");
+      done();
+   });
+
+   it("Should stem the lone secondary voice identically to the identical main-voice measure", (done: Mocha.Done) => {
+      const gms: GraphicalMusicSheet = graphicalMusicSheet();
+      const mainVoiceEntry: GraphicalVoiceEntry = loneVoiceEntry(gms, 0);      // measure 1, voice 1
+      const secondaryVoiceEntry: GraphicalVoiceEntry = loneVoiceEntry(gms, 1); // measure 2, voice 7
+      expect(secondaryVoiceEntry.parentVoiceEntry.WantedStemDirection).to.equal(
+         mainVoiceEntry.parentVoiceEntry.WantedStemDirection,
+         "identical notes should get the same stem treatment whether in the main or a secondary voice");
+      done();
+   });
+
+});

--- a/test/data/test_secondary_voice_stem_direction.musicxml
+++ b/test/data/test_secondary_voice_stem_direction.musicxml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <!--
+    Regression sample for issue #1719: a secondary (linked) voice that is the only
+    voice active at a staff entry must not be forced stem-down.
+
+    Two consecutive measures hold the identical pitch and rhythm (F4 half note,
+    which sits below the treble middle line, so its automatic stem points up):
+      - Measure 1 uses voice 1 (the main voice).
+      - Measure 2 uses voice 7 (a distinct voice number, parsed as a LinkedVoice).
+    The voices never overlap, so each measure has exactly one voice entry per staff
+    entry. No <note> carries a <stem>, and the encoding declares that stems are not
+    comprehensively supplied, so automatic (pitch-based) stemming is the default.
+
+    Expected: both measures auto-stem identically (WantedStemDirection Undefined,
+    resolved upward by pitch). The bug forces measure 2 stem-down only because its
+    voice is a LinkedVoice.
+  -->
+  <identification>
+    <encoding>
+      <software>Test fixture for OSMD issue #1719</software>
+      <supports type="no" element="stem"/>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <!-- Voice 1 (main voice) -->
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>2</duration><voice>1</voice><type>half</type></note>
+    </measure>
+    <measure number="2">
+      <!-- Voice 7 (secondary / linked voice), alone at its staff entry, no <stem> -->
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>2</duration><voice>7</voice><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Fixes #1719

## Repro
A secondary (linked) voice that is the **only** voice at its staff entry, in a file with no `<stem>` elements, is forced stem-**down** -- while an identical note in the main voice auto-stems normally.

`test/data/test_secondary_voice_stem_direction.musicxml` is a minimal reproduction: two consecutive measures with the identical F4 half note (F4 is below the treble middle line, so its automatic stem points **up**), no `<stem>` anywhere:
- Measure 1 uses voice 1 (main voice) -> auto-stems up.
- Measure 2 uses voice 7 (a distinct voice number, parsed as a `LinkedVoice`) -> forced down.

The voices never overlap, so each note is alone at its staff entry.

## Root cause
`MusicSheetCalculator.calculateStemDirectionFromVoices()` treats the two voice kinds asymmetrically. The main-voice branch only forces a direction **when another voice is present** at the same staff entry (`ParentSourceStaffEntry.VoiceEntries.length > 1`), but the `LinkedVoice` branch forced `StemDirectionType.Down` **unconditionally**:

```ts
if (voiceEntry.ParentVoice instanceof LinkedVoice) {
    voiceEntry.WantedStemDirection = StemDirectionType.Down;   // no clash guard
} else {
    if (voiceEntry.ParentSourceStaffEntry.VoiceEntries.length > 1) {
        voiceEntry.WantedStemDirection = StemDirectionType.Up;  // guarded
    }
}
```

A linked voice stays a `LinkedVoice` for the whole instrument, so it got `Down` even at timestamps where it is the sole active voice.

## Fix
Give the `LinkedVoice` branch the same `VoiceEntries.length > 1` clash guard. When the linked voice is alone at its staff entry, `WantedStemDirection` is left `Undefined`, so the normal pitch-based auto-stemming applies -- the same as the main voice. The main-voice branch is unchanged, and the caller only reaches this code when the MusicXML supplies no `<stem>`, so explicit stem directions are never overridden.

Per MusicXML, `<voice>` is a string identifier with no ordering or stem semantics, and this file declares `<supports type="no" element="stem"/>`, so automatic stemming is the intended default.

## Test
`VexFlowMeasure_SecondaryVoiceStemDirection_Test.ts` loads the fixture, calculates, and asserts the lone measure-2 linked-voice entry keeps `StemDirectionType.Undefined` and matches the identical main-voice measure. Red before the fix (`WantedStemDirection === Down`), green after; the sibling unison/stem tests still pass.

Reported by @rpatters1 (with a clear root-cause analysis and minimal `layer1layer4.xml`) -- thank you.

*AI-assisted: this fix and test were prepared with AI assistance and reviewed by me.*
