### PR TITLE
fix(Unison): Carry the hidden unison exception to the notehead and the tuplet

### DIFF
--- a/src/MusicalScore/Graphical/MusicSheetCalculator.ts
+++ b/src/MusicalScore/Graphical/MusicSheetCalculator.ts
@@ -2271,7 +2271,11 @@ export abstract class MusicSheetCalculator {
                         this.handleBeam(graphicalNote, note.NoteBeam, openBeams);
                     }
                 }
-                if (note.NoteTuplets.length > 0 && note.PrintObject) {
+                // Same for its tuplet: hidden or not, the note is one of the tuplet's notes, so the tuplet number
+                // (and bracket) has to span it. Leaving it out built the VF.Tuplet from the remaining notes and
+                // centered the number over those, off the beam's center.
+                // E.g. Debussy Arabesque no. 1 m.3 (test_unison_notehead_tuplet_arabesque_measure3).
+                if (note.NoteTuplets.length > 0 && (note.PrintObject || note.sharesNoteheadWithVisibleUnisonNote())) {
                     // a note can be part of more than one tuplet (nested tuplets); add it to each of them
                     for (const noteTuplet of note.NoteTuplets) {
                         this.handleTuplet(graphicalNote, noteTuplet, openTuplets);

--- a/src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry.ts
+++ b/src/MusicalScore/Graphical/VexFlow/VexFlowVoiceEntry.ts
@@ -59,6 +59,18 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
         }
     }
 
+    /** Whether the note is drawn although its own notehead is hidden (print-object="no"), because it shares the
+     * notehead of a visible unison note in another voice and its stem is beamed. The stem emanates from the shared
+     * notehead and has to reach the beam, and wherever Vexflow can't merge the two heads into one column it lays
+     * the hidden note's notehead out beside the visible one, where it has to be drawn too - otherwise the beam ends
+     * on a bare stem with nothing under it. E.g. Beethoven Moonlight Sonata 1st mvt. m.37, where the two heads are
+     * merged (test_unison_notehead_moonlight_sonata_measure37), and Debussy Arabesque no. 1 m.3, where the hidden
+     * eighth note's head can't merge with a half note's and gets a column of its own
+     * (test_unison_notehead_tuplet_arabesque_measure3). */
+    private static drawnAsSharedUnisonNote(note: Note): boolean {
+        return note.NoteBeam !== undefined && note.sharesNoteheadWithVisibleUnisonNote();
+    }
+
     /** (Re-)color notes and stems by setting their Vexflow styles.
      * Could be made redundant by a Vexflow PR, but Vexflow needs more solid and permanent color methods/variables for that
      * See VexFlowConverter.StaveNote()
@@ -75,6 +87,11 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
         for (let i: number = 0; i < this.notes.length; i++) {
             const note: GraphicalNote = this.notes[i];
 
+            // notehead="none" asks for no notehead at all, so it always stays hidden. print-object="no" hides it
+            // too, unless the note is drawn anyway because it shares a visible unison note's notehead: then it is
+            // drawn whole, notehead included, exactly like its stem below.
+            const noteheadVisible: boolean = note.sourceNote.Notehead?.Shape !== NoteHeadShape.NONE &&
+                (note.sourceNote.PrintObject || VexFlowVoiceEntry.drawnAsSharedUnisonNote(note.sourceNote));
             sourceNoteNoteheadColor = note.sourceNote.NoteheadColor;
             noteheadColor = sourceNoteNoteheadColor;
             // Switch between XML colors and automatic coloring
@@ -87,8 +104,8 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                     noteheadColor = this.rules.ColoringSetCurrent.getValue(fundamentalNote);
                 }
             }
-            if (!note.sourceNote.PrintObject || (note.sourceNote.Notehead?.Shape === NoteHeadShape.NONE)) {
-                noteheadColor = transparentColor; // transparent (for PrintObject=false or notehead="none")
+            if (!noteheadVisible) {
+                noteheadColor = transparentColor; // transparent (see noteheadVisible above)
             } else if (!noteheadColor // revert transparency after PrintObject was set to false, then true again
                 || noteheadColor === "#000000" // questionable, because you might want to set specific notes to black,
                                                // but unfortunately some programs export everything explicitly as black
@@ -105,15 +122,14 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                     ", in measure #" + measureNumber);
             }*/
 
-            if (!sourceNoteNoteheadColor && this.rules.ColoringMode === ColoringModes.XML &&
-                note.sourceNote.PrintObject && note.sourceNote.Notehead?.Shape !== NoteHeadShape.NONE) {
+            if (!sourceNoteNoteheadColor && this.rules.ColoringMode === ColoringModes.XML && noteheadVisible) {
                 if (!note.sourceNote.isRest() && defaultColorNotehead) {
                     noteheadColor = defaultColorNotehead;
                 } else if (note.sourceNote.isRest() && defaultColorRest) {
                     noteheadColor = defaultColorRest;
                 }
             }
-            if (noteheadColor && note.sourceNote.PrintObject && note.sourceNote.Notehead?.Shape !== NoteHeadShape.NONE) {
+            if (noteheadColor && noteheadVisible) {
                 note.sourceNote.NoteheadColorCurrentlyRendered = noteheadColor;
             } else if (!noteheadColor) {
                 continue;
@@ -181,12 +197,10 @@ export class VexFlowVoiceEntry extends GraphicalVoiceEntry {
                 stemTransparent = false;
                 break;
             }
-            // The note's own notehead is hidden, but it's shared with a visible unison note in another voice
-            // (print-object="no") and its stem is beamed. The stem emanates from the shared notehead and has to
-            // reach the beam, so keep it visible - otherwise the beam appears to hang in the air over a missing
-            // stem. E.g. Beethoven Moonlight Sonata 1st mvt. m.37: an eighth note shares a notehead with a dotted
-            // quarter in another voice, but its stem still joins the beam (test_unison_notehead_moonlight_sonata_measure37).
-            if (note.NoteBeam && note.sharesNoteheadWithVisibleUnisonNote()) {
+            // The note's own notehead is hidden, but it's drawn anyway because it shares a visible unison note's
+            // notehead and is beamed (see drawnAsSharedUnisonNote): its stem emanates from the shared notehead and
+            // has to reach the beam, otherwise the beam appears to hang in the air over a missing stem.
+            if (VexFlowVoiceEntry.drawnAsSharedUnisonNote(note)) {
                 stemTransparent = false;
                 break;
             }

--- a/src/MusicalScore/VoiceData/Note.ts
+++ b/src/MusicalScore/VoiceData/Note.ts
@@ -222,9 +222,13 @@ export class Note {
     }
     /** Whether this note's own notehead is hidden (e.g. print-object="no" or notehead "none") but there is a
      * visible note on the same staff line in another voice at the same staff entry - i.e. a unison whose visible
-     * notehead this note shares. Used to keep such a note's beam and stem rendered (the stem still emanates from
-     * the shared notehead and joins the beam) instead of dropping it. E.g. an eighth note sharing a notehead with
-     * a dotted quarter in Beethoven's Moonlight Sonata 1st mvt. m.37 (test_unison_notehead_moonlight_sonata_measure37). */
+     * notehead this note shares. Used to render such a note like a visible one instead of dropping it: its beam
+     * and stem (the stem still emanates from the shared notehead and joins the beam), the notehead Vexflow lays
+     * out beside the visible one wherever the two heads can't be merged into one column
+     * (VexFlowVoiceEntry.drawnAsSharedUnisonNote), and its place in a tuplet, whose number spans it either way.
+     * E.g. an eighth note sharing a notehead with a dotted quarter in Beethoven's Moonlight Sonata 1st mvt. m.37
+     * (test_unison_notehead_moonlight_sonata_measure37), or the first note of a triplet sharing a half note's
+     * notehead in Debussy's Arabesque no. 1 m.3 (test_unison_notehead_tuplet_arabesque_measure3). */
     public sharesNoteheadWithVisibleUnisonNote(): boolean {
         if (this.printObject && this.notehead?.Shape !== NoteHeadShape.NONE) {
             return false; // this note's own notehead is visible, nothing to share

--- a/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
+++ b/test/MusicalScore/Graphical/VexFlow/VexFlowMeasure_Test.ts
@@ -272,6 +272,48 @@ describe("VexFlow Measure", () => {
       }).catch(done);
    });
 
+   // Non-regression test for the same hidden unison note, in the case where Vexflow can't merge the two noteheads
+   // into one column: the hidden eighth's head can't be merged with the half note's, so Vexflow lays it out beside
+   // it, where it has to be drawn - a transparent head left the beam ending on a bare stem with nothing under it.
+   // Its tuplet has to count it too, otherwise the VF.Tuplet is built from the remaining notes and the number is
+   // centered over those. E.g. Debussy Arabesque no. 1 m.3, also Clair de lune and Liszt's Liebestraum no. 3.
+   it("Draws the notehead of a hidden unison note laid out beside the shared one, and counts it in its tuplet", (done: Mocha.Done) => {
+      const score: Document = TestUtils.getScore("test_unison_notehead_tuplet_arabesque_measure3.musicxml");
+      if (!score) {
+         done(new Error("Score file not found"));
+         return;
+      }
+      const osmd: OpenSheetMusicDisplay = TestUtils.createOpenSheetMusicDisplay(TestUtils.getDivElement(document));
+
+      osmd.load(score).then(() => {
+         osmd.render();
+         const gm: GraphicalMeasure = osmd.GraphicSheet.findGraphicalMeasure(0, 0);
+         // find the single invisible (print-object="no") note: the triplet's first eighth, in unison with the half note
+         let hiddenNoteheadStyle: { fillStyle?: string };
+         let hiddenVfStaveNote: any;
+         for (const se of gm.staffEntries) {
+            for (const gve of se.graphicalVoiceEntries) {
+               for (let i: number = 0; i < gve.notes.length; i++) {
+                  if (!gve.notes[i].sourceNote.PrintObject) {
+                     hiddenVfStaveNote = (gve as VexFlowVoiceEntry).vfStaveNote;
+                     hiddenNoteheadStyle = hiddenVfStaveNote.note_heads[i].getStyle();
+                  }
+               }
+            }
+         }
+         expect(hiddenVfStaveNote, "should find the invisible unison note").to.not.be.undefined;
+         // its notehead has a column of its own (the half note's head can't stand in for it), so it has to be drawn
+         expect(hiddenNoteheadStyle?.fillStyle, "unison notehead must not be transparent").to.not.equal("#00000000");
+         // and it is one of the triplet's three notes, so that the 3 is centered over all of them
+         const vftuplets: { [voiceID: number]: any[] } = (gm as any).vftuplets; // private, only needed here in the test
+         const allVfTuplets: any[] = Object.keys(vftuplets).reduce((all: any[], voiceID: string) => all.concat(vftuplets[voiceID]), []);
+         expect(allVfTuplets.length, "should find the triplet").to.equal(1);
+         expect(allVfTuplets[0].notes, "the triplet has to contain all three of its notes").to.have.lengthOf(3);
+         expect(allVfTuplets[0].notes, "the triplet has to contain the hidden note").to.include(hiddenVfStaveNote);
+         done();
+      }).catch(done);
+   });
+
    // Non-regression test for EngravingRules.RenderMeasureNumbersForImplicitMeasures.
    // Measures marked implicit="yes" in the MusicXML (e.g. measures without a meter like in Satie's Gnossiennes)
    // don't show a measure number by default, as per the MusicXML standard, but do when the rule is enabled.

--- a/test/data/test_unison_notehead_tuplet_arabesque_measure3.musicxml
+++ b/test/data/test_unison_notehead_tuplet_arabesque_measure3.musicxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<!-- Debussy, Arabesque no. 1, left hand, measure 3, as MuseScore exports it: a sustained F#3 half note
+     in voice 1, and a triplet in voice 2 whose first eighth is the same F#3, hidden with print-object="no"
+     so that a single notehead serves both voices. The same encoding appears in Clair de lune and in Liszt's
+     Liebestraum no. 3. The hidden note must still get its notehead (it is displaced next to the half note's,
+     so nothing else draws it) and its place in the triplet (the 3 belongs over all three notes). -->
+<score-partwise version="3.0">
+  <work>
+    <work-title>test_unison_notehead_tuplet_arabesque_measure3</work-title>
+    </work>
+  <part-list><score-part id="P1"><part-name/></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>6</divisions>
+        <key><fifths>4</fifths><mode>major</mode></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <!-- voice 1: the sustained bass, the note whose head both voices share -->
+      <note>
+        <pitch><step>F</step><alter>1</alter><octave>3</octave></pitch>
+        <duration>12</duration><voice>1</voice><type>half</type><stem>down</stem>
+      </note>
+      <backup><duration>12</duration></backup>
+      <!-- voice 2: the triplet, its first note hidden behind the half note's head -->
+      <note print-object="no">
+        <pitch><step>F</step><alter>1</alter><octave>3</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <stem>up</stem><beam number="1">begin</beam>
+        <notations><tuplet type="start" bracket="no"/></notations>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>3</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <stem>up</stem><beam number="1">continue</beam>
+      </note>
+      <note>
+        <pitch><step>C</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>4</duration><voice>2</voice><type>eighth</type>
+        <time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification>
+        <stem>up</stem><beam number="1">end</beam>
+        <notations><tuplet type="stop"/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
Fixes #1729.

`Note.sharesNoteheadWithVisibleUnisonNote()` already spares the beam and the stem of a note MuseScore hid with `print-object="no"` so that a visible unison note in another voice carries the shared notehead. Two other sites still gated on `PrintObject` alone, so the note ended up half-included in what it belongs to. This carries the exception to both.

Both symptoms on the test sample added here (Debussy's Arabesque no. 1 m.3) — `develop`, then this PR:

<img width="440" alt="OSMD develop: the triplet's beam rises from a bare stem, no notehead beside the half note's open head, and the 3 sits over the second and third notes" src="https://github.com/user-attachments/assets/db3cbf6a-05c9-42d2-b743-f9b936595e0b" />

<img width="440" alt="With the fix: a filled head beside the open one, and the 3 centred over all three notes" src="https://github.com/user-attachments/assets/43a70af3-b809-4c07-a45e-06b3b4b6bea9" />

### The notehead — `VexFlowVoiceEntry.color()`

Where Vexflow merges the two heads into one column (`StaveNote.format` → `mergeableUnison`), the visible note's head stands in for the hidden one and nothing is missing — that is the Moonlight Sonata case the predicate was written for. Where it can't, the hidden head is laid out beside the visible one and was painted fully transparent, so the beam ended on a bare stem with nothing under it.

A merge only ever happens between heads of the same shape (`mergeableUnison` refuses a half or whole note against anything else, and mismatched dots), which is what makes an eighth hidden under a half note stagger. So the head is now colored under exactly the condition its stem already uses — head and stem are drawn together, or neither is — and in the merged case the inked head lands on the visible one: same glyph, same position, no visual change. I checked that on `test_unison_notehead_moonlight_sonata_measure37`: the SVG comes out byte-identical apart from that one `fill`, the two head paths being identical strings at identical coordinates.

That makes the caveat I raised in the issue unnecessary — no displacement test is needed, because the only case where the head is not displaced is the case where inking it changes nothing.

`notehead="none"` is a deliberate request for no notehead and still stays hidden.

### The tuplet — `MusicSheetCalculator.handleVoiceEntry()`

Hidden or not, the note is one of the tuplet's notes. Left out of `handleTuplet()`, the `VF.Tuplet` was built from the remaining ones and its number centered over those — half a note spacing right of the beam's center in the test sample. One line, matching the beam gate two lines above it.

### Test sample

`test/data/test_unison_notehead_tuplet_arabesque_measure3.musicxml` is the minimal bar from the issue: a sustained F#3 half note in voice 1 and a triplet in voice 2 whose first eighth is the same F#3, hidden. It has both symptoms at once. The same encoding appears in Clair de lune and in Liszt's Liebestraum no. 3.

The new test in `VexFlowMeasure_Test.ts` asserts the hidden note's notehead is not transparent and that the `VF.Tuplet` contains all three notes; it fails on `develop` on the first assertion, and the tuplet one is visible in the render above as the `3` moving back to the beam's center.

Suite is green locally (403 tests).
