### PR TITLE
fix(Percussion): only apply percussion note positioning to notes under a percussion clef (#1726)

### DIFF
--- a/src/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator.ts
@@ -84,7 +84,10 @@ export class VexflowStafflineNoteCalculator implements IStafflineNoteCalculator 
         const staffIndex: number =
                 graphicalNote.parentVoiceEntry.parentStaffEntry.sourceStaffEntry.ParentStaff.idInMusicSheet;
 
-        if (!(graphicalNote instanceof VexFlowGraphicalNote) || graphicalNote.sourceNote.isRest()
+        // only reposition notes that are actually under a percussion clef, mirroring trackNote():
+        //   a percussion clef later in the part must not remap notes of earlier G/F clef measures (#1726)
+        if (!(graphicalNote instanceof VexFlowGraphicalNote) || graphicalNote.Clef().ClefType !== ClefEnum.percussion
+            || graphicalNote.sourceNote.isRest()
             || !this.staffPitchListMapping.containsKey(staffIndex)) {
             return graphicalNote;
         }

--- a/test/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator_Test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { GraphicalMeasure } from "../../../../src/MusicalScore/Graphical/GraphicalMeasure";
+import { VexFlowGraphicalNote } from "../../../../src/MusicalScore/Graphical/VexFlow/VexFlowGraphicalNote";
+import { OpenSheetMusicDisplay } from "../../../../src/OpenSheetMusicDisplay/OpenSheetMusicDisplay";
+import { TestUtils } from "../../../Util/TestUtils";
+
+describe("VexflowStafflineNoteCalculator", () => {
+    // #1726: a percussion clef in measure 3 must not reposition the notes of the G clef measures 1-2.
+    // Before the fix, A5 and E5 in measure 1 (pitches that also occur under the percussion clef)
+    // were remapped to the percussion one-line positions ("cn/3"), like the notes in measure 3.
+    it("does not apply percussion note positioning to notes under a non-percussion clef (#1726)", async () => {
+        const score: Document = TestUtils.getScore("test_percussion_clef_midpart_earlier_notes_1726.musicxml");
+        const div: HTMLElement = TestUtils.getDivElement(document);
+        const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(div);
+        await osmd.load(score);
+        osmd.render();
+
+        const vfKeysOfMeasure: (measureIndex: number) => string[] = (measureIndex: number): string[] => {
+            const measure: GraphicalMeasure = osmd.GraphicSheet.MeasureList[measureIndex][0];
+            const keys: string[] = [];
+            for (const staffEntry of measure.staffEntries) {
+                for (const voiceEntry of staffEntry.graphicalVoiceEntries) {
+                    for (const note of voiceEntry.notes) {
+                        keys.push((note as VexFlowGraphicalNote).vfpitch[0]);
+                    }
+                }
+            }
+            return keys;
+        };
+
+        // measure 1 and 2: G clef, notes keep their real pitch positions
+        expect(vfKeysOfMeasure(0)).to.deep.equal(["an/5", "gn/5", "fn/5", "en/5"]);
+        expect(vfKeysOfMeasure(1)).to.deep.equal(["cn/5"]);
+        // measure 3: percussion clef, 2 distinct pitches -> percussion position mapping still applies
+        expect(vfKeysOfMeasure(2)).to.deep.equal(["cn/3", "cn/3"]);
+    });
+});

--- a/test/data/test_percussion_clef_midpart_earlier_notes_1726.musicxml
+++ b/test/data/test_percussion_clef_midpart_earlier_notes_1726.musicxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Violin</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><type>quarter</type></note>
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><type>quarter</type></note>
+      <note><pitch><step>F</step><alter>1</alter><octave>5</octave></pitch><duration>1</duration><type>quarter</type><accidental>sharp</accidental></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>4</duration><type>whole</type></note>
+    </measure>
+    <measure number="3">
+      <attributes>
+        <clef><sign>percussion</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>2</duration><type>half</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>2</duration><type>half</type></note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Fixes #1726

## Problem

`VexflowStafflineNoteCalculator.trackNote()` only collects pitches for notes whose **own** clef is `ClefEnum.percussion`, but `positionNote()` did not check the note's clef at all — once a staff had a tracked pitch list, every note of that staff was remapped to the percussion positions.

So a percussion clef that appears later in a part (e.g. a stray clef produced by a notation-editor export, as in the OpenScore edition of Mozart K.465 / Fauré Op.121, Violin 1) repositioned notes of the **preceding G-clef measures**: an A5 ended up as `cn/3`, far below the staff, while notes whose pitch did not also occur under the percussion clef were left alone.

## Fix

Mirror the clef guard of `trackNote()` in `positionNote()` (one condition). Notes under a percussion clef are positioned exactly as before, so real percussion parts are unchanged.

## Test

`test/MusicalScore/Graphical/VexFlow/VexflowStafflineNoteCalculator_Test.ts` with the fixture from the issue (`test/data/test_percussion_clef_midpart_earlier_notes_1726.musicxml`: G clef in m.1–2, percussion clef in m.3):

- m.1 keeps `an/5, gn/5, fn/5, en/5`, m.2 keeps `cn/5` (before the fix: `cn/3, gn/5, fn/5, cn/3`)
- m.3 (percussion) still maps to `cn/3, cn/3`

Verified red → green locally (karma, ChromeHeadless). The only failing test in the full run is the pre-existing `SlurFlattenToObstacle` assertion, which fails identically on unmodified `develop`. `npm run lint` passes.
